### PR TITLE
Renewal backend

### DIFF
--- a/backend/clubs/management/commands/deactivate.py
+++ b/backend/clubs/management/commands/deactivate.py
@@ -32,6 +32,6 @@ class Command(BaseCommand):
                 self.stdout.write("Input:", ending=" ")
 
         # deactivate all clubs
-        Club.objects.all().update(active=False)
+        Club.objects.all().update(active=False, approved=False, approved_by=None)
 
         self.stdout.write("All clubs deactivated!")

--- a/backend/clubs/management/commands/deactivate.py
+++ b/backend/clubs/management/commands/deactivate.py
@@ -5,25 +5,33 @@ from clubs.models import Club
 
 class Command(BaseCommand):
     help = "Deactivates all clubs in the database. This should be used at \
-            the end of the school year when clubs must be renewed."
+            the beginning of the school year when clubs must be renewed."
 
-    def handle(self, *args, **kwargs):
-        print(
-            "\033[93m"
-            + "You are about to set all club status to inactive and will have"
-            + "to begin the renewal process. This should only happen at the end"
-            + " of the school year. Are you postive this is what you want"
-            + " to do? Type 'deactivate all clubs' to continue."
-            + "\033[0m"
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            dest="force",
+            action="store_true",
+            help="Do not prompt for confirmation, just start the club renewal process.",
         )
 
-        correct = "deactivate all clubs"
-        print("Input:", end=" ")
-        while input().strip() != correct:
-            print("Input:", end=" ")
+    def handle(self, *args, **kwargs):
+        if not kwargs["force"]:
+            self.stdout.write(
+                self.style.WARNING(
+                    "You are about to set all club status to inactive and will have "
+                    + "to begin the renewal process. This should only happen at the beginning "
+                    + "of the school year. Are you postive this is what you want "
+                    + "to do? Type 'deactivate all clubs' to continue."
+                )
+            )
+
+            correct = "deactivate all clubs"
+            self.stdout.write("Input:", ending=" ")
+            while input().strip() != correct:
+                self.stdout.write("Input:", ending=" ")
 
         # deactivate all clubs
-        for club in Club.objects.all():
-            club.active = False
+        Club.objects.all().update(active=False)
 
-        print("Clubs deactivated")
+        self.stdout.write("All clubs deactivated!")

--- a/backend/clubs/management/commands/deactivate.py
+++ b/backend/clubs/management/commands/deactivate.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+
+from clubs.models import Club
+
+
+class Command(BaseCommand):
+    help = "Deactivates all clubs in the database. This should be used at \
+            the end of the school year when clubs must be renewed."
+
+    def handle(self, *args, **kwargs):
+        print(
+            "\033[93m"
+            + "You are about to set all club status to inactive and will have"
+            + "to begin the renewal process. This should only happen at the end"
+            + " of the school year. Are you postive this is what you want"
+            + " to do? Type 'deactivate all clubs' to continue."
+            + "\033[0m"
+        )
+
+        correct = "deactivate all clubs"
+        print("Input:", end=" ")
+        while input().strip() != correct:
+            print("Input:", end=" ")
+
+        # deactivate all clubs
+        for club in Club.objects.all():
+            club.active = False
+
+        print("Clubs deactivated")

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -366,15 +366,6 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         else:
             return queryset.filter(approved=True)
 
-    @action(detail=True, methods=["get"])
-    def renew(self, request, *args, **kwargs):
-        """
-        Renew the club in question.
-        """
-        club = self.get_object()
-        club.active = True
-        return Response({"success": True})
-
     @action(detail=True, methods=["post"])
     def upload(self, request, *args, **kwargs):
         """

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -366,6 +366,15 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         else:
             return queryset.filter(approved=True)
 
+    @action(detail=True, methods=["get"])
+    def renew(self, request, *args, **kwargs):
+        """
+        Renew the club in question.
+        """
+        club = self.get_object()
+        club.active = True
+        return Response({"success": True})
+
     @action(detail=True, methods=["post"])
     def upload(self, request, *args, **kwargs):
         """

--- a/frontend/pages/club/[club]/renew.tsx
+++ b/frontend/pages/club/[club]/renew.tsx
@@ -246,8 +246,11 @@ const RenewPage = ({
   const nextStep = () => {
     setStep(step + 1)
     if (step === 3) {
-      doApiRequest(`/clubs/${club.code}/renew/`, {
-        method: 'POST',
+      doApiRequest(`/clubs/${club.code}/?format=json`, {
+        method: 'PATCH',
+        body: {
+          active: true,
+        },
       })
     }
   }

--- a/frontend/pages/club/[club]/renew.tsx
+++ b/frontend/pages/club/[club]/renew.tsx
@@ -245,6 +245,11 @@ const RenewPage = ({
 
   const nextStep = () => {
     setStep(step + 1)
+    if (step === 3) {
+      doApiRequest(`/clubs/${club.code}/renew/`, {
+        method: 'POST',
+      })
+    }
   }
 
   return (


### PR DESCRIPTION
Added:

- `/renew` detail endpoint for clubs that sets `active=true
- `deactivate` command that sets `active=false` for all clubs (be careful with this one!)
- Renew form now posts to renewal endpoint to clubs are set to active after finishing the form