### PR TITLE
Event Endpoints

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -222,7 +222,6 @@ class YearSerializer(serializers.ModelSerializer):
 
 
 class EventSerializer(serializers.ModelSerializer):
-    id = serializers.SlugField(required=False)
     club = serializers.SlugRelatedField(
         queryset=Club.objects.all(), required=False, slug_field="code"
     )

--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -29,6 +29,7 @@ from clubs.views import (
 
 router = routers.SimpleRouter()
 router.register(r"clubs", ClubViewSet, basename="clubs")
+router.register(r"events", EventViewSet, basename="events")
 router.register(r"tags", TagViewSet, basename="tags")
 router.register(r"favorites", FavoriteViewSet, basename="favorites")
 router.register(r"subscriptions", SubscribeViewSet, basename="subscribes")


### PR DESCRIPTION
[ch2250]

This PR adds some new endpoints for events, and gets rid of the requirement that events be namespaced to clubs.

The `test_event_list` testcase is also expanded to test these endpoints.

You can now get all events at `/api/events`, and can still get a club's events at `/api/club/[club]/events`.

- `/events` will get all events that haven't finished yet.
- `/events/live` will get all events which are currently happening (current time between start & end times).
- `/events/upcoming` will get all events which have not yet started.
- `/events/ended` will get all events that have end times in the past.