### PR TITLE
Branding Google Analytics tracking code switch

### DIFF
--- a/frontend/utils/analytics.tsx
+++ b/frontend/utils/analytics.tsx
@@ -1,11 +1,13 @@
 import ReactGA from 'react-ga'
 
+import { GA_TRACKING_CODE } from './branding'
+
 const dev = process.env.NODE_ENV !== 'production'
 
 export const initGA = (): void => {
   if (!dev) {
     console.log('GA init') // eslint-disable-line
-    ReactGA.initialize('UA-21029575-14')
+    ReactGA.initialize(GA_TRACKING_CODE)
   }
 }
 export const logPageView = (): void => {

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -68,6 +68,8 @@ const sites = {
         height: 80,
       },
     ],
+
+    GA_TRACKING_CODE: 'UA-21029575-14',
   },
   fyh: {
     SITE_NAME: 'Hub@Penn',
@@ -122,6 +124,8 @@ const sites = {
         className: 'mr-4 mb-4',
       },
     ],
+
+    GA_TRACKING_CODE: 'G-08JKZXMTZ4',
   },
 }
 
@@ -166,3 +170,5 @@ export const ALL_CLUB_FIELDS = new Set(
     .map(({ CLUB_FIELDS }) => CLUB_FIELDS)
     .flat(),
 )
+
+export const GA_TRACKING_CODE = sites[site].GA_TRACKING_CODE


### PR DESCRIPTION
Added the two tracking codes to the `branding.tsx` file and setup `analytics.tsx` to use the imported tracking code from branding.