### PR TITLE
Try a fix for modal mixup

### DIFF
--- a/frontend/components/EventPage/EventCard.tsx
+++ b/frontend/components/EventPage/EventCard.tsx
@@ -63,7 +63,7 @@ const EventCard = (props: {
         </Card>
       </EventCardContainer>
       <Modal show={modalVisible} closeModal={hideModal} width="45%">
-        <EventModal {...props} />
+        <EventModal event={event} isHappening={isHappening} />
       </Modal>
     </>
   )


### PR DESCRIPTION
There was a bug I saw in prod last night where the modal was containing some props from the correct event and other props (description and cover photo) from a completely different event on the page. @ezwang suggested this might be `key` related, so this is an attempt at fixing the bug.

I'm thinking the issue might have been that `key` was a prop that was passed down to the modal component along with the other props, and that is messing up the render props for the modal. This PR explicitly passes in the `event` and `isHappening` flag to try and fix the bug.