### PR TITLE
Add student type field frontend

### DIFF
--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -25,6 +25,7 @@ from clubs.views import (
     QuestionAnswerViewSet,
     ReportViewSet,
     SchoolViewSet,
+    StudentTypeViewSet,
     SubscribeViewSet,
     TagViewSet,
     TestimonialViewSet,
@@ -50,6 +51,7 @@ router.register(r"requests", MembershipRequestViewSet, basename="requests")
 
 router.register(r"schools", SchoolViewSet, basename="schools")
 router.register(r"majors", MajorViewSet, basename="majors")
+router.register(r"student_types", StudentTypeViewSet, basename="student_types"),
 router.register(r"reports", ReportViewSet, basename="reports")
 router.register(r"years", YearViewSet, basename="years")
 router.register(r"users", UserViewSet, basename="users")

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -56,6 +56,7 @@ from clubs.models import (
     QuestionAnswer,
     Report,
     School,
+    StudentType,
     Subscribe,
     Tag,
     Testimonial,
@@ -95,6 +96,7 @@ from clubs.serializers import (
     QuestionAnswerSerializer,
     ReportSerializer,
     SchoolSerializer,
+    StudentTypeSerializer,
     SubscribeBookmarkSerializer,
     SubscribeSerializer,
     TagSerializer,
@@ -336,6 +338,7 @@ class ClubsSearchFilter(filters.BaseFilterBackend):
             "target_majors": parse_tags,
             "target_schools": parse_tags,
             "target_years": parse_tags,
+            "target_students": parse_tags,
         }
 
         if not queryset.model == Club:
@@ -914,6 +917,26 @@ class MajorViewSet(viewsets.ModelViewSet):
     serializer_class = MajorSerializer
     permission_classes = [ReadOnly | IsSuperuser]
     queryset = Major.objects.all()
+
+
+class StudentTypeViewSet(viewsets.ModelViewSet):
+    """
+    list:
+    Retrieve a list of all the student types (ex: Online Student, Transfer Student, etc).
+
+    retrieve:
+    Retrieve a single student type by ID.
+
+    create:
+    Add a new student type to the list of student types.
+
+    destroy:
+    Remove a student type from the list of student types.
+    """
+
+    serializer_class = StudentTypeSerializer
+    permission_classes = [ReadOnly | IsSuperuser]
+    queryset = StudentType.objects.all()
 
 
 class YearViewSet(viewsets.ModelViewSet):

--- a/frontend/components/ClubEditPage.tsx
+++ b/frontend/components/ClubEditPage.tsx
@@ -21,6 +21,7 @@ import {
   Major,
   MembershipRank,
   School,
+  StudentType,
   Tag,
   UserInfo,
   Year,
@@ -63,6 +64,7 @@ type ClubFormProps = {
   majors: Major[]
   years: Year[]
   tags: Tag[]
+  student_types: StudentType[]
   router: SingletonRouter
 }
 
@@ -179,14 +181,22 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
   }
 
   render(): ReactElement {
-    const { authenticated, userInfo, schools, years, majors, tags } = this.props
+    const {
+      authenticated,
+      userInfo,
+      schools,
+      years,
+      majors,
+      tags,
+      student_types,
+    } = this.props
     const { club, isEdit, message } = this.state
 
     let metadata
     if (club) {
       metadata = <ClubMetadata club={club} />
     } else {
-      metadata = <Metadata title="Create Club" />
+      metadata = <Metadata title={`Create ${OBJECT_NAME_TITLE_SINGULAR}`} />
     }
 
     if (authenticated === false) {
@@ -249,6 +259,7 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
               years={years}
               majors={majors}
               tags={tags}
+              student_types={student_types}
               club={club}
               onSubmit={this.submit}
             />
@@ -416,6 +427,7 @@ class ClubForm extends Component<ClubFormProps, ClubFormState> {
               majors={majors}
               tags={tags}
               club={club === null ? {} : club}
+              student_types={student_types}
               onSubmit={this.submit}
             />
           </div>

--- a/frontend/components/ClubEditPage/ClubEditCard.tsx
+++ b/frontend/components/ClubEditPage/ClubEditCard.tsx
@@ -7,6 +7,7 @@ import {
   ClubSize,
   Major,
   School,
+  StudentType,
   Tag,
   Year,
 } from '../../types'
@@ -59,6 +60,7 @@ const CLUB_SIZES = [
 type ClubEditCardProps = {
   schools: Readonly<School[]>
   majors: Readonly<Major[]>
+  student_types: Readonly<StudentType[]>
   years: Readonly<Year[]>
   tags: Readonly<Tag[]>
   club: Partial<Club>
@@ -73,6 +75,7 @@ type ClubEditCardProps = {
 export default function ClubEditCard({
   schools,
   majors,
+  student_types,
   years,
   tags,
   club,
@@ -332,6 +335,14 @@ export default function ClubEditCard({
           type: 'multiselect',
           placeholder: `Select majors relevant to your ${OBJECT_NAME_SINGULAR}!`,
           choices: majors,
+          converter: (a) => ({ value: a.id, label: a.name }),
+          reverser: (a) => ({ id: a.value, name: a.label }),
+        },
+        {
+          name: 'student_types',
+          type: 'multiselect',
+          placeholder: `Select student types relevant to your ${OBJECT_NAME_SINGULAR}!`,
+          choices: student_types,
           converter: (a) => ({ value: a.id, label: a.name }),
           reverser: (a) => ({ id: a.value, name: a.label }),
         },

--- a/frontend/pages/club/[club]/edit.js
+++ b/frontend/pages/club/[club]/edit.js
@@ -2,14 +2,17 @@ import { withRouter } from 'next/router'
 
 import ClubEditPage from '../../../components/ClubEditPage'
 import renderPage from '../../../renderPage'
-import { doApiRequest } from '../../../utils'
+import { doApiRequest, isClubFieldShown } from '../../../utils'
 
 const Edit = (props) => <ClubEditPage {...props} />
 
 Edit.getInitialProps = async ({ query }) => {
-  const endpoints = ['tags', 'schools', 'majors', 'years']
+  const endpoints = ['tags', 'schools', 'majors', 'years', 'student_types']
   return Promise.all(
     endpoints.map(async (item) => {
+      if (!isClubFieldShown(item)) {
+        return [item, []]
+      }
       const request = await doApiRequest(`/${item}/?format=json`)
       const response = await request.json()
       return [item, response]

--- a/frontend/pages/club/[club]/renew.tsx
+++ b/frontend/pages/club/[club]/renew.tsx
@@ -11,8 +11,16 @@ import AuthPrompt from '../../../components/common/AuthPrompt'
 import { DARK_GRAY, GREEN, MEDIUM_GRAY } from '../../../constants/colors'
 import { CLUB_ROUTE } from '../../../constants/routes'
 import renderPage from '../../../renderPage'
-import { Club, MembershipRank } from '../../../types'
-import { doApiRequest, useSetting } from '../../../utils'
+import {
+  Club,
+  Major,
+  MembershipRank,
+  School,
+  StudentType,
+  Tag,
+  Year,
+} from '../../../types'
+import { doApiRequest, isClubFieldShown, useSetting } from '../../../utils'
 import {
   APPROVAL_AUTHORITY,
   APPROVAL_AUTHORITY_URL,
@@ -26,10 +34,11 @@ import {
 type RenewPageProps = {
   club: Club
   authenticated: boolean | null
-  schools: any[]
-  majors: any[]
-  years: any[]
-  tags: any[]
+  schools: School[]
+  majors: Major[]
+  years: Year[]
+  tags: Tag[]
+  student_types: StudentType[]
 }
 
 const SubTitle = s.h2`
@@ -151,6 +160,7 @@ const RenewPage = ({
   majors,
   years,
   tags,
+  student_types,
 }: RenewPageProps): ReactElement => {
   const [club, setClub] = useState<Club>(initialClub)
   const [step, setStep] = useState<number>(0)
@@ -275,6 +285,7 @@ const RenewPage = ({
             majors={majors}
             years={years}
             tags={tags}
+            student_types={student_types}
             club={club}
             isEdit={true}
             onSubmit={({ club, message }) => {
@@ -498,9 +509,12 @@ RenewPage.getInitialProps = async ({ query, req }: NextPageContext) => {
   const clubReq = await doApiRequest(`/clubs/${query.club}/?format=json`, data)
   const clubRes = await clubReq.json()
 
-  const endpoints = ['tags', 'schools', 'majors', 'years']
+  const endpoints = ['tags', 'schools', 'majors', 'years', 'student_types']
   return Promise.all(
     endpoints.map(async (item) => {
+      if (!isClubFieldShown(item)) {
+        return [item, []]
+      }
       const request = await doApiRequest(`/${item}/?format=json`, data)
       const response = await request.json()
       return [item, response]

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -27,7 +27,7 @@ import {
   SNOW,
 } from '../constants/colors'
 import { PaginatedClubPage, renderListPage } from '../renderPage'
-import { Badge, School, Tag, UserInfo, Year } from '../types'
+import { Badge, School, StudentType, Tag, UserInfo, Year } from '../types'
 import { doApiRequest, isClubFieldShown, useSetting } from '../utils'
 import { OBJECT_NAME_TITLE, SITE_TAGLINE } from '../utils/branding'
 
@@ -66,6 +66,7 @@ type SplashProps = {
   badges: Badge[]
   schools: School[]
   years: Year[]
+  student_types: StudentType[]
   clubCount: number
   liveEventCount: number
 }
@@ -328,6 +329,17 @@ const Splash = (props: SplashProps): ReactElement => {
               name: 'year',
             }))}
           />
+          {isClubFieldShown('student_types') && (
+            <SearchBarCheckboxItem
+              param="student_types__in"
+              label="Student Type"
+              options={props.student_types.map(({ id, name }) => ({
+                value: id,
+                label: name,
+                name: 'student_type',
+              }))}
+            />
+          )}
         </SearchBar>
 
         <SearchbarRightContainer>

--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -11,7 +11,7 @@ import { WHITE } from './constants/colors'
 import { NAV_HEIGHT } from './constants/measurements'
 import { BODY_FONT } from './constants/styles'
 import { Club, ClubEvent, ExtendedUserInfo, Tag, UserInfo } from './types'
-import { doApiRequest, OptionsContext } from './utils'
+import { doApiRequest, isClubFieldShown, OptionsContext } from './utils'
 import { logEvent } from './utils/analytics'
 import { logException } from './utils/sentry'
 
@@ -239,6 +239,7 @@ export function renderListPage(Page) {
       liveEventRequest,
       schoolRequest,
       yearRequest,
+      studentTypesRequest,
     ] = await Promise.all([
       doApiRequest('/clubs/?page=1&ordering=featured&format=json', data),
       doApiRequest('/tags/?format=json', data),
@@ -246,6 +247,9 @@ export function renderListPage(Page) {
       doApiRequest('/events/live/', data),
       doApiRequest('/schools/?format=json', data),
       doApiRequest('/years/?format=json', data),
+      isClubFieldShown('student_types')
+        ? doApiRequest('/student_types/?format=json', data)
+        : Promise.resolve(null),
     ])
 
     const [
@@ -255,6 +259,7 @@ export function renderListPage(Page) {
       liveEventResponse,
       schoolResponse,
       yearResponse,
+      studentTypesResponse,
     ] = await Promise.all([
       clubsRequest.json(),
       tagsRequest.json(),
@@ -262,6 +267,9 @@ export function renderListPage(Page) {
       liveEventRequest.json(),
       schoolRequest.json(),
       yearRequest.json(),
+      studentTypesRequest != null
+        ? studentTypesRequest.json()
+        : Promise.resolve([]),
     ])
 
     return {
@@ -270,6 +278,7 @@ export function renderListPage(Page) {
       clubs: clubsResponse,
       schools: schoolResponse,
       years: yearResponse,
+      student_types: studentTypesResponse,
       liveEventCount: liveEventResponse.length,
     }
   }

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -199,3 +199,8 @@ export interface Year {
   name: string
   year: number
 }
+
+export interface StudentType {
+  id: number
+  name: string
+}

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -110,6 +110,7 @@ const sites = {
       'appointment_needed',
       'available_virtually',
       'signature_events',
+      'student_types',
     ],
     SHOW_MEMBERS: false,
     SHOW_MEMBERSHIP_REQUEST: false,


### PR DESCRIPTION
- Add student type field to the frontend (club edit page, search sidebar).
- Only load student type field if enabled for the site (using branding constants).

![image](https://user-images.githubusercontent.com/4441174/97201085-6a385580-1788-11eb-9432-8ebb6783faaf.png)

[ch2747]