### PR TITLE
Add caching to events pages

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -745,6 +745,48 @@ class EventViewSet(viewsets.ModelViewSet):
         return upload_endpoint_helper(request, Event, "image", pk=event.pk)
 
     @action(detail=False, methods=["get"])
+    def fair(self, request, *args, **kwargs):
+        """
+        Get the minimal information required for a fair directory listing.
+        """
+        # cache the response for this endpoint with short timeout
+        key = f"events:fair:directory:{request.user.is_authenticated}"
+        cached = cache.get(key)
+        if cached:
+            return Response(cached)
+
+        events = Event.objects.filter(type=Event.FAIR, club__badges__purpose="fair").values_list(
+            "start_time", "end_time", "club__name", "club__code", "club__badges__label"
+        )
+        output = {}
+        for event in events:
+            # group by start date
+            ts = int(event[0].replace(second=0, microsecond=0).timestamp())
+            if ts not in output:
+                output[ts] = {
+                    "start_time": event[0],
+                    "end_time": event[1],
+                    "events": {},
+                }
+
+            # group by category
+            category = event[4]
+            if category not in output[ts]["events"]:
+                output[ts]["events"][category] = {
+                    "category": category,
+                    "events": [],
+                }
+
+            output[ts]["events"][category]["events"].append({"name": event[2], "code": event[3]})
+        for item in output.values():
+            item["events"] = list(sorted(item["events"].values(), key=lambda cat: cat["category"]))
+
+        output = list(sorted(output.values(), key=lambda cat: cat["start_time"]))
+        cache.set(key, output, 60 * 5)
+
+        return Response(output)
+
+    @action(detail=False, methods=["get"])
     def owned(self, request, *args, **kwargs):
         """
         Return all events that the user has officer permissions over.

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -811,7 +811,8 @@ class EventViewSet(viewsets.ModelViewSet):
         This endpoint is cached for 5 min for a no filter parameter call.
         """
         params = set(request.query_params.keys())
-        params.remove("format")
+        if "format" in params:
+            params.remove("format")
         should_cache = not params
 
         if should_cache:
@@ -839,7 +840,8 @@ class EventViewSet(viewsets.ModelViewSet):
         This endpoint is cached for 5 min for a no filter parameter call.
         """
         params = set(request.query_params.keys())
-        params.remove("format")
+        if "format" in params:
+            params.remove("format")
         should_cache = not params
 
         if should_cache:

--- a/frontend/pages/zoom.tsx
+++ b/frontend/pages/zoom.tsx
@@ -11,6 +11,7 @@ import {
   InfoPageTitle,
   Metadata,
 } from '../components/common'
+import AuthPrompt from '../components/common/AuthPrompt'
 import {
   CLUB_EDIT_ROUTE,
   CLUB_ROUTE,
@@ -25,6 +26,7 @@ import { ClubEvent, ClubEventType } from '../types'
 import { doApiRequest } from '../utils'
 
 type ZoomPageProps = {
+  authenticated: boolean | null
   events: ClubEvent[]
   userMeetings: ZoomMeeting[]
   zoomSettings: ZoomSettings
@@ -160,6 +162,7 @@ const loadEvents = (data?: any): Promise<ClubEvent[]> => {
 }
 
 const ZoomPage = ({
+  authenticated,
   events: initialEvents,
   zoomSettings: initialZoomSettings,
   userMeetings: initialUserMeetings,
@@ -182,6 +185,10 @@ const ZoomPage = ({
   useEffect(() => {
     setNextUrl(window.location.pathname)
   }, [])
+
+  if (authenticated === false) {
+    return <AuthPrompt />
+  }
 
   return (
     <Container background={SNOW}>


### PR DESCRIPTION
- Pages are starting to feel a little bit slow, add in some caching to make it better.
- Rewrite `/fair` page calculations to be on server side.
- Require authentication for `/zoom` page.