### PR TITLE
Club Management Page Modifications

### DIFF
--- a/frontend/components/ClubEditPage.tsx
+++ b/frontend/components/ClubEditPage.tsx
@@ -210,7 +210,7 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
       tabs = [
         {
           name: 'info',
-          label: 'Information',
+          label: 'Edit Club Page',
           content: (
             <ClubEditCard
               isEdit={this.state.isEdit}
@@ -233,6 +233,15 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
             </>
           ),
           disabled: !isEdit,
+        },
+        {
+          name: 'events',
+          label: 'Events',
+          content: (
+            <>
+              <EventsCard club={club} />
+            </>
+          ),
         },
         {
           name: 'recruitment',
@@ -265,7 +274,6 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
             <>
               <QRCodeCard club={club} />
               <MemberExperiencesCard club={club} />
-              <EventsCard club={club} />
               <FilesCard club={club} />
             </>
           ),

--- a/frontend/components/ClubEditPage.tsx
+++ b/frontend/components/ClubEditPage.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { SingletonRouter } from 'next/router'
-import { Component, ReactElement } from 'react'
+import React, { Component, ReactElement } from 'react'
 
 import BaseCard from '../components/ClubEditPage/BaseCard'
 import ClubEditCard from '../components/ClubEditPage/ClubEditCard'
@@ -228,8 +228,23 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
           label: 'Membership',
           content: (
             <>
-              <MembersCard club={club} />
               <InviteCard club={club} />
+              <PotentialMemberCard
+                club={club}
+                source="membershiprequests"
+                actions={[
+                  {
+                    name: 'Accept',
+                    onClick: (id: string): Promise<void> => {
+                      return doApiRequest(
+                        `/clubs/${club.code}/membershiprequests/${id}/accept/?format=json`,
+                        { method: 'POST' },
+                      ).then(() => undefined)
+                    },
+                  },
+                ]}
+              />
+              <MembersCard club={club} />
             </>
           ),
           disabled: !isEdit,
@@ -248,22 +263,8 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
           label: 'Recruitment',
           content: (
             <>
+              <QRCodeCard club={club} />
               <PotentialMemberCard club={club} source="subscription" />
-              <PotentialMemberCard
-                club={club}
-                source="membershiprequests"
-                actions={[
-                  {
-                    name: 'Accept',
-                    onClick: (id: string): Promise<void> => {
-                      return doApiRequest(
-                        `/clubs/${club.code}/membershiprequests/${id}/accept/?format=json`,
-                        { method: 'POST' },
-                      ).then(() => undefined)
-                    },
-                  },
-                ]}
-              />
             </>
           ),
         },
@@ -272,7 +273,6 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
           label: 'Resources',
           content: (
             <>
-              <QRCodeCard club={club} />
               <MemberExperiencesCard club={club} />
               <FilesCard club={club} />
             </>

--- a/frontend/components/ClubEditPage/EventsCard.tsx
+++ b/frontend/components/ClubEditPage/EventsCard.tsx
@@ -317,7 +317,8 @@ export default function EventsCard({ club }: EventsCardProps): ReactElement {
         currentTitle={(obj) => obj.name}
         onChange={(obj) => setDeviceContents(obj)}
       />
-      <Devices contents={deviceContents} />
+      {/* TODO: uncomment device preview when we have mobile integration. */}
+      {/* <Devices contents={deviceContents} /> */}
     </BaseCard>
   )
 }

--- a/frontend/components/ClubPage/Actions.tsx
+++ b/frontend/components/ClubPage/Actions.tsx
@@ -125,7 +125,7 @@ const Actions = ({
           {canEdit && (
             <Link href={CLUB_EDIT_ROUTE()} as={CLUB_EDIT_ROUTE(code)}>
               <ActionButton className="button is-success">
-                Edit Club
+                Manage Club
               </ActionButton>
             </Link>
           )}

--- a/frontend/components/ClubPage/ClubApprovalDialog.tsx
+++ b/frontend/components/ClubPage/ClubApprovalDialog.tsx
@@ -144,7 +144,7 @@ const ClubApprovalDialog = ({ club, userInfo }: Props): ReactElement | null => {
         club.is_member <= MembershipRank.Officer && (
           <>
             <div className="mb-3">
-              You can edit your club details using the <b>Edit Club</b> button
+              You can edit your club details using the <b>Manage Club</b> button
               on this page. After you have addressed the issues mentioned above,
               you can request renewal again using the button below.
             </div>

--- a/frontend/cypress/integration/superuser_spec.js
+++ b/frontend/cypress/integration/superuser_spec.js
@@ -20,7 +20,7 @@ describe('Permissioned user tests', () => {
     cy.visit('/club/pppjo')
     cy.contains('Benjamin Franklin').should('be.visible')
 
-    cy.contains('button', 'Edit Club').click({ force: true })
+    cy.contains('button', 'Manage Club').click({ force: true })
 
     cy.url({ timeout: 10000 }).should('contain', 'edit')
     cy.contains('.field', 'Name')
@@ -34,7 +34,7 @@ describe('Permissioned user tests', () => {
     cy.contains('View Club').click({ force: true })
     cy.contains('Penn Pre-Professional Juggling Organization - Edited')
 
-    cy.contains('button', 'Edit Club').click({ force: true })
+    cy.contains('button', 'Manage Club').click({ force: true })
     cy.contains('.field', 'Name')
       .find('input')
       .clear()
@@ -46,8 +46,9 @@ describe('Permissioned user tests', () => {
     cy.visit('/club/pppjo/edit')
 
     const tabs = [
-      'Information',
+      'Edit Club Page',
       'Membership',
+      'Events',
       'Recruitment',
       'Resources',
       'Questions',

--- a/frontend/pages/rank.tsx
+++ b/frontend/pages/rank.tsx
@@ -96,7 +96,7 @@ const Rank = (): ReactElement => (
       {
         name: 'Is Club Active',
         description:
-          'Clubs that are marked as inactive will be shifted to the bottom of the list. You can easily reactivate your club from the "Edit Club" page if it has been marked as inactive.',
+          'Clubs that are marked as inactive will be shifted to thev very bottom of the list. You can easily reactivate your club from the settings tab in the manage club page.',
       },
       {
         name: 'Random Factor',


### PR DESCRIPTION
[ch2241]
This PR makes some small tweaks to the edit page.

1. Changes button from `Edit Club` to `Manage Club`, since a lot more happens besides editing club details.
<img width="350" alt="Screen Shot 2020-08-18 at 2 19 10 PM" src="https://user-images.githubusercontent.com/436045/90551282-16453b00-e15f-11ea-948a-57ae81a7da50.png">

2. Moves events into its own tab on the club management page. Before it was buried at the bottom of "Resources".

There were also some other small tweaks, like renaming "Information" to "Edit Club Information". I also hid the mobile preview, since we don't currently have any mobile integration, it might be confusing for the SAC fair.

<img width="1010" alt="Screen Shot 2020-08-18 at 2 19 45 PM" src="https://user-images.githubusercontent.com/436045/90551410-468cd980-e15f-11ea-8d4a-23a8dd0d88a0.png">

3. The Membership tab now includes the components for inviting new members, accepting/rejecting membership requests, and viewing/managing existing memberships. The QR code is now in the recruitment tab, since it's used during recruitment season. Not sure if the ordering of invite, requests, actual members makes the most sense, am definitely open to feedback on if this whole reordering makes sense here.

<img width="654" alt="Screen Shot 2020-08-18 at 2 43 00 PM" src="https://user-images.githubusercontent.com/436045/90552848-7210c380-e161-11ea-8197-c715b7a5da42.png">


