### PR TITLE
Hub@Penn changes

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -886,13 +886,19 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
         """
         Check for required tags before saving the club.
         """
-        tag_names = [tag.get("name") for tag in value]
-        necessary_tags = {"Undergraduate", "Graduate"}
-        if not any(tag in necessary_tags for tag in tag_names):
-            if Tag.objects.filter(name__in=list(necessary_tags)).count() >= len(necessary_tags):
-                raise serializers.ValidationError(
-                    "You must specify either the 'Undergraduate' or 'Graduate' tag in this list."
-                )
+        if settings.BRANDING == "fyh":
+            if len(value) < 1:
+                raise serializers.ValidationError("You must specify at least one tag in this list.")
+        else:
+            tag_names = [tag.get("name") for tag in value]
+            necessary_tags = {"Undergraduate", "Graduate"}
+            if not any(tag in necessary_tags for tag in tag_names):
+                if Tag.objects.filter(name__in=list(necessary_tags)).count() >= len(necessary_tags):
+                    raise serializers.ValidationError(
+                        "You must specify either the {} tag in this list.".format(
+                            " or ".join(f"'{tag}'" for tag in necessary_tags)
+                        )
+                    )
         return value
 
     def validate_description(self, value):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2180,7 +2180,16 @@ class MassInviteAPIView(APIView):
             )
 
         role = request.data.get("role", Membership.ROLE_MEMBER)
-        title = request.data.get("title", "Member")
+        title = request.data.get("title")
+
+        if not title:
+            return Response(
+                {
+                    "detail": "You must enter a title for the members that you are inviting.",
+                    "success": False,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         if mem and mem.role > role and not request.user.is_superuser:
             return Response(

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -740,7 +740,9 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         """
         Custom return endpoint for the directory page, allows the page to load faster.
         """
-        serializer = ClubMinimalSerializer(Club.objects.all().order_by("name"), many=True)
+        serializer = ClubMinimalSerializer(
+            Club.objects.all().exclude(approved=False).order_by("name"), many=True
+        )
         return Response(serializer.data)
 
     def get_filename(self):

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -15,8 +15,6 @@ import os
 import dj_database_url
 
 
-DOMAIN = os.environ.get("DOMAIN", "example.com")
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -174,6 +172,7 @@ FROM_EMAIL = (
 EMAIL_SUBJECT_PREFIX = f"[{BRANDING_SITE_NAME}] "
 INVITE_URL = "https://{domain}/invite/{club}/{id}/{token}"
 DEFAULT_DOMAIN = "hub.provost.upenn.edu" if BRANDING == "fyh" else "pennclubs.com"
+DOMAIN = os.environ.get("DOMAIN", DEFAULT_DOMAIN)
 
 VIEW_URL = "https://{domain}/club/{club}"
 EDIT_URL = "https://{domain}/club/{club}/edit"

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1224,6 +1224,7 @@ class ClubTestCase(TestCase):
             {
                 "emails": "one@pennlabs.org, two@pennlabs.org, three@pennlabs.org",
                 "role": Membership.ROLE_OFFICER,
+                "title": "Member",
             },
             content_type="application/json",
         )
@@ -1294,7 +1295,11 @@ class ClubTestCase(TestCase):
 
         resp = self.client.post(
             reverse("club-invite", args=(self.club1.code,)),
-            {"emails": "test@example.upenn.edu", "role": Membership.ROLE_OFFICER},
+            {
+                "emails": "test@example.upenn.edu",
+                "role": Membership.ROLE_OFFICER,
+                "title": "Member",
+            },
             content_type="application/json",
         )
         self.assertIn(resp.status_code, [200, 201], resp.content)
@@ -1317,7 +1322,7 @@ class ClubTestCase(TestCase):
 
         resp = self.client.post(
             reverse("club-invite", args=(self.club1.code,)),
-            {"emails": "test@example.upenn.edu", "role": Membership.ROLE_MEMBER},
+            {"emails": "test@example.upenn.edu", "role": Membership.ROLE_MEMBER, "title": "Member"},
             content_type="application/json",
         )
         self.assertIn(resp.status_code, [200, 201], resp.content)

--- a/frontend/components/ClubCard.tsx
+++ b/frontend/components/ClubCard.tsx
@@ -65,7 +65,7 @@ const Card = styled.div<CardProps>`
 `
 
 const Image = styled.img`
-  height: 100%;
+  max-height: 100%;
   max-width: 150px;
   border-radius: ${BORDER_RADIUS};
   border-radius: 4px;

--- a/frontend/components/ClubEditPage/InviteCard.tsx
+++ b/frontend/components/ClubEditPage/InviteCard.tsx
@@ -7,6 +7,7 @@ import { doApiRequest, formatResponse, getRoleDisplay } from '../../utils'
 import {
   MEMBERSHIP_ROLE_NAMES,
   OBJECT_INVITE_LABEL,
+  OBJECT_MEMBERSHIP_DEFAULT_TITLE,
   OBJECT_MEMBERSHIP_LABEL,
   OBJECT_MEMBERSHIP_LABEL_LOWERCASE,
   OBJECT_NAME_SINGULAR,
@@ -30,7 +31,9 @@ type Invite = {
 
 export default function InviteCard({ club }: InviteCardProps): ReactElement {
   const [invites, setInvites] = useState<Invite[]>([])
-  const [inviteTitle, setInviteTitle] = useState<string>('Member')
+  const [inviteTitle, setInviteTitle] = useState<string>(
+    OBJECT_MEMBERSHIP_DEFAULT_TITLE,
+  )
   const [inviteRole, setInviteRole] = useState<MembershipRole>(
     () =>
       MEMBERSHIP_ROLES.find(({ value }) => value in MEMBERSHIP_ROLE_NAMES) ??

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -12,7 +12,7 @@ import { BG_GRADIENT, CLUBS_BLUE, WHITE } from '../constants/colors'
 import { BORDER_RADIUS } from '../constants/measurements'
 import renderPage from '../renderPage'
 import { UserInfo } from '../types'
-import { OBJECT_NAME_TITLE } from '../utils/branding'
+import { OBJECT_NAME_TITLE, SHOW_MEMBERSHIP_REQUEST } from '../utils/branding'
 
 const Notification = styled.span`
   border-radius: ${BORDER_RADIUS};
@@ -73,6 +73,7 @@ const Settings = ({ userInfo, authenticated }: SettingsProps) => {
       name: 'Requests',
       icon: 'user-check',
       content: <MembershipRequestsTab />,
+      disabled: !SHOW_MEMBERSHIP_REQUEST,
     },
     {
       name: 'Profile',

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -61,6 +61,7 @@ const sites = {
       'You will need to at least specify either the Undergraduate or Graduate tag.',
     FORM_LOGO_DESCRIPTION:
       'Changing this field will require reapproval from the Office of Student Affairs.',
+    OBJECT_MEMBERSHIP_DEFAULT_TITLE: 'Member',
 
     PARTNER_LOGOS: [
       {
@@ -145,6 +146,7 @@ const sites = {
     FORM_TAG_DESCRIPTION:
       'Tags will allow students to find your resource while filtering Hub@Penn. Select as many as apply. You will need to at least specify one tag.',
     FORM_LOGO_DESCRIPTION: 'Upload your approved Penn logo.',
+    OBJECT_MEMBERSHIP_DEFAULT_TITLE: '',
 
     PARTNER_LOGOS: [
       {
@@ -209,6 +211,8 @@ export const MEMBERSHIP_ROLE_NAMES: { [key: number]: string } =
 export const OBJECT_MEMBERSHIP_LABEL = sites[site].OBJECT_MEMBERSHIP_LABEL
 export const OBJECT_MEMBERSHIP_LABEL_LOWERCASE =
   sites[site].OBJECT_MEMBERSHIP_LABEL_LOWERCASE
+export const OBJECT_MEMBERSHIP_DEFAULT_TITLE =
+  sites[site].OBJECT_MEMBERSHIP_DEFAULT_TITLE
 
 export const PARTNER_LOGOS = sites[site].PARTNER_LOGOS
 


### PR DESCRIPTION
- Remove Requests tab from settings page for Hub@Penn
- Make only one tag required in Hub@Penn instead of either "Graduate" or "Undergraduate" tags
- Don't include rejected clubs on the directory

[ch2875]