### PR TITLE
jump to Q&A from sidebar

### DIFF
--- a/frontend/pages/club/[club]/index.tsx
+++ b/frontend/pages/club/[club]/index.tsx
@@ -1,5 +1,5 @@
 import { NextPageContext } from 'next'
-import { ReactElement, useState } from 'react'
+import { ReactElement, useRef, useState } from 'react'
 import Linkify from 'react-linkify'
 import s from 'styled-components'
 
@@ -63,12 +63,23 @@ type ClubPageProps = {
   questions: QuestionAnswer[]
 }
 
+const QAButton = s.button.attrs({ className: 'button is-primary' })`
+  font-size: 0.8em;
+  margin-bottom: 1rem;
+  padding: 1.5rem;
+  width: 100%;
+  white-space: pre-wrap;
+`
+
 const ClubPage = ({
   club: initialClub,
   questions,
   userInfo,
 }: ClubPageProps): ReactElement => {
   const [club, setClub] = useState<Club>(initialClub)
+  const scrollToRef = (ref) => window.scrollTo(0, ref.current.offsetTop - 100)
+  const questionsScrollRef = useRef(null)
+  const scrollToQuestions = () => scrollToRef(questionsScrollRef)
 
   const updateRequests = async (code: string): Promise<void> => {
     const newClub = { ...club }
@@ -171,10 +182,10 @@ const ClubPage = ({
           <StyledCard bordered>
             <Description club={club} />
           </StyledCard>
+          <StrongText ref={questionsScrollRef}>FAQ</StrongText>
+          <QuestionList club={club} questions={questions} />
           <StrongText>Members</StrongText>
           <MemberList club={club} />
-          <StrongText>FAQ</StrongText>
-          <QuestionList club={club} questions={questions} />
         </div>
         <div className="column is-one-third">
           <DesktopActions
@@ -182,6 +193,13 @@ const ClubPage = ({
             userInfo={userInfo}
             updateRequests={updateRequests}
           />
+          <QAButton onClick={scrollToQuestions}>
+            {questions.length > 0
+              ? `Click here to see the ${questions.length} question${
+                  questions.length === 1 ? '' : 's'
+                } asked about this club so far!`
+              : 'Be the first to ask a question about this club!'}
+          </QAButton>
           <StyledCard bordered>
             <StrongText>Basic Info</StrongText>
             <InfoBox club={club} />


### PR DESCRIPTION
[ch2302]

This PR adds a button to club pages to allow visitors to jump directly to the Q&A (which can be buried pretty far below the fold). It also puts Q&A above members, but let me know if we want to reverse that.

Wondering about what the copy should be here... Both of the options (no questions and questions having been asked) are kind of wordy. Open to suggestions on this one

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/436045/91513908-78b2df80-e8b3-11ea-9431-6d8bb8173e91.png">
