### PR TITLE
Enable events banner

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -234,7 +234,7 @@ const Splash = (props: SplashProps): ReactElement => {
                 </ClearAllLink>
               </div>
             )}
-            {false && props.liveEventCount > 0 && (
+            {props.liveEventCount > 0 && (
               <LiveEventsDialog liveEventCount={props.liveEventCount} />
             )}
             <ListRenewalDialog />


### PR DESCRIPTION
Just so we don't forget to do this on Tuesday :)

Banner won't show up until events start happening on Tuesday, since the `/live` endpoint is currently filtered to only include events for the club fair