### PR TITLE
Regenerate Clubs List Cache on Club Modification

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -542,6 +542,7 @@ def profile_delete_cleanup(sender, instance, **kwargs):
 
 
 @receiver(models.signals.post_save, sender=Club)
+@receiver(models.signals.post_delete, sender=Club)
 def club_modify_handler(sender, instance, **kwargs):
     """
     Regenerate the club list cache when a club is modified.

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -548,7 +548,6 @@ def club_modify_handler(sender, instance, **kwargs):
     """
 
     def regenerate_club_list_cache():
-        from clubs.models import Club, Membership
         from clubs.serializers import ClubListSerializer
         from clubs.views import ClubViewSet
 

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.core.mail import EmailMultiAlternatives
 from django.core.validators import validate_email
 from django.db import models

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -556,9 +556,6 @@ def club_modify_handler(sender, instance, **kwargs):
         key, cache_time = settings.CLUB_LIST_CACHE_KEY, settings.CLUB_LIST_CACHE_TIME
         cache.set(key, serializer.data, cache_time)
 
-    if settings.DEBUG:
-        regenerate_club_list_cache()
-    else:
-        t = threading.Thread(target=regenerate_club_list_cache)
-        t.setDaemon(True)
-        t.start()
+    t = threading.Thread(target=regenerate_club_list_cache)
+    t.setDaemon(True)
+    t.start()

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -538,11 +538,3 @@ def user_create(sender, instance, created, **kwargs):
 def profile_delete_cleanup(sender, instance, **kwargs):
     if instance.image:
         instance.image.delete(save=False)
-
-
-@receiver(models.signals.post_save, sender=Club)
-def club_modify_handler(sender, instance, **kwargs):
-    """
-    Delete the club list cache when a club is modified.
-    """
-    cache.delete(settings.CLUB_LIST_CACHE_KEY)

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -1,7 +1,7 @@
 import datetime
 import os
-import uuid
 import threading
+import uuid
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -550,6 +550,7 @@ def club_modify_handler(sender, instance, **kwargs):
     def regenerate_club_list_cache():
         from clubs.models import Club, Membership
         from clubs.serializers import ClubListSerializer
+
         queryset = (
             Club.objects.all()
             .annotate(favorite_count=models.Count("favorite"))

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -103,8 +103,10 @@ class EventSerializer(serializers.ModelSerializer):
             return None
         if obj.image.url.startswith("http"):
             return obj.image.url
-        else:
+        elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.image.url)
+        else:
+            return None
 
     def validate_description(self, value):
         """
@@ -226,8 +228,10 @@ class MembershipSerializer(ClubRouteMixin, serializers.ModelSerializer):
         image_url = obj.person.profile.image.url
         if image_url.startswith("http"):
             return image_url
-        else:
+        elif "request" in self.context:
             return self.context["request"].build_absolute_uri(image_url)
+        else:
+            return None
 
     def validate_role(self, value):
         """
@@ -324,8 +328,10 @@ class ClubListSerializer(serializers.ModelSerializer):
             return None
         if obj.image.url.startswith("http"):
             return obj.image.url
-        else:
+        elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.image.url)
+        else:
+            return None
 
     def get_fields(self):
         all_fields = super().get_fields()
@@ -655,8 +661,10 @@ class UserSerializer(serializers.ModelSerializer):
             return None
         if obj.profile.image.url.startswith("http"):
             return obj.profile.image.url
-        else:
+        elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.profile.image.url)
+        else:
+            return None
 
     def get_full_name(self, obj):
         return obj.get_full_name()
@@ -711,8 +719,10 @@ class AssetSerializer(serializers.ModelSerializer):
             return None
         if obj.file.url.startswith("http"):
             return obj.file.url
-        else:
+        elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.file.url)
+        else:
+            return None
 
     # Cannot exceed maximum upload size
     def validate_file(self, data):

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -106,7 +106,7 @@ class EventSerializer(serializers.ModelSerializer):
         elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.image.url)
         else:
-            return None
+            return obj.image.url
 
     def validate_description(self, value):
         """
@@ -231,7 +231,7 @@ class MembershipSerializer(ClubRouteMixin, serializers.ModelSerializer):
         elif "request" in self.context:
             return self.context["request"].build_absolute_uri(image_url)
         else:
-            return None
+            return image_url
 
     def validate_role(self, value):
         """
@@ -331,7 +331,7 @@ class ClubListSerializer(serializers.ModelSerializer):
         elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.image.url)
         else:
-            return None
+            return obj.image.url
 
     def get_fields(self):
         all_fields = super().get_fields()
@@ -664,7 +664,7 @@ class UserSerializer(serializers.ModelSerializer):
         elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.profile.image.url)
         else:
-            return None
+            return obj.profile.image.url
 
     def get_full_name(self, obj):
         return obj.get_full_name()
@@ -722,7 +722,7 @@ class AssetSerializer(serializers.ModelSerializer):
         elif "request" in self.context:
             return self.context["request"].build_absolute_uri(obj.file.url)
         else:
-            return None
+            return obj.file.url
 
     # Cannot exceed maximum upload size
     def validate_file(self, data):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -157,6 +157,21 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     lookup_field = "code"
     http_method_names = ["get", "post", "put", "patch", "delete"]
 
+    def regenerate_cache(self, request):
+        """
+        Helper function to regenerate the club list when a club is edited.
+        """
+        
+        def generate_club_list():
+            key = settings.CLUB_LIST_CACHE_KEY
+            resp = super().list(request)
+            if resp.status_code == 200:
+                cache.set(key, resp.data, settings.CLUB_LIST_CACHE_TIME)
+
+        t = threading.Thread(target=generate_club_list)
+        t.setDaemon(True)
+        t.start()
+
     @action(detail=True, methods=["post"])
     def upload(self, request, *args, **kwargs):
         """

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -230,7 +230,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         return ret
 
     def update(self, request, *args, **kwargs):
-        ret = super().update(request,  *args, **kwargs)
+        ret = super().update(request, *args, **kwargs)
         self.regenerate_cache(request)
         return ret
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -246,7 +246,8 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
     def list(self, request, *args, **kwargs):
         """
-        Return a list of all clubs. Results are cached, and the cache is regenerated when a club is edited.
+        Return a list of all clubs.
+        Results are cached, and the cache is regenerated when a club is edited.
         Note that some fields are removed in order to improve the response time.
         """
         # don't cache requests for spreadsheet format

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -163,7 +163,7 @@ FLYER_URL = "https://{domain}/club/{club}/flyer"
 
 # Cache settings
 CLUB_LIST_CACHE_KEY = "club:list"
-CLUB_LIST_CACHE_TIME = 10 * 60
+CLUB_LIST_CACHE_TIME = None
 
 # File upload settings
 

--- a/backend/pennclubs/settings/ci.py
+++ b/backend/pennclubs/settings/ci.py
@@ -4,3 +4,10 @@ from pennclubs.settings.base import *  # noqa: F401, F403
 TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
 TEST_OUTPUT_VERBOSE = 2
 TEST_OUTPUT_DIR = "test-results"
+
+# Use dummy cache for testing
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}

--- a/backend/pennclubs/settings/ci.py
+++ b/backend/pennclubs/settings/ci.py
@@ -6,8 +6,4 @@ TEST_OUTPUT_VERBOSE = 2
 TEST_OUTPUT_DIR = "test-results"
 
 # Use dummy cache for testing
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    }
-}
+CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}


### PR DESCRIPTION
Club list is regenerated in another thread when a club is edited.

- [x] Make cache indefinite
- [x] Regenerate cache in background thread when a club is modified
- [x] Fix image_url serialization errors
- [x] Debug failing tests