### PR TITLE
Manually configure dependabot for both subdirectores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Manually configure dependabot for both subdirectories to keep our dependencies up to date. See details [here](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-dependabot-version-updates).

@ArmaanT thoughts on this method?