### PR TITLE
Permissions changes

### DIFF
--- a/backend/clubs/admin.py
+++ b/backend/clubs/admin.py
@@ -112,7 +112,7 @@ send_edit_reminder.short_description = "Send edit page reminder"
 
 
 def mark_approved(modeladmin, request, queryset):
-    if not request.user.has_perm("approve_club"):
+    if not request.user.has_perm("clubs.approve_club"):
         modeladmin.message_user(
             request, "You do not have permission to approve clubs!", level=messages.ERROR
         )

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1036,6 +1036,11 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
                     needs_reapproval = True
                     break
 
+        # if the editing user has approval permissions, skip the approval process
+        request = self.context.get("request", None)
+        if request and request.user.has_perm("clubs.approve_club"):
+            needs_reapproval = False
+
         has_approved_version = (
             self.instance and self.instance.history.filter(approved=True).exists()
         )

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1603,6 +1603,21 @@ class ClubTestCase(TestCase):
             club.approved = True
             club.save(update_fields=["approved"])
 
+        # login to superuser account
+        self.client.login(username=self.user5.username, password="test")
+
+        # ensure editing works with skipping approval
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(club.code,)),
+            {field: "New Club Name/Description #2"},
+            content_type="application/json",
+        )
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+
+        # ensure club is still marked as approved
+        club.refresh_from_db()
+        self.assertTrue(club.approved)
+
     def test_club_detail_endpoints_unauth(self):
         """
         Ensure that club based endpoints are not usable by unauthenticated users.


### PR DESCRIPTION
- Admins (people with approval permissions) bypass the approval process when editing clubs.
- Global permissions override per object permissions. If a user has `clubs.manage_club`, they also have `clubs.manage_club:*`. This behavior is currently not used.