### PR TITLE
Use real member counts

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -622,6 +622,7 @@ class ClubListSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True)
     image_url = serializers.SerializerMethodField("get_image_url")
     favorite_count = serializers.IntegerField(read_only=True)
+    membership_count = serializers.IntegerField(read_only=True)
 
     is_favorite = serializers.SerializerMethodField("get_is_favorite")
     is_subscribe = serializers.SerializerMethodField("get_is_subscribe")
@@ -744,6 +745,7 @@ class ClubListSerializer(serializers.ModelSerializer):
             "is_favorite",
             "is_member",
             "is_subscribe",
+            "membership_count",
             "name",
             "size",
             "subtitle",

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -427,7 +427,10 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
     queryset = (
         Club.objects.all()
-        .annotate(favorite_count=Count("favorite", distinct=True))
+        .annotate(
+            favorite_count=Count("favorite", distinct=True),
+            membership_count=Count("membership", distinct=True, filter=Q(active=True)),
+        )
         .prefetch_related(
             "tags",
             "badges",

--- a/frontend/components/ClubDetails.tsx
+++ b/frontend/components/ClubDetails.tsx
@@ -44,9 +44,7 @@ const Details = ({ club }: DetailsProps): ReactElement => {
         style={{ color: CLUBS_GREY, fontSize: '80%', opacity: 0.8, flex: 1 }}
       >
         <Icon name="user" alt="members" size="0.8rem" style={iconStyles} />
-        {membershipCount > 0
-          ? `${membershipCount}`
-          : getSizeDisplay(size, false)}
+        {getSizeDisplay(size, false)}
         &nbsp;
         {' • '}
         &nbsp;

--- a/frontend/components/ClubDetails.tsx
+++ b/frontend/components/ClubDetails.tsx
@@ -33,6 +33,7 @@ type DetailsProps = {
 const Details = ({ club }: DetailsProps): ReactElement => {
   const {
     size,
+    membership_count: membershipCount,
     application_required: applicationRequired,
     accepting_members: acceptingMembers,
   } = club
@@ -43,7 +44,9 @@ const Details = ({ club }: DetailsProps): ReactElement => {
         style={{ color: CLUBS_GREY, fontSize: '80%', opacity: 0.8, flex: 1 }}
       >
         <Icon name="user" alt="members" size="0.8rem" style={iconStyles} />
-        {getSizeDisplay(size, false)}
+        {membershipCount > 0
+          ? `${membershipCount}`
+          : getSizeDisplay(size, false)}
         &nbsp;
         {' • '}
         &nbsp;

--- a/frontend/components/ClubPage/InfoBox.tsx
+++ b/frontend/components/ClubPage/InfoBox.tsx
@@ -29,7 +29,10 @@ const InfoBox = (props: InfoBoxProps): ReactElement => {
     {
       icon: 'user',
       alt: 'members',
-      text: ' ' + getSizeDisplay(props.club.size),
+      text:
+        props.club.membership_count > 0
+          ? `${props.club.membership_count} Members`
+          : ' ' + getSizeDisplay(props.club.size),
     },
     {
       icon: props.club.accepting_members ? 'check-circle' : 'x-circle',

--- a/frontend/components/ClubPage/InfoBox.tsx
+++ b/frontend/components/ClubPage/InfoBox.tsx
@@ -29,10 +29,9 @@ const InfoBox = (props: InfoBoxProps): ReactElement => {
     {
       icon: 'user',
       alt: 'members',
-      text:
-        props.club.membership_count > 0
-          ? `${props.club.membership_count} Members`
-          : ' ' + getSizeDisplay(props.club.size),
+      text: `${props.club.membership_count} Registered (${getSizeDisplay(
+        props.club.size,
+      )})`,
     },
     {
       icon: props.club.accepting_members ? 'check-circle' : 'x-circle',

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -134,6 +134,7 @@ export interface Club {
   linkedin: string
   listserv: string
   members: [Membership]
+  membership_count: number
   name: string
   size: ClubSize
   subtitle: string


### PR DESCRIPTION
Use real member counts instead of relying on clubs to put their own approximate member counts.

May want to consider showing the old club size field while people switch over.