### PR TITLE
[WIP] Rescue Club Tags

### DIFF
--- a/frontend/components/ClubPage/Header.tsx
+++ b/frontend/components/ClubPage/Header.tsx
@@ -18,7 +18,6 @@ type HeaderProps = {
 
 const Header = ({ club, style }: HeaderProps): ReactElement => {
   const { active, name, tags, badges } = club
-
   return (
     <div style={style}>
       <Wrapper>
@@ -28,8 +27,7 @@ const Header = ({ club, style }: HeaderProps): ReactElement => {
         </Title>
       </Wrapper>
       <div style={{ marginBottom: '1rem' }}>
-        <TagGroup tags={tags} />
-        <TagGroup tags={badges} />
+        <TagGroup tags={[...tags, ...badges]} />
       </div>
     </div>
   )

--- a/frontend/components/common/TagGroup.tsx
+++ b/frontend/components/common/TagGroup.tsx
@@ -25,6 +25,7 @@ export const TagGroup = ({ tags = [] }: TagGroupProps): ReactElement | null => {
               </DefaultTag>
             )
           case 'tag':
+          default:
             return (
               <BlueTag
                 key={`${tag.id}-${tag.kind}`}

--- a/frontend/pages/club/[club]/index.tsx
+++ b/frontend/pages/club/[club]/index.tsx
@@ -248,6 +248,16 @@ ClubPage.getInitialProps = async (ctx: NextPageContext) => {
   }
   const resp = await doApiRequest(`/clubs/${query.club}/?format=json`, data)
   const club = await resp.json()
+  // TODO: Enforce kind attribute using TS instead of manually annotating
+  const { badges, tags } = club
+  badges &&
+    badges.forEach((elem) => {
+      elem.kind = 'badge'
+    })
+  tags &&
+    tags.forEach((elem) => {
+      elem.kind = 'tag'
+    })
   return { club }
 }
 


### PR DESCRIPTION
So I figured out why the tags disappeared, turns out there was a switch statement that expects the kind property of a tag object to be populated with either "tag" or "badge", so I added a default branch and now tags show up.

However, from looking at the TS types, I suspect that somewhere in the frontend or the backend the tag objects should be annotated with the kind property containing either the string value of "tag" or "badge". Should I annotate the objects, and should it be on the backend (in a Serializer or smth) or on the frontend?