### PR TITLE
Various Hub@Penn fixes

### DIFF
--- a/frontend/components/ClubEditPage/AdvisorCard.tsx
+++ b/frontend/components/ClubEditPage/AdvisorCard.tsx
@@ -33,17 +33,17 @@ export default function AdvisorCard({
     club.advisor_set.length || 0,
   )
   const updateAdvisors = (
-    newAdvisors: (Advisor & { _error_message?: string })[],
+    newAdvisors: (Advisor & { _status?: boolean; _error_message?: string })[],
   ): void => {
     let validCount = 0
     if (newAdvisors.length) {
       validCount = newAdvisors.filter(
-        (advisor) => !advisor._error_message && advisor.public,
+        (advisor) =>
+          (advisor._status || !advisor._error_message) && advisor.public,
       ).length
     }
     if (validateAdvisors) {
-      if (validCount > 0) validateAdvisors(true)
-      else validateAdvisors(false)
+      validateAdvisors(validCount > 0)
     }
     setAdvisorsCount(validCount)
   }
@@ -90,7 +90,9 @@ export default function AdvisorCard({
           fields={fields}
         />
         {SITE_ID === 'fyh' && advisorsCount <= 0 && (
-          <RequireText>At least one public contact is required*</RequireText>
+          <RequireText>
+            * At least one public point of contact is required.
+          </RequireText>
         )}
       </BaseCard>
 
@@ -100,7 +102,6 @@ export default function AdvisorCard({
           administrators.
         </Text>
         <ModelForm
-          onUpdate={updateAdvisors}
           baseUrl={`/clubs/${club.code}/advisors/`}
           listParams="&public=false"
           defaultObject={{ public: false }}

--- a/frontend/components/ClubEditPage/ClubEditCard.tsx
+++ b/frontend/components/ClubEditPage/ClubEditCard.tsx
@@ -345,6 +345,7 @@ export default function ClubEditCard({
         {
           name: 'website',
           type: 'url',
+          help: 'Ensure that your URL starts with either http:// or https://.',
         },
         {
           name: 'facebook',

--- a/frontend/components/ClubPage/RenewalRequestDialog.tsx
+++ b/frontend/components/ClubPage/RenewalRequestDialog.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react'
 
 import { CLUB_RENEW_ROUTE } from '../../constants/routes'
 import { Club, MembershipRank } from '../../types'
+import { apiCheckPermission } from '../../utils'
 import {
   MEMBERSHIP_ROLE_NAMES,
   OBJECT_NAME_SINGULAR,
@@ -22,6 +23,8 @@ type RenewalRequestProps = {
 }
 
 const RenewalRequest = ({ club }: RenewalRequestProps): ReactElement => {
+  const canRenew = apiCheckPermission(`clubs.manage_club:${club.code}`)
+
   const textMapping = {
     clubs: {
       TITLE: (
@@ -53,15 +56,22 @@ const RenewalRequest = ({ club }: RenewalRequestProps): ReactElement => {
         {text.TITLE}
       </AlertText>
       <AlertDesc>
-        {club.is_member !== false &&
-        club.is_member <= MembershipRank.Officer ? (
+        {canRenew ? (
           <>
-            <p className="mb-2">
-              You are an {MEMBERSHIP_ROLE_NAMES[club.is_member].toLowerCase()}{' '}
-              of this {OBJECT_NAME_SINGULAR}, so you can {text.PROCESS_ACTION}{' '}
-              by clicking the button below. Your {OBJECT_NAME_SINGULAR} will not
-              be queued for approval until this process is complete.
-            </p>
+            {club.is_member !== false ? (
+              <p className="mb-2">
+                You are an {MEMBERSHIP_ROLE_NAMES[club.is_member].toLowerCase()}{' '}
+                of this {OBJECT_NAME_SINGULAR}, so you can {text.PROCESS_ACTION}{' '}
+                by clicking the button below. Your {OBJECT_NAME_SINGULAR} will
+                not be queued for approval until this process is complete.
+              </p>
+            ) : (
+              <p className="mb-2">
+                Although you are not a part of this {OBJECT_NAME_SINGULAR}, you
+                have permissions to {text.PROCESS_ACTION} for this club. You can
+                do so using the button below.
+              </p>
+            )}
             <Link href={CLUB_RENEW_ROUTE()} as={CLUB_RENEW_ROUTE(club.code)}>
               <a className="button is-danger is-light">{text.BUTTON_TEXT}</a>
             </Link>

--- a/frontend/components/Footer/index.tsx
+++ b/frontend/components/Footer/index.tsx
@@ -2,6 +2,7 @@ import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import { PINK, SNOW } from '../../constants/colors'
+import { SHOW_ACCESSIBILITY } from '../../utils/branding'
 import { Icon, SmallText } from '../common'
 import Social from './Social'
 
@@ -30,6 +31,16 @@ const Footer = (): ReactElement => (
       />{' '}
       by <a href="https://pennlabs.org/">Penn Labs</a>
     </SmallText>
+    {SHOW_ACCESSIBILITY && (
+      <SmallText style={{ marginBottom: '0rem' }}>
+        <a
+          rel="noopener noreferrer"
+          href="https://accessibility.web-resources.upenn.edu/get-help"
+        >
+          Report Accessibility Issues and Get Help
+        </a>
+      </SmallText>
+    )}
     <Social />
   </Foot>
 )

--- a/frontend/components/Header/Feedback.tsx
+++ b/frontend/components/Header/Feedback.tsx
@@ -33,6 +33,7 @@ const FeedbackLink = styled.a`
 
 const Feedback = (): ReactElement => (
   <FeedbackLink
+    rel="noopener noreferrer"
     href={FEEDBACK_URL}
     title="Feedback"
     target="_blank"

--- a/frontend/components/ModelForm.tsx
+++ b/frontend/components/ModelForm.tsx
@@ -320,7 +320,7 @@ export const ModelForm = (props: ModelFormProps): ReactElement => {
         resolve({
           _status: false,
           _error_message:
-            'This object hass already been deleted and cannot be saved.',
+            'This object has already been deleted and cannot be saved.',
         })
       })
     }
@@ -349,6 +349,7 @@ export const ModelForm = (props: ModelFormProps): ReactElement => {
             .then((resp) => {
               if (resp.ok) {
                 object._status = true
+                object._error_message = null
                 return resp.json().then((resp) => {
                   Object.keys(resp).forEach((key) => {
                     object[key] = resp[key]

--- a/frontend/components/ResourceCreationPage.tsx
+++ b/frontend/components/ResourceCreationPage.tsx
@@ -321,7 +321,10 @@ const ResourceCreationPage = ({
       <div className="has-text-right">
         {step < steps.length - 1 ? (
           <button
-            onClick={nextStep}
+            onClick={() => {
+              nextStep()
+              window.scrollTo(0, 0)
+            }}
             disabled={steps[step].disabled}
             className="button is-primary"
           >

--- a/frontend/components/ResourceCreationPage.tsx
+++ b/frontend/components/ResourceCreationPage.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import React, { ReactElement, useState } from 'react'
 
-import { CLUB_ROUTE, DIRECTORY_ROUTE, SNOW } from '../constants'
+import { CLUB_ROUTE, DIRECTORY_ROUTE, RED, SNOW } from '../constants'
 import { Club, Major, School, StudentType, Tag, Year } from '../types'
 import { doApiRequest } from '../utils'
 import {
@@ -156,6 +156,9 @@ const ResourceCreationPage = ({
             student_types={studentTypes}
             onSubmit={({ message, club }): Promise<void> => {
               setClub(club ?? null)
+              if (club) {
+                message = `The initial information for this ${OBJECT_NAME_SINGULAR} has been saved. Continue with the steps below to finish the ${OBJECT_NAME_SINGULAR} creation process.`
+              }
               setMessage(message)
               return Promise.resolve(undefined)
             }}
@@ -171,7 +174,6 @@ const ResourceCreationPage = ({
             will be shown publicly on the website, while private points of
             contact will only be available to {SITE_NAME} administrators.
           </Text>
-          <Text>You should specify at least one public point of contact.</Text>
           {club !== null ? (
             <AdvisorCard validateAdvisors={validateAdvisors} club={club} />
           ) : (
@@ -184,6 +186,32 @@ const ResourceCreationPage = ({
             After you are finished with creating your {OBJECT_NAME_SINGULAR},
             press the continue button below to move on to the next step.
           </Text>
+          {club === null || !advisorsValid ? (
+            <>
+              <Text>
+                You still need to complete the following items on this page to
+                continue:
+              </Text>
+              <div className="content" style={{ color: RED }}>
+                <ul>
+                  {club === null && (
+                    <li>
+                      Filling out and submitting the basic club information
+                      form.
+                    </li>
+                  )}
+                  {!advisorsValid && (
+                    <li>Filling out at least one public point of contact.</li>
+                  )}
+                </ul>
+              </div>
+            </>
+          ) : (
+            <Text>
+              You have completed all required steps on this page. Press continue
+              to move on to the next step.
+            </Text>
+          )}
           <Text>
             Your {OBJECT_NAME_SINGULAR} will not be submitted for approval until
             you complete all steps of the {OBJECT_NAME_SINGULAR} creation

--- a/frontend/pages/club/[club]/index.tsx
+++ b/frontend/pages/club/[club]/index.tsx
@@ -17,7 +17,7 @@ import Header from '../../../components/ClubPage/Header'
 import InfoBox from '../../../components/ClubPage/InfoBox'
 import MemberList from '../../../components/ClubPage/MemberList'
 import QuestionList from '../../../components/ClubPage/QuestionList'
-import RenewalRequest from '../../../components/ClubPage/RenewalRequest'
+import RenewalRequest from '../../../components/ClubPage/RenewalRequestDialog'
 import SocialIcons from '../../../components/ClubPage/SocialIcons'
 import Testimonials from '../../../components/ClubPage/Testimonials'
 import {

--- a/frontend/pages/club/[club]/renew.tsx
+++ b/frontend/pages/club/[club]/renew.tsx
@@ -161,10 +161,6 @@ const PolicyBox = ({ onChecked = () => undefined }: Props): ReactElement => {
 }
 
 const RenewPage = (props: RenewPageProps): ReactElement => {
-  if (SITE_ID === 'fyh') {
-    return <ResourceCreationPage {...props} />
-  }
-
   const {
     club: initialClub,
     authenticated,
@@ -186,6 +182,8 @@ const RenewPage = (props: RenewPageProps): ReactElement => {
   const [isSacChecked, setSacChecked] = useState<boolean>(club.fair)
   const isFairOpen = useSetting('FAIR_REGISTRATION_OPEN')
 
+  const hasPermission = apiCheckPermission(`clubs.manage_club:${club.code}`)
+
   if (authenticated === false) {
     return <AuthPrompt />
   }
@@ -201,7 +199,7 @@ const RenewPage = (props: RenewPageProps): ReactElement => {
     )
   }
 
-  if (!apiCheckPermission(`clubs.manage_club:${club.code}`)) {
+  if (!hasPermission) {
     return (
       <AuthPrompt title="Oh no!" hasLogin={false}>
         <ClubMetadata club={club} />
@@ -218,6 +216,10 @@ const RenewPage = (props: RenewPageProps): ReactElement => {
         )}
       </AuthPrompt>
     )
+  }
+
+  if (SITE_ID === 'fyh') {
+    return <ResourceCreationPage {...props} />
   }
 
   const year = new Date().getFullYear()

--- a/frontend/pages/faq.tsx
+++ b/frontend/pages/faq.tsx
@@ -58,7 +58,13 @@ const THANKS_CONTENT = (): ReactElement => (
     <br />
     <div>
       {PARTNER_LOGOS.map(({ name, url, image, height, className }) => (
-        <a href={url} target="_blank" key={name} className={className}>
+        <a
+          href={url}
+          target="_blank"
+          key={name}
+          className={className}
+          rel="noopener noreferrer"
+        >
           <img
             style={{
               maxHeight: height || 100,
@@ -67,7 +73,6 @@ const THANKS_CONTENT = (): ReactElement => (
             }}
             src={image}
             alt={name}
-            title={name}
           />
         </a>
       ))}
@@ -96,7 +101,9 @@ const GENERIC_TEMPLATE = (data): ReactElement => (
       We're so excited to let everyone at the {SCHOOL_NAME} contribute to the
       development of {SITE_NAME}! Your feedback is incredibly important to us.
       Have any questions or comments? Find any bugs?{' '}
-      <a href={FEEDBACK_URL}>Please let us know on our feedback form.</a>
+      <a rel="noopener noreferrer" href={FEEDBACK_URL}>
+        Please let us know on our feedback form.
+      </a>
     </Question>
     <Line />
     <Question title="Why do I have to log in?">
@@ -203,7 +210,9 @@ const GENERIC_TEMPLATE = (data): ReactElement => (
       </Question>
     )}
     <Question title="I have another question!">
-      <a href={FEEDBACK_URL}>Please let us know on our feedback form :)</a>
+      <a rel="noopener noreferrer" href={FEEDBACK_URL}>
+        Please let us know on our feedback form :)
+      </a>
     </Question>
     <Line />
     {THANKS_CONTENT()}
@@ -225,7 +234,9 @@ const FAQS = {
         We're so excited to let everyone at Penn contribute to the development
         of Hub@Penn! Your feedback is incredibly important to us. Have any
         questions or comments? Find any bugs?{' '}
-        <a href={FEEDBACK_URL}>Please let us know on our feedback form.</a>
+        <a rel="noopener noreferrer" href={FEEDBACK_URL}>
+          Please let us know on our feedback form.
+        </a>
       </Question>
       <Line />
       <Question title="How do I use this site?">
@@ -282,7 +293,9 @@ const FAQS = {
         reviewed.
       </Question>
       <Question title="I have another question!">
-        <a href={FEEDBACK_URL}>Please let us know on our feedback form.</a>
+        <a rel="noopener noreferrer" href={FEEDBACK_URL}>
+          Please let us know on our feedback form.
+        </a>
       </Question>
       <Line />
       {THANKS_CONTENT()}

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -56,6 +56,7 @@ const sites = {
     SHOW_MEMBERS: true,
     SHOW_MEMBERSHIP_REQUEST: true,
     SHOW_RANK_ALGORITHM: true,
+    SHOW_ACCESSIBILITY: false,
     MEMBERSHIP_ROLE_NAMES: { 0: 'Owner', 10: 'Officer', 20: 'Member' },
     OBJECT_MEMBERSHIP_LABEL: 'Members',
     OBJECT_MEMBERSHIP_LABEL_LOWERCASE: "member's",
@@ -163,6 +164,7 @@ const sites = {
     SHOW_MEMBERS: false,
     SHOW_MEMBERSHIP_REQUEST: false,
     SHOW_RANK_ALGORITHM: false,
+    SHOW_ACCESSIBILITY: true,
     MEMBERSHIP_ROLE_NAMES: { 0: 'Owner', 10: 'Editor' },
     OBJECT_MEMBERSHIP_LABEL: 'Staff',
     OBJECT_MEMBERSHIP_LABEL_LOWERCASE: 'staff',
@@ -243,6 +245,7 @@ export const SHOW_MEMBERSHIP_REQUEST = sites[site].SHOW_MEMBERSHIP_REQUEST
 export const SHOW_RANK_ALGORITHM = sites[site].SHOW_RANK_ALGORITHM
 export const MEMBERSHIP_ROLE_NAMES: { [key: number]: string } =
   sites[site].MEMBERSHIP_ROLE_NAMES
+export const SHOW_ACCESSIBILITY = sites[site].SHOW_ACCESSIBILITY
 export const OBJECT_MEMBERSHIP_LABEL = sites[site].OBJECT_MEMBERSHIP_LABEL
 export const OBJECT_MEMBERSHIP_LABEL_LOWERCASE =
   sites[site].OBJECT_MEMBERSHIP_LABEL_LOWERCASE


### PR DESCRIPTION
- Add accessibility link in footer of Hub@Penn
- Add a warning to add "http://" or "https://" in front of the URL for websites, or the form will not work.
- Allow people who can manage the club to go through the approval process, even if they are not a member of the club (superusers can now approve).
- Add a list of clubs that are in the inactive state to the queue approval page.
- Update the wording after the initial form submission on the Hub@Penn creation page to be less confusing.
- Add the required steps to move on to the next page at the bottom of the page for the 2nd resource creation page.
- Add "noopener" and "noreferrer" to Airtable and Penn links.

[ch2923] [ch2920] [ch2913]