### PR TITLE
Member card width/padding bug

### DIFF
--- a/frontend/components/common/Grid.js
+++ b/frontend/components/common/Grid.js
@@ -54,6 +54,7 @@ const ColContainer = s.div`
   background: ${({ background }) => background || 'transparent'};
   overflow-x: visible;
   position: relative;
+  min-width: 0;
   ${({ flex }) => flex && 'display: flex; flex: 1;'}
   ${({ margin }) =>
     margin && `margin-left: ${margin}; margin-right: ${margin};`}


### PR DESCRIPTION
Should fix the name overflow issue by truncating with ellipses - more sustainable solution is a WIP
<img width="756" alt="Screen Shot 2020-01-26 at 5 59 32 PM" src="https://user-images.githubusercontent.com/50744387/73143235-9e4de100-4065-11ea-9bf6-27e8ce94c7f5.png">
