### PR TITLE
Bump helm-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   docker: circleci/docker@0.5.19
   django-tools: pennlabs/django-tools@0.0.3
-  helm-tools: pennlabs/helm-tools@0.1.7
+  helm-tools: pennlabs/helm-tools@0.1.9
   react-tools: pennlabs/react-tools@0.0.5
 
 branch-filters: &branch-filters


### PR DESCRIPTION
Bump the helm-tools orb to allow slack notifacations to the #deployments channel on successful deploys.