### PR TITLE
Move Delete Profile Picture Button

### DIFF
--- a/frontend/components/Form.js
+++ b/frontend/components/Form.js
@@ -197,6 +197,7 @@ class Form extends Component {
       disabled = false,
       required,
       help,
+      trivia,
     } = field
 
     const {
@@ -343,6 +344,7 @@ class Form extends Component {
               </span>
               <span className="file-label">Choose a file...</span>
             </span>
+            {trivia}
           </label>
           {this.state.uploadStatus[name] ? (
             <span style={{ paddingTop: 3, paddingLeft: 8 }}>

--- a/frontend/components/Settings/ProfileForm.js
+++ b/frontend/components/Settings/ProfileForm.js
@@ -82,18 +82,22 @@ class ProfileForm extends React.Component {
         name: 'image',
         type: 'file',
         label: 'Profile Picture',
-        trivia: settings.image_url ? <button
-        onClick={this.deleteProfilePic}
-        className="button is-danger is-pulled-right"
-        style={{
-          marginLeft: M2
-        }}
-      >
-        <span className="file-icon"><Icon name="trash" /></span>
-        <span className="file-label">
-          Remove Image
-        </span>
-      </button> : <></>
+        trivia: settings.image_url ? (
+          <button
+            onClick={this.deleteProfilePic}
+            className="button is-danger is-pulled-right"
+            style={{
+              marginLeft: M2,
+            }}
+          >
+            <span className="file-icon">
+              <Icon name="trash" />
+            </span>
+            <span className="file-label">Remove Image</span>
+          </button>
+        ) : (
+          <></>
+        ),
       },
       {
         name: 'graduation_year',
@@ -126,8 +130,8 @@ class ProfileForm extends React.Component {
           defaults={settings}
           onSubmit={this.submit}
           submitButton={
-              <a className="button is-success">
-                <Icon alt="save" name="edit" />
+            <a className="button is-success">
+              <Icon alt="save" name="edit" />
               Save
             </a>
           }
@@ -138,7 +142,6 @@ class ProfileForm extends React.Component {
             </a>
           }
         />
-
       </>
     )
   }

--- a/frontend/components/Settings/ProfileForm.js
+++ b/frontend/components/Settings/ProfileForm.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { M1, M2 } from '../../constants'
 import { doApiRequest } from '../../utils'
 import { Icon } from '../common/Icon'
 import Form from '../Form'
@@ -80,6 +81,19 @@ class ProfileForm extends React.Component {
       {
         name: 'image',
         type: 'file',
+        label: 'Profile Picture',
+        trivia: settings.image_url ? <button
+        onClick={this.deleteProfilePic}
+        className="button is-danger is-pulled-right"
+        style={{
+          marginLeft: M2
+        }}
+      >
+        <span className="file-icon"><Icon name="trash" /></span>
+        <span className="file-label">
+          Remove Image
+        </span>
+      </button> : <></>
       },
       {
         name: 'graduation_year',
@@ -105,7 +119,6 @@ class ProfileForm extends React.Component {
         reverser: (a) => ({ id: a.value, name: a.label }),
       },
     ]
-
     return (
       <>
         <Form
@@ -113,8 +126,8 @@ class ProfileForm extends React.Component {
           defaults={settings}
           onSubmit={this.submit}
           submitButton={
-            <a className="button is-success">
-              <Icon alt="save" name="edit" />
+              <a className="button is-success">
+                <Icon alt="save" name="edit" />
               Save
             </a>
           }
@@ -125,14 +138,7 @@ class ProfileForm extends React.Component {
             </a>
           }
         />
-        {settings.image_url && (
-          <button
-            onClick={this.deleteProfilePic}
-            className="button is-danger is-pulled-right"
-          >
-            <Icon name="trash" /> Delete Profile Picture
-          </button>
-        )}
+
       </>
     )
   }


### PR DESCRIPTION
![Screenshot from 2020-08-10 14-14-55](https://user-images.githubusercontent.com/2645695/89821521-b3c7bb80-db1c-11ea-9ae9-5a5edeb6a0cb.png)

One thing that's confusing with this change is that the upload image button requires you to press save, whereas the delete image button deletes the image straight up, without needing the user to press save. Maybe I should edit the Form component so that you can have a file upload field that shows two buttons when the field is uploaded, one of which sets [name]: null like the delete profile pic button was doing before, instead of "injecting' the button like I did here? lmk what y'all think.