### PR TITLE
Add backend for searching through events

### DIFF
--- a/backend/clubs/filters.py
+++ b/backend/clubs/filters.py
@@ -1,0 +1,96 @@
+import random
+from collections import OrderedDict
+from urllib.parse import quote
+
+from rest_framework import filters
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+DEFAULT_PAGE_SIZE = 15
+DEFAULT_SEED = 1234
+
+
+class RandomPageNumberPagination(PageNumberPagination):
+    """
+    Custom pagination that supports randomly sorting objects with pagination.
+    Must be used with the associated ordering filter.
+    """
+
+    page_size = DEFAULT_PAGE_SIZE
+    page_size_query_param = "page_size"
+
+    def paginate_queryset(self, queryset, request, view=None):
+        if "random" in request.query_params.get("ordering", "").split(","):
+            rng = random.Random(request.GET.get("seed", DEFAULT_SEED))
+            results = list(queryset)
+            rng.shuffle(results)
+
+            self._random_count = getattr(request, "_original_item_count", None)
+            if self._random_count is None:
+                self._random_count = queryset.model.objects.count()
+            else:
+                del request._original_item_count
+
+            page = int(request.GET.get("page", 1))
+            page_size = int(request.GET.get("page_size", DEFAULT_PAGE_SIZE))
+
+            if (page - 1) * page_size >= self._random_count:
+                self._random_next_page = None
+            else:
+                new_params = request.GET.dict()
+                new_params["page"] = str(page + 1)
+                self._random_next_page = "{}?{}".format(
+                    request.build_absolute_uri(request.path),
+                    "&".join(["{}={}".format(k, quote(v)) for k, v in new_params.items()]),
+                )
+            return results
+
+        if self.page_query_param not in request.query_params:
+            return None
+
+        return super().paginate_queryset(queryset, request, view)
+
+    def get_paginated_response(self, data):
+        if hasattr(self, "_random_next_page"):
+            return Response(
+                OrderedDict(
+                    [
+                        ("count", self._random_count),
+                        ("next", self._random_next_page),
+                        ("results", data),
+                    ]
+                )
+            )
+
+        return super().get_paginated_response(data)
+
+
+class RandomOrderingFilter(filters.OrderingFilter):
+    """
+    Custom ordering filter that supports random pagination.
+    Must be used with the associated pagination class.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        new_queryset = super().filter_queryset(request, queryset, view)
+        ordering = request.GET.get("ordering", "").split(",")
+
+        # handle random ordering
+        if "random" in ordering:
+            page = int(request.GET.get("page", 1)) - 1
+            page_size = int(request.GET.get("page_size", DEFAULT_PAGE_SIZE))
+            rng = random.Random(request.GET.get("seed", DEFAULT_SEED))
+
+            all_ids = list(new_queryset.order_by("id").values_list("id", flat=True))
+            rng.shuffle(all_ids)
+
+            start_index = page * page_size
+            end_index = (page + 1) * page_size
+            page_ids = all_ids[start_index:end_index]
+
+            request._original_item_count = new_queryset.count()
+
+            return new_queryset.filter(id__in=page_ids)
+
+        return new_queryset

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -477,8 +477,17 @@ class ClubListSerializer(serializers.ModelSerializer):
     def get_short_description(self, obj):
         if obj.subtitle:
             return obj.subtitle
-        return re.sub(
-            r"<[^>]+>", "", "".join(re.split(r"(\.|\n|!)", obj.description.lstrip())[:2]).strip()
+
+        # return first sentence of description without html tags
+        return (
+            re.sub(r"<[^>]+>", "", "".join(re.split(r"(\.|\n|!)", obj.description.lstrip())[:2]))
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&ndash;", "-")
+            .replace("&mdash;", "-")
+            .replace("&nbsp;", " ")
+            .strip()
         )
 
     def get_is_favorite(self, obj):

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -462,10 +462,6 @@ class ClubListSerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField("get_image_url")
     favorite_count = serializers.IntegerField(read_only=True)
 
-    target_schools = SchoolSerializer(many=True, required=False)
-    target_majors = MajorSerializer(many=True, required=False)
-    target_years = YearSerializer(many=True, required=False)
-
     is_favorite = serializers.SerializerMethodField("get_is_favorite")
     is_subscribe = serializers.SerializerMethodField("get_is_subscribe")
     is_member = serializers.SerializerMethodField("get_is_member")
@@ -562,9 +558,6 @@ class ClubListSerializer(serializers.ModelSerializer):
             "image_url",
             "favorite_count",
             "active",
-            "target_schools",
-            "target_majors",
-            "target_years",
             "is_favorite",
             "is_subscribe",
             "is_member",
@@ -603,6 +596,10 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
     approved_comment = serializers.CharField(required=False, allow_blank=True)
     approved_by = serializers.SerializerMethodField("get_approved_by")
     description = serializers.CharField()
+
+    target_schools = SchoolSerializer(many=True, required=False)
+    target_majors = MajorSerializer(many=True, required=False)
+    target_years = YearSerializer(many=True, required=False)
 
     is_ghost = serializers.SerializerMethodField("get_is_ghost")
 
@@ -863,6 +860,9 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
             "linkedin",
             "listserv",
             "members",
+            "target_majors",
+            "target_schools",
+            "target_years",
             "testimonials",
             "twitter",
             "website",

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -467,7 +467,7 @@ class ClubListSerializer(serializers.ModelSerializer):
     is_member = serializers.SerializerMethodField("get_is_member")
 
     email = serializers.SerializerMethodField("get_email")
-    description = serializers.SerializerMethodField("get_short_description")
+    subtitle = serializers.SerializerMethodField("get_short_description")
 
     def get_email(self, obj):
         if obj.email_public:
@@ -476,8 +476,10 @@ class ClubListSerializer(serializers.ModelSerializer):
 
     def get_short_description(self, obj):
         if obj.subtitle:
-            return None
-        return "".join(re.split(r"(\.|\n|!)", obj.description.lstrip())[:2]).strip()
+            return obj.subtitle
+        return re.sub(
+            r"<[^>]+>", "", "".join(re.split(r"(\.|\n|!)", obj.description.lstrip())[:2]).strip()
+        )
 
     def get_is_favorite(self, obj):
         user = self.context["request"].user
@@ -544,23 +546,22 @@ class ClubListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Club
         fields = [
-            "name",
-            "code",
-            "approved",
-            "description",
-            "founded",
-            "size",
-            "email",
-            "tags",
-            "subtitle",
-            "application_required",
             "accepting_members",
-            "image_url",
-            "favorite_count",
             "active",
+            "application_required",
+            "approved",
+            "code",
+            "email",
+            "favorite_count",
+            "founded",
+            "image_url",
             "is_favorite",
-            "is_subscribe",
             "is_member",
+            "is_subscribe",
+            "name",
+            "size",
+            "subtitle",
+            "tags",
         ]
         extra_kwargs = {
             "name": {
@@ -570,8 +571,8 @@ class ClubListSerializer(serializers.ModelSerializer):
             "code": {
                 "required": False,
                 "validators": [validators.UniqueValidator(queryset=Club.objects.all())],
-                "help_text": "An alphanumeric string shown in the URL"
-                + "and used to identify this club.",
+                "help_text": "An alphanumeric string shown in the URL "
+                "and used to identify this club.",
             },
             "description": {
                 "help_text": "A long description for the club. Certain HTML tags are allowed."
@@ -579,8 +580,8 @@ class ClubListSerializer(serializers.ModelSerializer):
             "email": {"help_text": "The primary contact email for the club."},
             "subtitle": {
                 "required": False,
-                "help_text": "The text shown to the user in a preview card."
-                + "Short description of the club.",
+                "help_text": "The text shown to the user in a preview card. "
+                "Short description of the club.",
             },
         }
 
@@ -595,7 +596,6 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
     fair = serializers.BooleanField(default=False)
     approved_comment = serializers.CharField(required=False, allow_blank=True)
     approved_by = serializers.SerializerMethodField("get_approved_by")
-    description = serializers.CharField()
 
     target_schools = SchoolSerializer(many=True, required=False)
     target_majors = MajorSerializer(many=True, required=False)
@@ -848,6 +848,7 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
             "approved_by",
             "approved_comment",
             "badges",
+            "description",
             "events",
             "facebook",
             "fair",

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1,9 +1,6 @@
 import json
 import os
-import random
 import re
-from collections import OrderedDict
-from urllib.parse import quote
 
 import qrcode
 from django.conf import settings
@@ -21,11 +18,11 @@ from rest_framework import filters, generics, parsers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError as DRFValidationError
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from clubs.filters import RandomOrderingFilter, RandomPageNumberPagination
 from clubs.mixins import XLSXFormatterMixin
 from clubs.models import (
     Asset,
@@ -89,10 +86,6 @@ from clubs.serializers import (
     YearSerializer,
 )
 from clubs.utils import html_to_text
-
-
-DEFAULT_PAGE_SIZE = 15
-DEFAULT_SEED = 1234
 
 
 def file_upload_endpoint_helper(request, code):
@@ -187,60 +180,6 @@ class ReportViewSet(viewsets.ModelViewSet):
             return Report.objects.none()
 
         return Report.objects.filter(Q(creator=self.request.user) | Q(public=True))
-
-
-class ClubPagination(PageNumberPagination):
-    """
-    Custom pagination for club list view.
-    """
-
-    page_size = DEFAULT_PAGE_SIZE
-    page_size_query_param = "page_size"
-
-    def paginate_queryset(self, queryset, request, view=None):
-        if "random" in request.query_params.get("ordering", "").split(","):
-            rng = random.Random(request.GET.get("seed", DEFAULT_SEED))
-            results = list(queryset)
-            rng.shuffle(results)
-
-            self._random_count = getattr(request, "_original_clubs_count", None)
-            if self._random_count is None:
-                self._random_count = Club.objects.count()
-            else:
-                del request._original_clubs_count
-
-            page = int(request.GET.get("page", 1))
-            page_size = int(request.GET.get("page_size", DEFAULT_PAGE_SIZE))
-
-            if (page - 1) * page_size >= self._random_count:
-                self._random_next_page = None
-            else:
-                new_params = request.GET.dict()
-                new_params["page"] = str(page + 1)
-                self._random_next_page = "{}?{}".format(
-                    request.build_absolute_uri(request.path),
-                    "&".join(["{}={}".format(k, quote(v)) for k, v in new_params.items()]),
-                )
-            return results
-
-        if self.page_query_param not in request.query_params:
-            return None
-
-        return super().paginate_queryset(queryset, request, view)
-
-    def get_paginated_response(self, data):
-        if hasattr(self, "_random_next_page"):
-            return Response(
-                OrderedDict(
-                    [
-                        ("count", self._random_count),
-                        ("next", self._random_next_page),
-                        ("results", data),
-                    ]
-                )
-            )
-
-        return super().get_paginated_response(data)
 
 
 class ClubsSearchFilter(filters.BaseFilterBackend):
@@ -357,7 +296,7 @@ class ClubsSearchFilter(filters.BaseFilterBackend):
         return queryset
 
 
-class ClubsOrderingFilter(filters.OrderingFilter):
+class ClubsOrderingFilter(RandomOrderingFilter):
     """
     Custom ordering filter for club objects.
     """
@@ -382,23 +321,6 @@ class ClubsOrderingFilter(filters.OrderingFilter):
     def filter_queryset(self, request, queryset, view):
         new_queryset = super().filter_queryset(request, queryset, view)
         ordering = request.GET.get("ordering", "").split(",")
-
-        # handle random ordering
-        if "random" in ordering:
-            page = int(request.GET.get("page", 1)) - 1
-            page_size = int(request.GET.get("page_size", DEFAULT_PAGE_SIZE))
-            rng = random.Random(request.GET.get("seed", DEFAULT_SEED))
-
-            all_ids = list(new_queryset.order_by("id").values_list("id", flat=True))
-            rng.shuffle(all_ids)
-
-            start_index = page * page_size
-            end_index = (page + 1) * page_size
-            page_ids = all_ids[start_index:end_index]
-
-            request._original_clubs_count = new_queryset.count()
-
-            return new_queryset.filter(id__in=page_ids)
 
         if "featured" in ordering:
             return queryset.order_by("-rank")
@@ -453,7 +375,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
     lookup_field = "code"
     http_method_names = ["get", "post", "put", "patch", "delete"]
-    pagination_class = ClubPagination
+    pagination_class = RandomPageNumberPagination
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -13,6 +13,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from clubs.filters import DEFAULT_PAGE_SIZE
 from clubs.models import (
     Badge,
     Club,
@@ -25,7 +26,6 @@ from clubs.models import (
     Tag,
     Testimonial,
 )
-from clubs.views import DEFAULT_PAGE_SIZE
 
 
 class SearchTestCase(TestCase):

--- a/frontend/components/ClubCard.tsx
+++ b/frontend/components/ClubCard.tsx
@@ -18,7 +18,6 @@ import {
 } from '../constants/measurements'
 import { CLUB_ROUTE } from '../constants/routes'
 import { Club } from '../types'
-import { stripTags } from '../utils'
 import ClubDetails from './ClubDetails'
 import { InactiveTag, TagGroup } from './common'
 
@@ -95,11 +94,9 @@ type ClubCardProps = {
 }
 
 const ClubCard = ({ club }: ClubCardProps): ReactElement => {
-  const { name, active, approved, description, subtitle, tags, code } = club
+  const { name, active, approved, subtitle, tags, code } = club
   const img = club.image_url
-  const textDescription = shorten(
-    subtitle || stripTags(description) || 'This club has no description.',
-  )
+  const textDescription = shorten(subtitle || 'This club has no description.')
 
   return (
     <CardWrapper className="column is-half-desktop">

--- a/frontend/components/ClubPage/Description.tsx
+++ b/frontend/components/ClubPage/Description.tsx
@@ -23,7 +23,6 @@ const Description = ({ club }: Props): ReactElement => (
       <StrongText>Description</StrongText>
       <div
         className="content"
-        style={{ whiteSpace: 'pre-wrap' }}
         dangerouslySetInnerHTML={{
           __html: club.description || EMPTY_DESCRIPTION,
         }}

--- a/frontend/components/ClubPage/Events.tsx
+++ b/frontend/components/ClubPage/Events.tsx
@@ -71,7 +71,7 @@ const Event = ({ entry }: { entry: ClubEvent }): ReactElement => {
         </div>
       </Wrapper>
       {show && (
-        <Modal show={show} closeModal={hideModal}>
+        <Modal show={show} closeModal={hideModal} marginBottom={false}>
           <EventModal
             event={entry}
             isHappening={false}

--- a/frontend/components/EventPage/CoverPhoto.tsx
+++ b/frontend/components/EventPage/CoverPhoto.tsx
@@ -15,6 +15,7 @@ const Placeholder = styled.div`
   background-color: ${CLUBS_NAVY};
   height: 9.5rem;
   color: white;
+  text-align: center;
 
   ${Card} & {
     margin: -0.5rem -0.5rem 0.5rem;
@@ -31,6 +32,7 @@ const CoverPhotoImage = styled.div<{ image: string | null }>`
   padding-bottom: ${SIXTEEN_BY_NINE};
   background-image: url(${(props) => props.image});
   background-size: cover;
+  background-position: center;
   ${Card} & {
     margin: -0.5rem -0.5rem 0.5rem;
   }

--- a/frontend/cypress/integration/authed_spec.js
+++ b/frontend/cypress/integration/authed_spec.js
@@ -102,6 +102,10 @@ describe('Authenticated user tests', () => {
     cy.contains('Select tags relevant to your club!').click()
     cy.contains('Undergraduate').click()
 
+    // set description
+    cy.contains('Type your club description here!').click({ force: true })
+    cy.focused().type('This is an example club description!').blur()
+
     // submit form
     cy.contains('Submit').click()
 


### PR DESCRIPTION
- Add backend for searching through events through `club__` selectors.
- Separate out random ordering and pagination system into separate file.
- List endpoint now only returns subtitle if it exists, or short description if it does not. This is all that is used by the frontend.
- Remove `target_*` fields from list view, no longer being used by the frontend.
- Style fixes for events cards.