### PR TITLE
Update Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 # IDE files
-.vscode/*
-!.vscode/settings.json
+.vscode/
 .idea/
 
 # Python files
 __pycache__/
 *.pyc
+.log/
 
 # Distribution
 build/


### PR DESCRIPTION
Removed `.vscode/` and `.log/` from staging for Clubs.

There used to be an exception for `.vscode/settings.json`, but it looks like it has machine-specific settings in it for me (like the pipenv virtualenv name) that shouldn't be committed. 

Feel free to reject this PR if these omissions are intentional :D 