### PR TITLE
Fix tag styling issues

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1659,6 +1659,9 @@ class BadgeViewSet(viewsets.ModelViewSet):
     lookup_field = "name"
 
     def get_queryset(self):
+        if self.request.user.is_authenticated and self.request.user.is_superuser:
+            return Badge.objects.all()
+
         return Badge.objects.filter(Q(purpose="fair") | Q(label__in=["SAC", "Wharton Council"]))
 
 

--- a/frontend/components/FilterSearch.tsx
+++ b/frontend/components/FilterSearch.tsx
@@ -9,10 +9,12 @@ import {
   CLUBS_GREY_LIGHT,
   FOCUS_GRAY,
   MEDIUM_GRAY,
+  TAG_BACKGROUND_COLOR_MAP,
+  TAG_TEXT_COLOR_MAP,
   WHITE,
 } from '../constants/colors'
 import { MD, mediaMaxWidth } from '../constants/measurements'
-import { Icon, SelectedTag } from './common'
+import { Icon, SelectedTag, Tag } from './common'
 
 const SearchWrapper = s.div`
   margin-bottom: 30px;
@@ -83,9 +85,11 @@ type SearchProps = {
   updateTag: (tag: FuseTag, name: string) => void
   clearTags: () => void
   name: string
+  param: string
 }
 
 const Search = ({
+  param,
   name,
   selected = [],
   searchTags,
@@ -122,8 +126,24 @@ const Search = ({
     IndicatorSeparator: () => null,
     DropdownIndicator: () => <SearchIcon name="tag" />,
     MultiValueContainer: ({ innerProps, children }) => {
+      const backgroundColor = TAG_BACKGROUND_COLOR_MAP[param]
+      const foregroundColor = TAG_TEXT_COLOR_MAP[param] ?? 'white'
+
+      if (backgroundColor != null) {
+        return (
+          <Tag
+            {...innerProps}
+            color={backgroundColor}
+            foregroundColor={foregroundColor}
+            className="tag is-rounded"
+          >
+            {children}
+          </Tag>
+        )
+      }
+
       return (
-        <SelectedTag {...innerProps} className="tag is-rounded has-text-white">
+        <SelectedTag {...innerProps} className="tag is-rounded">
           {children}
         </SelectedTag>
       )
@@ -186,6 +206,7 @@ const selectInitial = (name: string, tags: FuseTag[] = []) => {
 }
 
 type FilterProps = {
+  param: string
   name: string
   tags: FuseTag[]
   updateTag: (tag: FuseTag, name: string) => void
@@ -194,6 +215,7 @@ type FilterProps = {
 }
 
 const Filter = ({
+  param,
   name,
   tags,
   updateTag,
@@ -211,7 +233,7 @@ const Filter = ({
       text: label as string,
       label: (
         <>
-          {color != null && <ColorPreview color={color}> </ColorPreview>}
+          {color != null && <ColorPreview color={color} />}
           {`${label}${count != null ? ` (${count})` : ''}`}
           {!!description && <SubLabel>{description}</SubLabel>}
         </>
@@ -249,6 +271,7 @@ const Filter = ({
     <>
       <SearchWrapper>
         <Search
+          param={param}
           name={name}
           selected={selected}
           searchTags={searchTags}

--- a/frontend/components/SearchBar.tsx
+++ b/frontend/components/SearchBar.tsx
@@ -426,6 +426,7 @@ export const SearchBarTagItem = ({
   return (
     <Collapsible name={label}>
       <FilterSearch
+        param={param}
         name={label}
         tags={options}
         updateTag={updateTag}

--- a/frontend/components/common/Tags.tsx
+++ b/frontend/components/common/Tags.tsx
@@ -6,10 +6,9 @@ import {
   FOCUS_GRAY,
   PRIMARY_TAG_BG,
   PRIMARY_TAG_TEXT,
-  WHITE,
 } from '../../constants/colors'
 
-const calculateForegroundColor = (color) => {
+const calculateForegroundColor = (color: string): string => {
   let obj = Color(`#${color}`)
   if (obj.isDark()) {
     obj = obj.lighten(0.8)
@@ -19,14 +18,16 @@ const calculateForegroundColor = (color) => {
   return obj.hex()
 }
 
-export const Tag = s.span`
+export const Tag = s.span<{ color?: string; foregroundColor?: string }>`
   margin: 0 4px 4px 0;
   font-weight: 600;
-  ${({ color }) =>
+  ${({ color, foregroundColor }) =>
     color &&
     `
-    background-color: #${color} !important;
-    color: ${calculateForegroundColor(color)} !important;
+    background-color: #${
+      color.startsWith('#') ? color.substr(1) : color
+    } !important;
+    color: ${foregroundColor ?? calculateForegroundColor(color)} !important;
   `}
 `
 
@@ -37,7 +38,7 @@ export const BlueTag = s(Tag)`
 
 export const SelectedTag = s(Tag)`
   background-color: ${PRIMARY_TAG_BG} !important;
-  color: ${WHITE} !important;
+  color: ${PRIMARY_TAG_TEXT} !important;
 `
 
 export const InactiveTag = s(Tag)`

--- a/frontend/constants/colors.ts
+++ b/frontend/constants/colors.ts
@@ -110,3 +110,14 @@ export const PROPIC_TEXT = [
   '#541625',
   '#280A42',
 ]
+
+export const TAG_TEXT_COLOR_MAP = {
+  tags__in: PRIMARY_TAG_TEXT,
+}
+
+export const TAG_BACKGROUND_COLOR_MAP = {
+  tags__in: PRIMARY_TAG_BG,
+  size__in: CLUBS_NAVY,
+  application_required__in: CLUBS_RED,
+  badges__in: CLUBS_PURPLE,
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -18,25 +18,17 @@ import SearchBar, {
 } from '../components/SearchBar'
 import {
   CLUBS_GREY_LIGHT,
-  CLUBS_NAVY,
   CLUBS_PURPLE,
-  CLUBS_RED,
   FOCUS_GRAY,
   H1_TEXT,
-  PRIMARY_TAG_BG,
   SNOW,
+  TAG_BACKGROUND_COLOR_MAP,
+  TAG_TEXT_COLOR_MAP,
 } from '../constants/colors'
 import { PaginatedClubPage, renderListPage } from '../renderPage'
 import { Badge, School, StudentType, Tag, UserInfo, Year } from '../types'
 import { doApiRequest, isClubFieldShown, useSetting } from '../utils'
 import { OBJECT_NAME_TITLE, SITE_TAGLINE } from '../utils/branding'
-
-const colorMap = {
-  tags__in: PRIMARY_TAG_BG,
-  size__in: CLUBS_NAVY,
-  application_required__in: CLUBS_RED,
-  badges__in: CLUBS_PURPLE,
-}
 
 const ClearAllLink = s.span`
   cursor: pointer;
@@ -108,10 +100,12 @@ const SearchTags = ({
           {tags.map((tag) => {
             return (
               <span
-                key={tag.value}
-                className="tag is-rounded has-text-white"
+                key={`${tag.value} ${tag.label}`}
+                className="tag is-rounded"
                 style={{
-                  backgroundColor: colorMap[tag.name],
+                  color: TAG_TEXT_COLOR_MAP[tag.name] ?? 'white',
+                  backgroundColor:
+                    TAG_BACKGROUND_COLOR_MAP[tag.name] ?? CLUBS_PURPLE,
                   fontWeight: 600,
                   margin: 3,
                 }}
@@ -257,6 +251,24 @@ const Splash = (props: SplashProps): ReactElement => {
     { value: 4, label: 'more than 100', name: 'size' },
   ]
 
+  const schoolOptions = props.schools.map(({ id, name }) => ({
+    value: id,
+    label: name,
+    name: 'school',
+  }))
+
+  const yearOptions = props.years.map(({ id, name }) => ({
+    value: id,
+    label: name,
+    name: 'year',
+  }))
+
+  const studentTypeOptions = props.student_types.map(({ id, name }) => ({
+    value: id,
+    label: name,
+    name: 'student_type',
+  }))
+
   return (
     <>
       <Metadata />
@@ -324,30 +336,18 @@ const Splash = (props: SplashProps): ReactElement => {
           <SearchBarCheckboxItem
             param="target_schools__in"
             label="School"
-            options={props.schools.map(({ id, name }) => ({
-              value: id,
-              label: name,
-              name: 'school',
-            }))}
+            options={schoolOptions}
           />
           <SearchBarCheckboxItem
             param="target_years__in"
             label="School Year"
-            options={props.years.map(({ id, name }) => ({
-              value: id,
-              label: name,
-              name: 'year',
-            }))}
+            options={yearOptions}
           />
           {isClubFieldShown('student_types') && (
             <SearchBarCheckboxItem
               param="student_types__in"
               label="Student Type"
-              options={props.student_types.map(({ id, name }) => ({
-                value: id,
-                label: name,
-                name: 'student_type',
-              }))}
+              options={studentTypeOptions}
             />
           )}
         </SearchBar>
@@ -380,6 +380,9 @@ const Splash = (props: SplashProps): ReactElement => {
                 badges__in: badgeOptions,
                 application_required__in: applicationRequiredOptions,
                 size__in: sizeOptions,
+                target_schools__in: schoolOptions,
+                target_years__in: yearOptions,
+                student_types__in: studentTypeOptions,
               }}
             />
 


### PR DESCRIPTION
- Fix issue with tag text colors not being properly rendered.
- Separate out tag colors for tags and badges.
- Add in tag colors for school, school year, and student type.
  - @snie11 we may want to color these differently, send me color scheme for Penn Clubs / Hub@Penn if this is the case.
- Fix issue with duplicate key not rerendering element on top tags section.

![image](https://user-images.githubusercontent.com/4441174/97782163-56189d80-1b66-11eb-82f1-26901e5d64e8.png)

[ch2778]