### PR TITLE
Add date parameter for fair page

### DIFF
--- a/backend/clubs/admin.py
+++ b/backend/clubs/admin.py
@@ -185,8 +185,12 @@ class ClubAdmin(simple_history.admin.SimpleHistoryAdmin):
 
 
 class EventAdmin(admin.ModelAdmin):
+    list_display = ("name", "club", "type", "start_time", "end_time")
     search_fields = ("name", "club__name")
     list_filter = ("start_time", "end_time")
+
+    def club(self, obj):
+        return obj.club.name
 
 
 class FavoriteAdmin(admin.ModelAdmin):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -957,6 +957,8 @@ class EventViewSet(viewsets.ModelViewSet):
         """
         # accept custom date for preview rendering
         date = request.query_params.get("date")
+        if date in {"null", "undefined"}:
+            date = None
         if date:
             date = parse(date)
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -952,17 +952,26 @@ class EventViewSet(viewsets.ModelViewSet):
     def fair(self, request, *args, **kwargs):
         """
         Get the minimal information required for a fair directory listing.
+        Groups by the start date of the event, and then the event category.
+        Each event's club must have an associated fair badge in order to be displayed.
         """
-        # cache the response for this endpoint with short timeout
-        key = f"events:fair:directory:{request.user.is_authenticated}"
-        cached = cache.get(key)
-        if cached:
-            return Response(cached)
+        # accept custom date for preview rendering
+        date = request.query_params.get("date")
+        if date:
+            date = parse(date)
 
-        now = timezone.now()
+        # cache the response for this endpoint with short timeout
+        if not date:
+            key = f"events:fair:directory:{request.user.is_authenticated}"
+            cached = cache.get(key)
+            if cached:
+                return Response(cached)
+
+        now = date or timezone.now()
         events = Event.objects.filter(
             type=Event.FAIR,
             club__badges__purpose="fair",
+            start_time__lte=now + datetime.timedelta(days=7),
             end_time__gte=now - datetime.timedelta(days=1),
         ).values_list("start_time", "end_time", "club__name", "club__code", "club__badges__label")
         output = {}
@@ -993,7 +1002,8 @@ class EventViewSet(viewsets.ModelViewSet):
                 )
 
         output = list(sorted(output.values(), key=lambda cat: cat["start_time"]))
-        cache.set(key, output, 60 * 5)
+        if not date:
+            cache.set(key, output, 60 * 5)
 
         return Response(output)
 

--- a/frontend/pages/fair.tsx
+++ b/frontend/pages/fair.tsx
@@ -207,7 +207,10 @@ FairPage.getInitialProps = async (ctx: NextPageContext) => {
     headers: req ? { cookie: req.headers.cookie } : undefined,
   }
 
-  const resp = await doApiRequest('/events/fair/?format=json', data)
+  const resp = await doApiRequest(
+    `/events/fair/?date=${ctx.query.date as string}&format=json`,
+    data,
+  )
   const json = await resp.json()
 
   return { events: json }


### PR DESCRIPTION
Add a date parameter for the fair page that simulates the fair page display on a certain date.

Will be used for recreating a screenshot of the SAC fair page.