### PR TITLE
Populate Events

### DIFF
--- a/backend/clubs/management/commands/populate.py
+++ b/backend/clubs/management/commands/populate.py
@@ -403,12 +403,13 @@ class Command(BaseCommand):
         now = timezone.now()
 
         # Create an event for right now so cypress can test current events
+        live_event_club = Club.objects.all()[0]
         event, created = Event.objects.get_or_create(
-            club=club,
-            code="test-event-for-club-now".format(Club.objects.all()[0]),
+            club=live_event_club,
+            code="test-event-for-club-now",
             defaults={
                 "creator": ben,
-                "name": f"Test Event now for {club.name}",
+                "name": f"Test Event now for {live_event_club.name}",
                 "description": "This is the description for this event.",
                 "start_time": now,
                 "end_time": now + datetime.timedelta(hours=1),

--- a/backend/clubs/management/commands/populate.py
+++ b/backend/clubs/management/commands/populate.py
@@ -400,11 +400,30 @@ class Command(BaseCommand):
         # create test events
         event_image_url = "https://i.imgur.com/IBCoKE3.jpg"
 
+        now = timezone.now()
+
+        # Create an event for right now so cypress can test current events
+        event, created = Event.objects.get_or_create(
+            club=club,
+            code="test-event-for-club-now".format(Club.objects.all()[0]),
+            defaults={
+                "creator": ben,
+                "name": f"Test Event now for {club.name}",
+                "description": "This is the description for this event.",
+                "start_time": now,
+                "end_time": now + datetime.timedelta(hours=1),
+            },
+        )
+
+        if created:
+            contents = get_image(event_image_url)
+            event.image.save("image.png", ContentFile(contents))
+
         # 10am today
-        even_base = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
+        even_base = timezone.now().replace(hour=14, minute=0, second=0, microsecond=0)
 
         # 2pm today
-        odd_base = timezone.now().replace(hour=14, minute=0, second=0, microsecond=0)
+        odd_base = timezone.now().replace(hour=18, minute=0, second=0, microsecond=0)
 
         for j in range(-14, 15):
             for i, club in enumerate(Club.objects.all()[:10]):


### PR DESCRIPTION
Updated test data for events:
- Spans two weeks forward and backward
- Alternates days with overlapping events (30 minute overlap) and zero overlap events
- 10 events for each day

[ch2853]