### PR TITLE
Invite Cypress Testing complete

### DIFF
--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -66,7 +66,9 @@ urlpatterns = [
 
 # Only add the following endpoint if Django is in development/testing
 if settings.DEBUG:
-    urlpatterns.append(path(r"test/lastemail", LastEmailInviteTestAPIView.as_view(), name="last-email"))
+    urlpatterns.append(
+        path(r"test/lastemail", LastEmailInviteTestAPIView.as_view(), name="last-email")
+    )
 
 urlpatterns += router.urls
 urlpatterns += clubs_router.urls

--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import path
 from rest_framework_nested import routers
 
@@ -7,7 +8,7 @@ from clubs.views import (
     ClubViewSet,
     EventViewSet,
     FavoriteViewSet,
-    LastEmailAPIView,
+    LastEmailInviteTestAPIView,
     MajorViewSet,
     MassInviteAPIView,
     MemberInviteViewSet,
@@ -61,8 +62,11 @@ urlpatterns = [
     path(r"settings/permissions/", UserPermissionAPIView.as_view(), name="users-permission"),
     path(r"clubs/<slug:club_code>/invite/", MassInviteAPIView.as_view(), name="club-invite"),
     path(r"emailpreview/", email_preview, name="email-preview"),
-    path(r"test/lastemail", LastEmailAPIView.as_view(), name="last-email"),
 ]
+
+# Only add the following endpoint if Django is in development/testing
+if settings.DEBUG:
+    urlpatterns.append(path(r"test/lastemail", LastEmailInviteTestAPIView.as_view(), name="last-email"))
 
 urlpatterns += router.urls
 urlpatterns += clubs_router.urls

--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -25,6 +25,7 @@ from clubs.views import (
     UserUpdateAPIView,
     YearViewSet,
     email_preview,
+    LastEmailAPIView,
 )
 
 
@@ -60,6 +61,7 @@ urlpatterns = [
     path(r"settings/permissions/", UserPermissionAPIView.as_view(), name="users-permission"),
     path(r"clubs/<slug:club_code>/invite/", MassInviteAPIView.as_view(), name="club-invite"),
     path(r"emailpreview/", email_preview, name="email-preview"),
+    path(r"test/lastemail", LastEmailAPIView.as_view(), name="last-email"),
 ]
 
 urlpatterns += router.urls

--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -7,6 +7,7 @@ from clubs.views import (
     ClubViewSet,
     EventViewSet,
     FavoriteViewSet,
+    LastEmailAPIView,
     MajorViewSet,
     MassInviteAPIView,
     MemberInviteViewSet,
@@ -25,7 +26,6 @@ from clubs.views import (
     UserUpdateAPIView,
     YearViewSet,
     email_preview,
-    LastEmailAPIView,
 )
 
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1229,6 +1229,35 @@ class MassInviteAPIView(APIView):
             {"detail": "Sent invite(s) to {} email(s)!".format(len(emails)), "success": True}
         )
 
+class LastEmailAPIView(APIView):
+    """
+    get: Return the club code, invite id and token of the last sent email invite
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        latest_email_invite = MembershipInvite.objects.filter(active=True).latest('created_at')
+        club_code = latest_email_invite.club.code
+        email_id = latest_email_invite.id
+        email_token = latest_email_invite.token
+
+        if os.environ.get("DJANGO_SETTINGS_MODULE") == "pennclubs.settings.development":
+            return Response(
+                {
+                    "code": "{}".format(club_code),
+                    "id": "{}".format(email_id),
+                    "token": "{}".format(email_token),
+                },
+            )
+        else:
+            return Response(
+                {
+                    "detail": "You can only access this endpoint during development/testing",
+                    "success": False,
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
 class EmailPreviewContext(dict):
     """

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1247,14 +1247,14 @@ class LastEmailInviteTestAPIView(APIView):
             return Response(
                 {
                     "code": club_code,
-                    "id": "{}".format(email_id),
-                    "token": "{}".format(email_token),
+                    "id": email_id,
+                    "token": email_token,
                 },
             )
         else:
             return Response(
                 {
-                    "detail": "You can only access tokens for invitations that match your email",
+                    "detail": "You can only access tokens for invitations that match your email.",
                     "email": request.user.email,
                     "success": False,
                 },

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1242,7 +1242,7 @@ class LastEmailInviteTestAPIView(APIView):
         club_code = latest_email_invite.club.code
         email_id = latest_email_invite.id
         email_token = latest_email_invite.token
-        
+ 
         if request.user.email == latest_email_invite.email:
             return Response(
                 {
@@ -1254,7 +1254,7 @@ class LastEmailInviteTestAPIView(APIView):
         else:
             return Response(
                 {
-                    "detail": "You can only access invitation token that matches your email credentials",
+                    "detail": "You can only access tokens that matche your email credentials",
                     "email": request.user.email,
                     "success": False,
                 },

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1229,6 +1229,7 @@ class MassInviteAPIView(APIView):
             {"detail": "Sent invite(s) to {} email(s)!".format(len(emails)), "success": True}
         )
 
+
 class LastEmailAPIView(APIView):
     """
     get: Return the club code, invite id and token of the last sent email invite
@@ -1237,7 +1238,7 @@ class LastEmailAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        latest_email_invite = MembershipInvite.objects.filter(active=True).latest('created_at')
+        latest_email_invite = MembershipInvite.objects.filter(active=True).latest("created_at")
         club_code = latest_email_invite.club.code
         email_id = latest_email_invite.id
         email_token = latest_email_invite.token
@@ -1258,6 +1259,7 @@ class LastEmailAPIView(APIView):
                 },
                 status=status.HTTP_403_FORBIDDEN,
             )
+
 
 class EmailPreviewContext(dict):
     """

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1254,7 +1254,7 @@ class LastEmailInviteTestAPIView(APIView):
         else:
             return Response(
                 {
-                    "detail": "You can only access tokens that matche your email credentials",
+                    "detail": "You can only access tokens for invitations that match your email",
                     "email": request.user.email,
                     "success": False,
                 },

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1244,13 +1244,7 @@ class LastEmailInviteTestAPIView(APIView):
         email_token = latest_email_invite.token
 
         if request.user.email == latest_email_invite.email:
-            return Response(
-                {
-                    "code": club_code,
-                    "id": email_id,
-                    "token": email_token,
-                },
-            )
+            return Response({"code": club_code, "id": email_id, "token": email_token},)
         else:
             return Response(
                 {

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1242,7 +1242,7 @@ class LastEmailInviteTestAPIView(APIView):
         club_code = latest_email_invite.club.code
         email_id = latest_email_invite.id
         email_token = latest_email_invite.token
- 
+
         if request.user.email == latest_email_invite.email:
             return Response(
                 {

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1230,7 +1230,7 @@ class MassInviteAPIView(APIView):
         )
 
 
-class LastEmailAPIView(APIView):
+class LastEmailInviteTestAPIView(APIView):
     """
     get: Return the club code, invite id and token of the last sent email invite
     """
@@ -1242,11 +1242,11 @@ class LastEmailAPIView(APIView):
         club_code = latest_email_invite.club.code
         email_id = latest_email_invite.id
         email_token = latest_email_invite.token
-
-        if os.environ.get("DJANGO_SETTINGS_MODULE") == "pennclubs.settings.development":
+        
+        if request.user.email == latest_email_invite.email:
             return Response(
                 {
-                    "code": "{}".format(club_code),
+                    "code": club_code,
                     "id": "{}".format(email_id),
                     "token": "{}".format(email_token),
                 },
@@ -1254,7 +1254,8 @@ class LastEmailAPIView(APIView):
         else:
             return Response(
                 {
-                    "detail": "You can only access this endpoint during development/testing",
+                    "detail": "You can only access invitation token that matches your email credentials",
+                    "email": request.user.email,
                     "success": False,
                 },
                 status=status.HTTP_403_FORBIDDEN,

--- a/frontend/components/ClubPage/MemberList.js
+++ b/frontend/components/ClubPage/MemberList.js
@@ -12,8 +12,6 @@ const Toggle = s.div`
 `
 
 const MemberList = ({ club: { members } }) => {
-  members = members.filter((member) => member.public)
-
   const [expanded, setExpanded] = useState(false)
   const hasMembers = members.length > 0
 

--- a/frontend/components/ClubPage/MemberList.js
+++ b/frontend/components/ClubPage/MemberList.js
@@ -12,8 +12,11 @@ const Toggle = s.div`
 `
 
 const MemberList = ({ club: { members } }) => {
+  members = members.filter((member) => member.public)
+
   const [expanded, setExpanded] = useState(false)
   const hasMembers = members.length > 0
+
   return hasMembers ? (
     <div>
       {expanded ? (

--- a/frontend/components/ClubPage/MemberList.js
+++ b/frontend/components/ClubPage/MemberList.js
@@ -14,7 +14,6 @@ const Toggle = s.div`
 const MemberList = ({ club: { members } }) => {
   const [expanded, setExpanded] = useState(false)
   const hasMembers = members.length > 0
-
   return hasMembers ? (
     <div>
       {expanded ? (

--- a/frontend/cypress/integration/invite_spec.js
+++ b/frontend/cypress/integration/invite_spec.js
@@ -1,7 +1,9 @@
 describe('Invitation tests', () => {
   before(() => {
     cy.login('bfranklin', 'test') 
+    cy.visit('/api/admin/auth/user')  
   })
+
 
   after(() => {
     // Remove James Madison from the club

--- a/frontend/cypress/integration/invite_spec.js
+++ b/frontend/cypress/integration/invite_spec.js
@@ -1,0 +1,114 @@
+describe('Invitation tests', () => {
+  before(() => {
+    cy.login() 
+
+    const fields = [
+      { label: 'Name', value: 'test new club', pressEnter: false },
+      { label: 'Size', value: '< 20', pressEnter: true },
+      {
+        label: 'Is an application required to join your organization?',
+        value: 'No Application Required',
+        pressEnter: true,
+      },
+    ]
+    
+    // Create club
+    cy.visit('/create')
+
+    fields.forEach(({ label, value, pressEnter }) => {
+      const input = cy.contains('.field', label).find('input')
+      input.focus().clear().type(value)
+
+      if (pressEnter) {
+        input.type('{enter}')
+      }
+
+      input.blur()
+    })
+
+    cy.contains('Select tags relevant to your club!').click()
+    cy.contains('Undergraduate').click()
+
+    cy.contains('Submit').click()
+
+    // wait for club to be created, should be redirected to renewal page
+    cy.contains('Renew Club').should('be.visible') 
+  })
+
+  after(() => {
+    cy.login()
+    cy.visit('/club/test-new-club/edit#settings')
+    cy.contains('Delete Club')
+    cy.contains('.button', 'Delete Club').click()
+    cy.contains('404 Not Found')
+    
+    cy.logout()
+  })
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('sessionid', 'csrftoken')
+  })
+
+  it('Invites User', () => {
+    cy.visit('/club/test-new-club/edit#member')
+    cy.contains('Invite Members').scrollIntoView()
+    cy.get('[data-testid="invite-emails-input"]').type(
+        'bfranklin@seas.upenn.edu'
+    )
+
+    cy.get('[data-testid="invite-emails-submit"]').click()
+
+    cy.contains('Sent invite(s) to 1 email(s)!').should('be.visible')
+
+    cy.visit('/club/test-new-club/edit#member')
+    cy.contains('Invite Members').scrollIntoView()
+    cy.get('[data-testid="invite-emails-input"]').type(
+        'bfranklin@seas.upenn.edu'
+    )
+
+    cy.get('[data-testid="invite-emails-submit"]').click()
+
+    cy.contains('Sent invite(s) to 1 email(s)!').should('be.visible')
+
+  })
+
+  it('Visits invitation page', () => {
+    cy.request('GET', '/api/test/lastemail').then((response) => {
+      cy.visit(`/invite/${response.body['code']}/${response.body['id']}/${response.body['token']}`)
+      cy.contains('Invitation for test new club')
+    })
+  })
+
+  it('Accepts invitation using incorrect login credentials', () => {
+    cy.contains('Accept Invitation').click()
+    cy.contains('This invitation was meant for "bfranklin", but you are logged in as "test"!')
+    cy.logout()
+  })
+
+  it('Accepts invitation as public using incorrect and correct token with correct login credentials', () => {
+    cy.login('bfranklin', 'test')
+
+    cy.request('GET', '/api/test/lastemail').then((response) => {
+      // Wrong Token leads to error
+      cy.visit(`/invite/${response.body['code']}/${response.body['id']}/WRONGTOKEN`)
+
+      cy.contains('Accept Invitation').click()
+      cy.contains('Missing or invalid token in request!')
+
+      // Correct Token leads to success
+      cy.visit(`/invite/${response.body['code']}/${response.body['id']}/${response.body['token']}`)
+
+      cy.contains('Accept Invitation').click()
+
+      // Redirect to club page
+      cy.contains('test new club needs to be re-registered for the 2020-2021 academic year').should('be.visible')
+      cy.contains('bfranklin@seas.upenn.edu')
+      
+      // Accessing invitation link after accepting it leads to 404 
+      cy.visit(`/invite/${response.body['code']}/${response.body['id']}/${response.body['token']}`)
+      cy.contains('404 Not Found')
+
+      cy.logout()
+    })
+  })
+})

--- a/frontend/cypress/integration/invite_spec.js
+++ b/frontend/cypress/integration/invite_spec.js
@@ -1,47 +1,13 @@
 describe('Invitation tests', () => {
   before(() => {
-    cy.login() 
-
-    const fields = [
-      { label: 'Name', value: 'test new club', pressEnter: false },
-      { label: 'Size', value: '< 20', pressEnter: true },
-      {
-        label: 'Is an application required to join your organization?',
-        value: 'No Application Required',
-        pressEnter: true,
-      },
-    ]
-    
-    // Create club
-    cy.visit('/create')
-
-    fields.forEach(({ label, value, pressEnter }) => {
-      const input = cy.contains('.field', label).find('input')
-      input.focus().clear().type(value)
-
-      if (pressEnter) {
-        input.type('{enter}')
-      }
-
-      input.blur()
-    })
-
-    cy.contains('Select tags relevant to your club!').click()
-    cy.contains('Undergraduate').click()
-
-    cy.contains('Submit').click()
-
-    // wait for club to be created, should be redirected to renewal page
-    cy.contains('Renew Club').should('be.visible') 
+    cy.login('bfranklin', 'test') 
   })
 
   after(() => {
-    cy.login()
-    cy.visit('/club/test-new-club/edit#settings')
-    cy.contains('Delete Club')
-    cy.contains('.button', 'Delete Club').click()
-    cy.contains('404 Not Found')
-    
+    // Remove James Madison from the club
+    cy.visit('/settings')
+    cy.get('table > tbody > tr').last().contains('Leave').click()
+     
     cy.logout()
   })
 
@@ -50,43 +16,39 @@ describe('Invitation tests', () => {
   })
 
   it('Invites User', () => {
-    cy.visit('/club/test-new-club/edit#member')
+    cy.visit('/club/pppjo/edit#member')
     cy.contains('Invite Members').scrollIntoView()
     cy.get('[data-testid="invite-emails-input"]').type(
-        'bfranklin@seas.upenn.edu'
+        'jmadison@seas.upenn.edu'
     )
 
     cy.get('[data-testid="invite-emails-submit"]').click()
 
     cy.contains('Sent invite(s) to 1 email(s)!').should('be.visible')
-
-    cy.visit('/club/test-new-club/edit#member')
-    cy.contains('Invite Members').scrollIntoView()
-    cy.get('[data-testid="invite-emails-input"]').type(
-        'bfranklin@seas.upenn.edu'
-    )
-
-    cy.get('[data-testid="invite-emails-submit"]').click()
-
-    cy.contains('Sent invite(s) to 1 email(s)!').should('be.visible')
-
   })
 
   it('Visits invitation page', () => {
+    cy.logout()
+
+    cy.login('jmadison', 'test')
+
     cy.request('GET', '/api/test/lastemail').then((response) => {
+      cy.logout()
+      cy.login('bfranklin', 'test')
+
       cy.visit(`/invite/${response.body['code']}/${response.body['id']}/${response.body['token']}`)
-      cy.contains('Invitation for test new club')
+      cy.contains('Invitation for Penn Pre-Professional Juggling Organization')
     })
   })
 
   it('Accepts invitation using incorrect login credentials', () => {
     cy.contains('Accept Invitation').click()
-    cy.contains('This invitation was meant for "bfranklin", but you are logged in as "test"!')
+    cy.contains('This invitation was meant for "jmadison", but you are logged in as "bfranklin"!')
     cy.logout()
   })
 
-  it('Accepts invitation as public using incorrect and correct token with correct login credentials', () => {
-    cy.login('bfranklin', 'test')
+  it('Accepts invitation using incorrect and correct token with correct login credentials', () => {
+    cy.login('jmadison', 'test')
 
     cy.request('GET', '/api/test/lastemail').then((response) => {
       // Wrong Token leads to error
@@ -101,14 +63,12 @@ describe('Invitation tests', () => {
       cy.contains('Accept Invitation').click()
 
       // Redirect to club page
-      cy.contains('test new club needs to be re-registered for the 2020-2021 academic year').should('be.visible')
-      cy.contains('bfranklin@seas.upenn.edu')
+      cy.contains('has been approved by Unknown').should('be.visible')
+      cy.contains('jmadison@seas.upenn.edu')
       
       // Accessing invitation link after accepting it leads to 404 
       cy.visit(`/invite/${response.body['code']}/${response.body['id']}/${response.body['token']}`)
       cy.contains('404 Not Found')
-
-      cy.logout()
     })
   })
 })

--- a/frontend/cypress/integration/invite_spec.js
+++ b/frontend/cypress/integration/invite_spec.js
@@ -1,15 +1,29 @@
 describe('Invitation tests', () => {
   before(() => {
     cy.login('bfranklin', 'test') 
+
     cy.visit('/api/admin/auth/user')  
+
+    // Promote James Madision as a staff
+    cy.contains('jmadison').click()
+    cy.get('input[id="id_is_staff"]').check()
+    cy.get('input[id="id_is_superuser"]').check()
+    cy.contains('Save').click({ force: true })
   })
 
 
   after(() => {
-    // Remove James Madison from the club
+    // Remove James Madison (self) from the club
     cy.visit('/settings')
     cy.get('table > tbody > tr').last().contains('Leave').click()
      
+    // Demote James Madison (self) from staff
+    cy.visit('/api/admin/auth/user')  
+    cy.contains('jmadison').click()
+    cy.get('input[id="id_is_staff"]').uncheck()
+    cy.get('input[id="id_is_superuser"]').uncheck()
+    cy.contains('Save').click({ force: true })
+
     cy.logout()
   })
 
@@ -65,8 +79,7 @@ describe('Invitation tests', () => {
       cy.contains('Accept Invitation').click()
 
       // Redirect to club page
-      cy.contains('has been approved by Unknown').should('be.visible')
-      cy.contains('jmadison@seas.upenn.edu')
+      cy.title().should('eq', 'Penn Pre-Professional Juggling Organization')
       
       // Accessing invitation link after accepting it leads to 404 
       cy.visit(`/invite/${response.body['code']}/${response.body['id']}/${response.body['token']}`)


### PR DESCRIPTION
- Quick bug fix of public/private status. The club page was displaying user's who were private
[Before VIDEO](https://youtu.be/-Sm2TDi8_0A)
[After fix VIDEO](https://youtu.be/zTaOPYThleI)

- Added endpoint /test/lastemail that displays the club code, invite id, token only in development

- Added cypress testing for club invitation
[VIDEO](https://youtu.be/JZHTJJ4Pa-0)
