### PR TITLE
Separate point of contact form

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -935,6 +935,22 @@ class YearViewSet(viewsets.ModelViewSet):
     queryset = Year.objects.all()
 
 
+class AdvisorSearchFilter(filters.BaseFilterBackend):
+    """
+    A DRF filter to implement custom filtering logic for advisor objects.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        public = request.GET.get("public")
+
+        if public is not None:
+            public = public.strip().lower()
+            if public in {"true", "false"}:
+                queryset = queryset.filter(public=public == "true")
+
+        return queryset
+
+
 class AdvisorViewSet(viewsets.ModelViewSet):
     """
     list:
@@ -958,6 +974,7 @@ class AdvisorViewSet(viewsets.ModelViewSet):
 
     serializer_class = AdvisorSerializer
     permission_classes = [ClubItemPermission | IsSuperuser]
+    filter_backends = [AdvisorSearchFilter]
     lookup_field = "id"
     http_method_names = ["get", "post", "put", "patch", "delete"]
 

--- a/frontend/components/ClubEditPage/AdvisorCard.tsx
+++ b/frontend/components/ClubEditPage/AdvisorCard.tsx
@@ -16,46 +16,68 @@ type Props = {
 }
 
 export default function AdvisorCard({ club, schools }: Props): ReactElement {
+  const fields = [
+    { name: 'name', type: 'text' },
+    { name: 'title', type: 'text' },
+    {
+      name: 'school',
+      type: 'multiselect',
+      placeholder:
+        'Select schools or departments that this point of contact belongs under',
+      choices: schools,
+      converter: (a) => ({ value: a.id, label: a.name }),
+      reverser: (a) => ({ id: a.value, name: a.label }),
+    },
+    { name: 'email', type: 'email' },
+    { name: 'phone', type: 'text' },
+    {
+      name: 'public',
+      type: 'checkbox',
+      label: 'Show contact information to the public?',
+    },
+  ]
+
   return (
-    <BaseCard title="Points of Contact">
-      <Text>
-        Provide points of contact for your organization. Public points of
-        contact will be shown to the public, while private points of contact
-        will be shown to only {SITE_NAME} administrators.
-        {SHOW_MEMBERS && (
-          <>
-            {' '}
-            Your {OBJECT_NAME_SINGULAR} members will show up on the{' '}
-            {OBJECT_NAME_SINGULAR} page, but only the name, title, and profile
-            picture will be shown. If you would like to provide more detailed
-            contact information, use the form below.
-          </>
-        )}
-      </Text>
-      <ModelForm
-        baseUrl={`/clubs/${club.code}/advisors/`}
-        initialData={club.advisor_set}
-        fields={[
-          { name: 'name', type: 'text' },
-          { name: 'title', type: 'text' },
-          {
-            name: 'school',
-            type: 'multiselect',
-            placeholder:
-              'Select schools or departments that this point of contact belongs under',
-            choices: schools,
-            converter: (a) => ({ value: a.id, label: a.name }),
-            reverser: (a) => ({ id: a.value, name: a.label }),
-          },
-          { name: 'email', type: 'email' },
-          { name: 'phone', type: 'text' },
-          {
-            name: 'public',
-            type: 'checkbox',
-            label: 'Show contact information to the public?',
-          },
-        ]}
-      />
-    </BaseCard>
+    <>
+      <BaseCard title="Public Points of Contact">
+        <Text>
+          Provide points of contact for your organization. These public points
+          of contact will be shown to the public.
+          {SHOW_MEMBERS && (
+            <>
+              {' '}
+              Your {OBJECT_NAME_SINGULAR} members will show up on the{' '}
+              {OBJECT_NAME_SINGULAR} page, but only the name, title, and profile
+              picture will be shown. If you would like to provide more detailed
+              contact information, use the form below.
+            </>
+          )}
+        </Text>
+        <ModelForm
+          baseUrl={`/clubs/${club.code}/advisors/`}
+          listParams="&public=true"
+          defaultObject={{ public: true }}
+          initialData={club.advisor_set.filter(
+            ({ public: isPublic }) => isPublic,
+          )}
+          fields={fields}
+        />
+      </BaseCard>
+      <BaseCard title="Internal Points of Contact">
+        <Text>
+          These private points of contact will be shown to only {SITE_NAME}{' '}
+          administrators.
+        </Text>
+        <ModelForm
+          baseUrl={`/clubs/${club.code}/advisors/`}
+          listParams="&public=false"
+          defaultObject={{ public: false }}
+          initialData={club.advisor_set.filter(
+            ({ public: isPublic }) => !isPublic,
+          )}
+          fields={fields}
+        />
+      </BaseCard>
+    </>
   )
 }

--- a/frontend/components/Form.js
+++ b/frontend/components/Form.js
@@ -643,7 +643,8 @@ export class ModelForm extends Component {
     this.state = {
       objects: null,
       currentlyEditing: null,
-      createObject: {},
+      createObject:
+        props.defaultObject != null ? { ...props.defaultObject } : {},
       newCount: 0,
     }
 
@@ -666,6 +667,7 @@ export class ModelForm extends Component {
     this.setState(({ objects, newCount }) => {
       objects.push({
         tempId: newCount,
+        ...(this.props.defaultObject ?? {}),
       })
       return { objects, newCount: newCount + 1 }
     })
@@ -801,7 +803,9 @@ export class ModelForm extends Component {
   }
 
   componentDidMount() {
-    doApiRequest(`${this.props.baseUrl}?format=json`)
+    doApiRequest(
+      `${this.props.baseUrl}?format=json${this.props.listParams ?? ''}`,
+    )
       .then((resp) => resp.json())
       .then((resp) => {
         this.setState({ objects: resp })
@@ -942,7 +946,10 @@ export class ModelForm extends Component {
                       this.setState({
                         objects: [...objects],
                         currentlyEditing: obj[keyField],
-                        createObject: {},
+                        createObject:
+                          this.props.defaultObject != null
+                            ? { ...this.props.defaultObject }
+                            : {},
                       })
                     } else {
                       this.setState({
@@ -981,7 +988,10 @@ export class ModelForm extends Component {
                   getApiUrl,
                   formatResponse,
                   getRoleDisplay,
-                  createObject: {},
+                  createObject:
+                    this.props.defaultObject != null
+                      ? { ...this.props.defaultObject }
+                      : {},
                 })
                 this.onChange({})
               }}


### PR DESCRIPTION
Separate the point of contact form for public and private contacts. Still allows you to switch between the two with a checkbox, this behavior may be confusing and it might be a good idea to remove it.

![image](https://user-images.githubusercontent.com/4441174/97066029-bf554b00-157f-11eb-8293-70da7fc17734.png)

[ch2749]