### PR TITLE
Add Button For Alphabetical Sort On Splashpage

### DIFF
--- a/frontend/components/DisplayButtons.tsx
+++ b/frontend/components/DisplayButtons.tsx
@@ -47,6 +47,7 @@ const buttonStyles = {
 
 const DisplayButtons = ({
   switchDisplay,
+  switchSort,
   shuffle,
 }: DisplayButtonsProps): ReactElement => (
   <DisplayButtonsTag>
@@ -73,7 +74,7 @@ const DisplayButtons = ({
       &nbsp;&nbsp; Shuffle
     </button>
     <button
-      // onClick={}
+      onClick={switchSort}
       style={{ ...buttonStyles, color: DARK_GRAY, fontWeight: 600 }}
       className="button is-small"
     >
@@ -91,6 +92,7 @@ const DisplayButtons = ({
 
 type DisplayButtonsProps = {
   switchDisplay: (disp: string) => void
+  switchSort: () => void
   shuffle: () => void
 }
 

--- a/frontend/components/DisplayButtons.tsx
+++ b/frontend/components/DisplayButtons.tsx
@@ -72,6 +72,14 @@ const DisplayButtons = ({
       <Icon name="shuffle" alt="shuffle club order" style={iconStyles} />
       &nbsp;&nbsp; Shuffle
     </button>
+    <button
+      // onClick={}
+      style={{ ...buttonStyles, color: DARK_GRAY, fontWeight: 600 }}
+      className="button is-small"
+    >
+      <Icon name="filter" alt="shuffle club order" style={iconStyles} />
+      &nbsp;&nbsp; Reorder
+    </button>
     <Link href="/create">
       <AddClubButton className="button is-small">
         <Icon name="plus" alt="create club" style={iconStylesDark} />

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -76,6 +76,8 @@ type SplashState = {
   clubLoaded: boolean
   clubCount: number
   displayClubs: RankedClub[]
+  alphabeticalDisplayClubs: RankedClub[]
+  displayAlphabetized: boolean
   selectedTags: any[]
   nameInput: string
   display: string
@@ -89,6 +91,8 @@ class Splash extends React.Component<SplashProps, SplashState> {
       clubCount: props.clubCount,
       clubLoaded: false,
       displayClubs: props.clubs,
+      alphabeticalDisplayClubs: [...props.clubs].sort(({name: a}, {name: b}) => a.localeCompare(b)),
+      displayAlphabetized: false,
       selectedTags: [],
       nameInput: '',
       display: 'cards',
@@ -96,6 +100,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
 
     this.shuffle = this.shuffle.bind(this)
     this.switchDisplay = this.switchDisplay.bind(this)
+    this.switchSort = this.switchSort.bind(this)
   }
 
   componentDidMount() {
@@ -185,6 +190,15 @@ class Splash extends React.Component<SplashProps, SplashState> {
     this.forceUpdate()
   }
 
+  switchSort(){
+    const { displayClubs, displayAlphabetized } = this.state
+    if (displayAlphabetized) this.setState({ displayAlphabetized: false})
+    else this.setState({
+      displayAlphabetized: true,
+      alphabeticalDisplayClubs: [...displayClubs].sort(({name: a}, {name: b}) => a.localeCompare(b))
+    })
+  }
+
   updateTag(tag, name) {
     const { selectedTags } = this.state
     const { value } = tag
@@ -245,6 +259,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
       club.rank += 2 * Math.random()
     })
     this.setState({
+      displayAlphabetized: false,
       displayClubs: clubs.sort((a, b) => {
         if (typeof b.rank === 'undefined') {
           return -1
@@ -270,6 +285,8 @@ class Splash extends React.Component<SplashProps, SplashState> {
       clubCount,
       displayClubs,
       display,
+      alphabeticalDisplayClubs,
+      displayAlphabetized,
       selectedTags,
       nameInput,
     } = this.state
@@ -291,6 +308,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
                 <DisplayButtons
                   shuffle={this.shuffle}
                   switchDisplay={this.switchDisplay}
+                  switchSort={this.switchSort}
                 />
 
                 <Title className="title" style={{ color: CLUBS_GREY }}>
@@ -343,7 +361,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
               )}
 
               <ClubDisplay
-                displayClubs={displayClubs}
+                displayClubs={displayAlphabetized ? alphabeticalDisplayClubs : displayClubs}
                 display={display}
                 tags={tags}
               />

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -83,6 +83,10 @@ type SplashState = {
   display: string
 }
 
+function sortClubsByName (clubs: RankedClub[]): RankedClub[] {
+  return [...clubs].sort(({ name: a }, { name: b }) => a.localeCompare(b))
+}
+
 class Splash extends React.Component<SplashProps, SplashState> {
   constructor(props) {
     super(props)
@@ -91,9 +95,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
       clubCount: props.clubCount,
       clubLoaded: false,
       displayClubs: props.clubs,
-      alphabeticalDisplayClubs: [
-        ...props.clubs,
-      ].sort(({ name: a }, { name: b }) => a.localeCompare(b)),
+      alphabeticalDisplayClubs: sortClubsByName(props.clubs),
       displayAlphabetized: false,
       selectedTags: [],
       nameInput: '',
@@ -118,7 +120,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
           results.forEach((c) => seenClubs.add(c.code))
           clubs.concat(newClubs)
           if (!next || count === 0) {
-            this.setState({ clubs, displayClubs: clubs, clubCount: count })
+            this.setState({ clubs, displayClubs: clubs, alphabeticalDisplayClubs: sortClubsByName(clubs), clubCount: count })
           }
           if (next) {
             paginationDownload(next, count + 1)
@@ -182,7 +184,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
     })
       .then((res) => res.json())
       .then((displayClubs) => {
-        this.setState({ displayClubs, nameInput, selectedTags })
+        this.setState({ displayClubs, alphabeticalDisplayClubs: sortClubsByName(displayClubs), nameInput, selectedTags })
       })
   }
 
@@ -193,15 +195,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
   }
 
   switchSort() {
-    const { displayClubs, displayAlphabetized } = this.state
-    if (displayAlphabetized) this.setState({ displayAlphabetized: false })
-    else
-      this.setState({
-        displayAlphabetized: true,
-        alphabeticalDisplayClubs: [
-          ...displayClubs,
-        ].sort(({ name: a }, { name: b }) => a.localeCompare(b)),
-      })
+    this.setState(({ displayAlphabetized }) => ({ displayAlphabetized: !displayAlphabetized}))
   }
 
   updateTag(tag, name) {
@@ -281,6 +275,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
         }
         return 0
       }),
+      alphabeticalDisplayClubs: sortClubsByName(clubs)
     })
   }
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -83,7 +83,7 @@ type SplashState = {
   display: string
 }
 
-function sortClubsByName (clubs: RankedClub[]): RankedClub[] {
+function sortClubsByName(clubs: RankedClub[]): RankedClub[] {
   return [...clubs].sort(({ name: a }, { name: b }) => a.localeCompare(b))
 }
 
@@ -120,7 +120,12 @@ class Splash extends React.Component<SplashProps, SplashState> {
           results.forEach((c) => seenClubs.add(c.code))
           clubs.concat(newClubs)
           if (!next || count === 0) {
-            this.setState({ clubs, displayClubs: clubs, alphabeticalDisplayClubs: sortClubsByName(clubs), clubCount: count })
+            this.setState({
+              clubs,
+              displayClubs: clubs,
+              alphabeticalDisplayClubs: sortClubsByName(clubs),
+              clubCount: count,
+            })
           }
           if (next) {
             paginationDownload(next, count + 1)
@@ -184,7 +189,12 @@ class Splash extends React.Component<SplashProps, SplashState> {
     })
       .then((res) => res.json())
       .then((displayClubs) => {
-        this.setState({ displayClubs, alphabeticalDisplayClubs: sortClubsByName(displayClubs), nameInput, selectedTags })
+        this.setState({
+          displayClubs,
+          alphabeticalDisplayClubs: sortClubsByName(displayClubs),
+          nameInput,
+          selectedTags,
+        })
       })
   }
 
@@ -195,7 +205,9 @@ class Splash extends React.Component<SplashProps, SplashState> {
   }
 
   switchSort() {
-    this.setState(({ displayAlphabetized }) => ({ displayAlphabetized: !displayAlphabetized}))
+    this.setState(({ displayAlphabetized }) => ({
+      displayAlphabetized: !displayAlphabetized,
+    }))
   }
 
   updateTag(tag, name) {
@@ -275,7 +287,7 @@ class Splash extends React.Component<SplashProps, SplashState> {
         }
         return 0
       }),
-      alphabeticalDisplayClubs: sortClubsByName(clubs)
+      alphabeticalDisplayClubs: sortClubsByName(clubs),
     })
   }
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -91,7 +91,9 @@ class Splash extends React.Component<SplashProps, SplashState> {
       clubCount: props.clubCount,
       clubLoaded: false,
       displayClubs: props.clubs,
-      alphabeticalDisplayClubs: [...props.clubs].sort(({name: a}, {name: b}) => a.localeCompare(b)),
+      alphabeticalDisplayClubs: [
+        ...props.clubs,
+      ].sort(({ name: a }, { name: b }) => a.localeCompare(b)),
       displayAlphabetized: false,
       selectedTags: [],
       nameInput: '',
@@ -190,13 +192,16 @@ class Splash extends React.Component<SplashProps, SplashState> {
     this.forceUpdate()
   }
 
-  switchSort(){
+  switchSort() {
     const { displayClubs, displayAlphabetized } = this.state
-    if (displayAlphabetized) this.setState({ displayAlphabetized: false})
-    else this.setState({
-      displayAlphabetized: true,
-      alphabeticalDisplayClubs: [...displayClubs].sort(({name: a}, {name: b}) => a.localeCompare(b))
-    })
+    if (displayAlphabetized) this.setState({ displayAlphabetized: false })
+    else
+      this.setState({
+        displayAlphabetized: true,
+        alphabeticalDisplayClubs: [
+          ...displayClubs,
+        ].sort(({ name: a }, { name: b }) => a.localeCompare(b)),
+      })
   }
 
   updateTag(tag, name) {
@@ -361,7 +366,9 @@ class Splash extends React.Component<SplashProps, SplashState> {
               )}
 
               <ClubDisplay
-                displayClubs={displayAlphabetized ? alphabeticalDisplayClubs : displayClubs}
+                displayClubs={
+                  displayAlphabetized ? alphabeticalDisplayClubs : displayClubs
+                }
                 display={display}
                 tags={tags}
               />

--- a/frontend/public/static/img/icons/filter.svg
+++ b/frontend/public/static/img/icons/filter.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-filter"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>


### PR DESCRIPTION
![reorderButton](https://user-images.githubusercontent.com/2645695/89752043-470add80-da98-11ea-9d43-e5a4b380fb37.PNG)

Added "reorder" button on the splashpage. I don't like how cluttered the filtering buttons are with the addition of this button, and I also think it could have better wording, but I defer to the design team on those matters - the button is functional.