### PR TITLE
Resolved members n+1 slowdown issue

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -469,7 +469,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
                 "membership_set",
                 queryset=Membership.objects.order_by(
                     "role", "person__first_name", "person__last_name"
-                ),
+                ).prefetch_related("person__profile"),
             ),
         )
         .order_by("-favorite_count", "name")


### PR DESCRIPTION
Literally wrote like 20 characters, but look at the number of queries decrease!

Problem was that we were using fields from the `Profile` model (image, has_been_prompted, graduation_year, etc.) in the `MembershipSerializer` without prefetching that model.

<img width="215" alt="Screen Shot 2020-10-21 at 1 56 45 AM" src="https://user-images.githubusercontent.com/19808574/96679069-f853ac80-1340-11eb-9d40-2a3ceaa8e16f.png">
<img width="214" alt="Screen Shot 2020-10-21 at 1 57 42 AM" src="https://user-images.githubusercontent.com/19808574/96679070-f853ac80-1340-11eb-867b-38e1a8318bfa.png">

[ch2772]