### PR TITLE
Delete old csrftoken cookie

### DIFF
--- a/frontend/renderPage.js
+++ b/frontend/renderPage.js
@@ -48,6 +48,9 @@ function renderPage(Page) {
         .then(data => this.setState({ clubs: data }))
 
       this.updateUserInfo()
+
+      // Delete old csrf token cookie
+      document.cookie = 'csrftoken=; domain=.pennclubs.com; expires = Thu, 01 Jan 1970 00:00:00 GMT'
     }
 
     render() {

--- a/frontend/renderPage.js
+++ b/frontend/renderPage.js
@@ -51,6 +51,7 @@ function renderPage(Page) {
 
       // Delete old csrf token cookie
       document.cookie = 'csrftoken=; domain=.pennclubs.com; expires = Thu, 01 Jan 1970 00:00:00 GMT'
+      document.cookie = 'sessionid=; domain=.pennclubs.com; expires = Thu, 01 Jan 1970 00:00:00 GMT'
     }
 
     render() {


### PR DESCRIPTION
Delete old csrftoken cookie on every page load. Fixes bug with old token shadowing the current working cookie. This code should be removed in a year or so.