### PR TITLE
Fair Event Security

### DIFF
--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -81,6 +81,23 @@ class EventPermission(permissions.BasePermission):
         else:
             return True
 
+    def has_object_permission(self, request, view, obj):
+        """
+        Do not allow transitions from and to club fair event.
+        """
+        FAIR_TYPE = 4
+        old_type = obj.type
+        new_type = request.data.get("type", old_type)
+
+        if view.action in ["update", "partial_update"]:
+            if old_type == FAIR_TYPE and new_type != FAIR_TYPE:
+                return False
+
+            if old_type != FAIR_TYPE and new_type == FAIR_TYPE:
+                return False
+
+        return True
+
 
 class ClubItemPermission(permissions.BasePermission):
     """

--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -85,15 +85,19 @@ class EventPermission(permissions.BasePermission):
         """
         Do not allow transitions from and to club fair event.
         """
-        FAIR_TYPE = 4
+        # prevent circular import
+        from clubs.models import Event
+
+        FAIR_TYPE = Event.FAIR
+
         old_type = obj.type
         new_type = request.data.get("type", old_type)
 
         if view.action in ["update", "partial_update"]:
-            if old_type == FAIR_TYPE and new_type != FAIR_TYPE:
+            if old_type == FAIR_TYPE and not new_type == FAIR_TYPE:
                 return False
 
-            if old_type != FAIR_TYPE and new_type == FAIR_TYPE:
+            if not old_type == FAIR_TYPE and new_type == FAIR_TYPE:
                 return False
 
         return True

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -774,7 +774,10 @@ class EventViewSet(viewsets.ModelViewSet):
         now = timezone.now()
         return Response(
             EventSerializer(
-                self.get_queryset().filter(start_time__lte=now, end_time__gte=now), many=True
+                self.get_queryset()
+                .filter(start_time__lte=now, end_time__gte=now)
+                .filter(type=Event.FAIR),
+                many=True,
             ).data
         )
 
@@ -785,7 +788,9 @@ class EventViewSet(viewsets.ModelViewSet):
         """
         now = timezone.now()
         return Response(
-            EventSerializer(self.get_queryset().filter(start_time__gte=now), many=True).data
+            EventSerializer(
+                self.get_queryset().filter(start_time__gte=now).filter(type=Event.FAIR), many=True
+            ).data
         )
 
     @action(detail=False, methods=["get"])
@@ -821,7 +826,7 @@ class EventViewSet(viewsets.ModelViewSet):
         if self.action in ["list"]:
             qs = qs.filter(end_time__gte=now)
 
-        return qs.select_related("club", "creator",).filter(type=Event.FAIR).order_by("start_time")
+        return qs.select_related("club", "creator",).order_by("start_time")
 
 
 class TestimonialViewSet(viewsets.ModelViewSet):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -821,7 +821,7 @@ class EventViewSet(viewsets.ModelViewSet):
         if self.action in ["list"]:
             qs = qs.filter(end_time__gte=now)
 
-        return qs.select_related("club", "creator",)
+        return qs.select_related("club", "creator",).filter(type=Event.FAIR).order_by("start_time")
 
 
 class TestimonialViewSet(viewsets.ModelViewSet):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -798,6 +798,20 @@ class EventViewSet(viewsets.ModelViewSet):
             EventSerializer(self.get_queryset().filter(end_time__lt=now), many=True).data
         )
 
+    def create(self, request, *args, **kwargs):
+        """
+        Do not let non-superusers create events with the FAIR type through the API.
+        """
+        type = request.data.get("type", 0)
+        if type == Event.FAIR and not self.request.user.is_superuser:
+            raise DRFValidationError(
+                detail="Approved activities fair events have already been created. "
+                "See above for events to edit, and "
+                "please email contact@pennclubs.com if this is en error."
+            )
+
+        return super().create(request, *args, **kwargs)
+
     def get_queryset(self):
         qs = Event.objects.all()
         if self.kwargs.get("club_code") is not None:

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -428,6 +428,41 @@ class ClubTestCase(TestCase):
         self.assertEquals(1, len(resp.data), resp.data)
         self.assertEquals(e2.id, resp.data[0]["id"], resp.data)
 
+    def test_event_update_fair(self):
+        Membership.objects.create(person=self.user1, club=self.club1, role=Membership.ROLE_OWNER)
+
+        self.client.login(username=self.user1.username, password="test")
+        resp = self.client.patch(
+            reverse("club-events-detail", args=(self.club1.code, self.event1.pk)),
+            {"type": Event.FAIR},
+            content_type="application/json",
+        )
+        self.assertFalse(200 <= resp.status_code < 300, resp.data)
+
+        e2 = Event.objects.create(
+            code="test-event-2",
+            club=self.club1,
+            name="Past Test Event 2",
+            start_time=timezone.now() - timezone.timedelta(days=3),
+            end_time=timezone.now() + timezone.timedelta(days=2),
+            type=Event.FAIR,
+        )
+
+        resp = self.client.patch(
+            reverse("club-events-detail", args=(self.club1.code, e2.pk)),
+            {"type": Event.RECRUITMENT},
+            content_type="application/json",
+        )
+        self.assertFalse(200 <= resp.status_code < 300, resp.data)
+
+        # test can change other properties
+        resp = self.client.patch(
+            reverse("club-events-detail", args=(self.club1.code, e2.pk)),
+            {"name": "New name for event"},
+            content_type="application/json",
+        )
+        self.assertTrue(200 <= resp.status_code < 300, resp.data)
+
     def test_event_create_delete(self):
         """
         Test creating and deleting a club event.

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -389,6 +389,7 @@ class ClubTestCase(TestCase):
             name="Past Test Event 2",
             start_time=timezone.now() - timezone.timedelta(days=3),
             end_time=timezone.now() - timezone.timedelta(days=2),
+            type=Event.FAIR,
         )
         e3 = Event.objects.create(
             code="test-event-3",
@@ -396,7 +397,10 @@ class ClubTestCase(TestCase):
             name="Present Test Event 3",
             start_time=timezone.now() - timezone.timedelta(days=3),
             end_time=timezone.now() + timezone.timedelta(days=2),
+            type=Event.FAIR,
         )
+        self.event1.type = Event.FAIR
+        self.event1.save()
 
         # list events without a club to namespace.
         resp = self.client.get(reverse("events-list"), content_type="application/json",)

--- a/frontend/components/Form.js
+++ b/frontend/components/Form.js
@@ -956,6 +956,7 @@ export class ModelForm extends Component {
               />
             </>
           )}
+
           {currentlyEditing !== null && (
             <span
               onClick={() => {
@@ -982,6 +983,11 @@ export class ModelForm extends Component {
             </span>
           )}
           <ModelStatus status={currentObject._status} />
+          {currentObject._error_message && (
+            <div style={{ color: 'red', marginTop: '1rem' }}>
+              <Icon name="alert-circle" /> {currentObject._error_message}
+            </div>
+          )}
         </>
       )
     }


### PR DESCRIPTION
- Can't create an event with the activity fair type
- Can't change an existing event from or to that type
- Form.js will show DRF validation errors now
- Test to make sure I dont break things
- only show fair events on the /events page (TODO: remove this after fair)