### PR TITLE
Lots of minor mobile fixes

### DIFF
--- a/frontend/components/DisplayButtons.tsx
+++ b/frontend/components/DisplayButtons.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { ReactElement } from 'react'
 import styled from 'styled-components'
 
+import { mediaMaxWidth, PHONE } from '../constants'
 import {
   ALLBIRDS_GRAY,
   BLACK_ALPHA,
@@ -21,6 +22,12 @@ const DisplayButtonsTag = styled.div`
 
   .button {
     margin-left: 8px;
+  }
+
+  ${mediaMaxWidth(PHONE)} {
+    float: none;
+    text-align: right;
+    margin-bottom: 1rem;
   }
 `
 

--- a/frontend/components/DropdownFilter.tsx
+++ b/frontend/components/DropdownFilter.tsx
@@ -9,14 +9,11 @@ import {
   CLUBS_RED,
   LIGHT_GRAY,
   PRIMARY_TAG_BG,
-  WHITE,
 } from '../constants/colors'
 import {
   ANIMATION_DURATION,
   MD,
   mediaMaxWidth,
-  NAV_HEIGHT,
-  SEARCH_BAR_MOBILE_HEIGHT,
 } from '../constants/measurements'
 import { logEvent } from '../utils/analytics'
 import { Icon } from './common'
@@ -61,22 +58,13 @@ const TableRow = styled.tr`
 `
 
 const TableWrapper = styled.div`
-  max-height: 0;
-  opacity: 0;
   overflow: hidden;
 
   max-height: 150vh;
   opacity: 1;
 
   ${mediaMaxWidth(MD)} {
-    position: fixed;
-    left: 0;
     width: 100%;
-    top: calc(${SEARCH_BAR_MOBILE_HEIGHT} + ${NAV_HEIGHT});
-    background: ${WHITE};
-    height: calc(100vh - ${SEARCH_BAR_MOBILE_HEIGHT} - ${NAV_HEIGHT});
-    overflow-y: auto;
-    max-height: calc(100vh - ${SEARCH_BAR_MOBILE_HEIGHT} - ${NAV_HEIGHT});
   }
 `
 

--- a/frontend/components/FilterSearch.tsx
+++ b/frontend/components/FilterSearch.tsx
@@ -21,17 +21,11 @@ const SearchWrapper = styled.div`
   overflow: visible;
 
   ${mediaMaxWidth(MD)} {
-    height: auto;
-    overflow: visible;
     width: 100%;
     margin: 0;
-    padding: 8px 1rem;
+    padding-bottom: 16px;
     border-bottom: 1px solid ${BORDER};
-    position: fixed;
-    left: 0;
-    z-index: 1000;
     background: ${WHITE};
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.075);
   }
 `
 

--- a/frontend/components/Header/Links.tsx
+++ b/frontend/components/Header/Links.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { SHORT_ANIMATION_DURATION } from '../../constants/animations'
 import {
+  BANNER_BG,
   BANNER_TEXT,
   LOGIN_BACKGROUND,
   WHITE,
@@ -58,9 +59,14 @@ const StyledLinkAnchor = styled.a`
   color: ${BANNER_TEXT} !important;
   display: inline-block;
   cursor: pointer;
+
+  ${mediaMaxWidth(MD)} {
+    padding: 14px 0px;
+    padding-right: 20px;
+  }
 `
 
-const StyledLink = (props) => {
+const StyledLink = (props): ReactElement => {
   return (
     <Link href={props.href}>
       <StyledLinkAnchor {...props} />
@@ -72,6 +78,8 @@ const Menu = styled.div<{ show?: boolean }>`
   ${mediaMaxWidth(MD)} {
     ${({ show }) => show && 'display: block;'}
   }
+
+  background-color: ${BANNER_BG};
 `
 
 type Props = {

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -12,6 +12,7 @@ import {
   MD,
   mediaMaxWidth,
   NAV_HEIGHT,
+  PHONE,
   TITLE_MARGIN,
   TITLE_SIZE,
   TITLE_SPACING,
@@ -102,6 +103,23 @@ const LogoBackground = styled.div`
   background-repeat: no-repeat;
   height: ${NAV_HEIGHT};
   position: fixed;
+
+  ${mediaMaxWidth(PHONE)} {
+    display: none;
+  }
+`
+
+const LogoItem = styled.a<{ isHub?: boolean }>`
+  padding: 0;
+
+  ${({ isHub }) =>
+    isHub
+      ? `
+    ${mediaMaxWidth(MD)} {
+      margin-top: 1rem;
+    }
+  `
+      : ''}
 `
 
 type HeaderProps = {
@@ -137,6 +155,7 @@ function withFading<T>(
 }
 
 const FadingLogoBackground = withFading(LogoBackground, true, 0.6)
+const isHub = SITE_ID === 'fyh'
 
 const Header = ({ authenticated, userInfo }: HeaderProps): ReactElement => {
   const [show, setShow] = useState(false)
@@ -149,14 +168,18 @@ const Header = ({ authenticated, userInfo }: HeaderProps): ReactElement => {
 
       <NavSpacer />
 
-      <Nav className="navbar" role="navigation" aria-label="main navigation">
+      <Nav
+        className={`navbar ${isHub ? 'is-dark' : ''}`}
+        role="navigation"
+        aria-label="main navigation"
+      >
         <div className="navbar-brand">
           {LOGO_BACKGROUND_IMAGE != null && <FadingLogoBackground />}
           <Link href={HOME_ROUTE}>
-            <a className="navbar-item" style={{ padding: 0 }}>
+            <LogoItem className="navbar-item" isHub={isHub}>
               <Logo src={SITE_LOGO} alt={`${SITE_NAME} Logo`} />
               <Title>{SITE_NAME}</Title>
-            </a>
+            </LogoItem>
           </Link>
 
           <Burger toggle={toggle} />
@@ -164,7 +187,7 @@ const Header = ({ authenticated, userInfo }: HeaderProps): ReactElement => {
 
         <Links userInfo={userInfo} authenticated={authenticated} show={show} />
       </Nav>
-      {SITE_ID === 'fyh' && <ImageHead />}
+      {isHub && <ImageHead />}
 
       <Feedback />
     </>

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -112,6 +112,10 @@ const LogoBackground = styled.div`
 const LogoItem = styled.a<{ isHub?: boolean }>`
   padding: 0;
 
+  &:hover {
+    background-color: transparent !important;
+  }
+
   ${({ isHub }) =>
     isHub
       ? `

--- a/frontend/components/OrderInput.tsx
+++ b/frontend/components/OrderInput.tsx
@@ -7,7 +7,12 @@ import {
   FOCUS_GRAY,
   MEDIUM_GRAY,
 } from '../constants/colors'
-import { BORDER_RADIUS, MD, mediaMaxWidth } from '../constants/measurements'
+import {
+  BORDER_RADIUS,
+  MD,
+  mediaMaxWidth,
+  PHONE,
+} from '../constants/measurements'
 import { BODY_FONT } from '../constants/styles'
 import { Icon } from './common'
 
@@ -83,6 +88,10 @@ const OrderingWrapper = styled.div`
     border: 1px solid ${BORDER};
     color: ${MEDIUM_GRAY};
     background: ${FOCUS_GRAY};
+  }
+
+  ${mediaMaxWidth(PHONE)} {
+    padding-bottom: 16px;
   }
 `
 

--- a/frontend/components/SearchBar.tsx
+++ b/frontend/components/SearchBar.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components'
 
 import {
   ALLBIRDS_GRAY,
-  BORDER,
   CLUBS_GREY,
   FOCUS_GRAY,
   H1_TEXT,
@@ -23,6 +22,7 @@ import {
   MD,
   mediaMaxWidth,
   mediaMinWidth,
+  NAV_HEIGHT,
   SEARCH_BAR_MOBILE_HEIGHT,
 } from '../constants/measurements'
 import { BODY_FONT } from '../constants/styles'
@@ -52,14 +52,15 @@ export const SearchbarRightContainer = styled.div`
   }
 `
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ isScrolled?: boolean }>`
   height: 100vh;
   width: 20vw;
   overflow-x: hidden;
   overflow-y: auto;
   position: fixed;
   top: 0;
-  padding-top: ${FULL_NAV_HEIGHT};
+  padding-top: ${({ isScrolled }) =>
+    isScrolled ? NAV_HEIGHT : FULL_NAV_HEIGHT};
   color: ${H1_TEXT};
 
   ${mediaMaxWidth(MD)} {
@@ -88,15 +89,15 @@ const Content = styled.div`
   }
 
   ${mediaMaxWidth(MD)} {
-    height: auto;
-    overflow: visible;
+    overflow-x: hidden;
     width: 100%;
     margin: 0;
-    padding: 8px 1rem;
-    border-bottom: 1px solid ${BORDER};
+    padding: 16px 1rem;
     position: fixed;
     z-index: 1000;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.075);
+    background: ${WHITE};
+    top: ${NAV_HEIGHT};
   }
 `
 
@@ -155,16 +156,26 @@ const Collapsible = ({
   active,
   name,
 }: CollapsibleProps): ReactElement => {
-  const [isActive, setActive] = useState<boolean>(active ?? true)
+  const [isActive, setActive] = useState<boolean | null>(active ?? null)
+  const [defaultActive, setDefaultActive] = useState<boolean>(true)
+
+  useEffect(() => {
+    const onResize = () => {
+      setDefaultActive(window.innerWidth >= parseInt(MD))
+    }
+    onResize()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   return (
     <>
       <FilterHeader
-        active={isActive}
+        active={isActive ?? defaultActive}
         name={name}
         toggleActive={() => setActive((active) => !active)}
       />
-      {isActive && children}
+      {(isActive ?? defaultActive) && children}
     </>
   )
 }
@@ -245,7 +256,7 @@ export const SearchBarCheckboxItem = ({
   }, [searchValue])
 
   return (
-    <Collapsible name={label} key={param}>
+    <Collapsible name={label}>
       <DropdownFilter
         name={param}
         options={options}
@@ -447,9 +458,20 @@ const SearchBar = ({
   searchInput,
   children,
 }: SearchBarProps): ReactElement => {
+  const [isScrolled, setScrolled] = useState<boolean>(false)
+
+  useEffect(() => {
+    const onScroll = () => {
+      setScrolled(window.scrollY >= 150)
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
   return (
     <>
-      <Wrapper>
+      <Wrapper isScrolled={isScrolled}>
         <Content>
           <SearchBarValueContext.Provider value={searchInput}>
             <SearchBarContext.Provider value={updateSearch}>

--- a/frontend/components/common/Grid.tsx
+++ b/frontend/components/common/Grid.tsx
@@ -13,6 +13,14 @@ const percent = (numCols: number): string => (numCols / 12) * 100 + '%'
 export const Flex = styled.div`
   width: 100%;
   display: flex;
+
+  ${mediaMaxWidth(PHONE)} {
+    display: block;
+
+    & img {
+      margin: 0;
+    }
+  }
 `
 
 export const Row = styled.div<{ alwaysFlex?: boolean; margin?: string }>`

--- a/frontend/components/common/ProfilePic.tsx
+++ b/frontend/components/common/ProfilePic.tsx
@@ -50,7 +50,9 @@ const Avatar = styled.img<{ isRound?: boolean }>`
 
 const AvatarWrapper = styled.div<{ isCentered?: boolean }>`
   border-radius: 50%;
-  margin: 5px 15px;
+  ${mediaMinWidth(PHONE)} {
+    margin: 5px 15px;
+  }
   ${({ isCentered }) =>
     isCentered
       ? `

--- a/frontend/constants/measurements.ts
+++ b/frontend/constants/measurements.ts
@@ -67,7 +67,7 @@ export const DESKTOP = '1248px'
 export const TABLET = '992px'
 export const PHONE = '584px'
 
-export const SEARCH_BAR_MOBILE_HEIGHT = '91.33px'
+export const SEARCH_BAR_MOBILE_HEIGHT = '60px'
 
 export const ANIMATION_DURATION = '200ms'
 export const LONG_ANIMATION_DURATION = '400ms'

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -17,6 +17,7 @@ import SearchBar, {
   SearchBarTextItem,
   SearchInput,
 } from '../components/SearchBar'
+import { mediaMaxWidth, PHONE } from '../constants'
 import {
   CLUBS_GREY_LIGHT,
   CLUBS_PURPLE,
@@ -50,6 +51,10 @@ const ResultsText = styled.div`
   background: transparent !important;
   fontsize: 0.7em;
   margin: 5px;
+
+  ${mediaMaxWidth(PHONE)} {
+    margin-bottom: 1rem;
+  }
 `
 
 type SplashProps = {


### PR DESCRIPTION
- Fix scrolling issue with the sidebar on Hub@Penn. Uses the window scroll event, can be made much more efficient.
  - <img src="https://user-images.githubusercontent.com/4441174/98719058-3ef36000-235d-11eb-98f2-b6419991d6a5.png" width="300" />
- Fix issues with search bar rendering improperly for Penn Clubs and Hub@Penn. This design isn't optimal, but at least it is usable.
- Ensure that background image is not shown on mobile view, even after scrolling.
- Ensure that padding is correct for logo in Hub@Penn mobile view.
  - ![image](https://user-images.githubusercontent.com/4441174/98719345-a14c6080-235d-11eb-94b2-9bf95e330961.png)
- Fix issues with the navbar being the wrong color, make the navbar item vertical space smaller on mobile, and fix the issue with the background being the wrong color.
   - ![image](https://user-images.githubusercontent.com/4441174/98719525-dd7fc100-235d-11eb-8fd8-38819d2c9660.png)
- Modify search bar dropdowns to be expanded/contracted based on page size by default, with user settings overriding after they have expanded/collapsed an item.
- Fix padding and alignment issues on homepage.
  - ![image](https://user-images.githubusercontent.com/4441174/98721996-fdfc4b00-235e-11eb-8485-618945b6833b.png)
- Ensure that things look mostly alright on Penn Clubs.
  - ![image](https://user-images.githubusercontent.com/4441174/98722538-2d12bc80-235f-11eb-9091-0c8ece7ad28d.png)
  - ![image](https://user-images.githubusercontent.com/4441174/98722553-33a13400-235f-11eb-85c2-7d922e1fb32b.png)

[ch2864] [ch2866] [ch549]