### PR TITLE
Remove special case in club list queryset

### DIFF
--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -62,11 +62,19 @@ class ClubPermission(permissions.BasePermission):
     Only club owners should be able to delete.
     Club owners and officers should be able to update.
     Anyone with permission should be able to create.
+
+    Anyone should be able to view, if the club is approved.
+    Otherwise, only members or people with permission should be able to view.
     """
 
     def has_object_permission(self, request, view, obj):
         if view.action in ["retrieve", "children"]:
-            return True
+            if obj.approved or obj.ghost:
+                return True
+            return request.user.is_authenticated and (
+                request.user.has_perm("clubs.see_pending_clubs")
+                or find_membership_helper(request.user, obj) is not None
+            )
 
         if not request.user.is_authenticated:
             return False

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -544,7 +544,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         if (
             self.request.user.has_perm("clubs.see_pending_clubs")
             or self.request.query_params.get("bypass", "").lower() == "true"
-            or self.action in {"retrieve", "children"}
+            or self.action not in {"list"}
         ):
             return queryset
         else:

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -546,11 +546,6 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             or self.request.query_params.get("bypass", "").lower() == "true"
         ):
             return queryset
-        elif self.request.user.is_authenticated:
-            # Show approved clubs along with clubs that the logged-in user is a member of.
-            return queryset.filter(
-                Q(approved=True) | Q(membership__person=self.request.user) | Q(ghost=True)
-            ).distinct()
         else:
             return queryset.filter(Q(approved=True) | Q(ghost=True))
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -544,6 +544,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         if (
             self.request.user.has_perm("clubs.see_pending_clubs")
             or self.request.query_params.get("bypass", "").lower() == "true"
+            or self.action in {"retrieve", "children"}
         ):
             return queryset
         else:


### PR DESCRIPTION
Removes pending clubs that a user is a member of from the club list.

Not sure if this will fix the issue, but if it's a SQLite vs postgres issue this might be the one way to check easily for it.

This PR means that club owners won't be able to see their pending clubs in the main list anymore, but they'll still see it on their user profile page.