### PR TITLE
Add guides list page

### DIFF
--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -69,7 +69,7 @@ class ClubFairPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if view.action in {"list", "retrieve", "register"}:
             return True
-        return False
+        return request.user.is_authenticated and request.user.has_perm("clubs.see_fair_status")
 
 
 class ClubPermission(permissions.BasePermission):

--- a/frontend/constants/routes.ts
+++ b/frontend/constants/routes.ts
@@ -23,6 +23,8 @@ export const DIRECTORY_ROUTE = '/directory'
 export const LIVE_EVENTS = '/events'
 export const FAIR_INFO_ROUTE = '/fair'
 export const FAIR_OFFICER_GUIDE_ROUTE = '/sacfairguide'
+export const GUIDE_ROUTE = (slug?: string): string =>
+  slug ? `/guides/${slug}` : '/guides/[page]'
 
 export const REPORT_LIST_ROUTE = '/reports'
 export const REPORT_CREATE_ROUTE = '/reports/create'

--- a/frontend/pages/guides.tsx
+++ b/frontend/pages/guides.tsx
@@ -1,0 +1,55 @@
+import fs from 'fs'
+import { NextPageContext } from 'next'
+import Link from 'next/link'
+import path from 'path'
+import { ReactElement } from 'react'
+import util from 'util'
+
+import { Container, InfoPageTitle, Metadata, Text } from '../components/common'
+import { GUIDE_ROUTE, SNOW } from '../constants'
+import renderPage from '../renderPage'
+import { SITE_NAME } from '../utils/branding'
+
+const readDirPromise = util.promisify(fs.readdir)
+
+type GuideListPageProps = {
+  guides: string[]
+}
+
+const GuideListPage = ({ guides }: GuideListPageProps): ReactElement => {
+  return (
+    <Container fullHeight background={SNOW}>
+      <Metadata title="Guide List" />
+      <InfoPageTitle>Guide List</InfoPageTitle>
+      <Text>You can find a list of guides for {SITE_NAME} on this page.</Text>
+      <div className="content">
+        <ul>
+          {guides.map((item) => (
+            <li>
+              <Link href={GUIDE_ROUTE()} as={GUIDE_ROUTE(item)}>
+                <a>{item}</a>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Container>
+  )
+}
+
+const completePage = renderPage(GuideListPage)
+const initialProps = completePage.getInitialProps
+completePage.getInitialProps = undefined
+
+export const getServerSideProps = async (
+  ctx: NextPageContext,
+): Promise<{ props: { guides: string[] } }> => {
+  const guidesDir = await readDirPromise(path.join(process.cwd(), 'markdown'))
+  const props = await (initialProps ?? (async () => ({})))(ctx)
+
+  return {
+    props: { ...props, guides: guidesDir.map((file) => file.split('.')[0]) },
+  }
+}
+
+export default completePage


### PR DESCRIPTION
- Add extremely simple list page for guides.
- Allow people with `clubs.see_fair_status` to perform edits.

![image](https://user-images.githubusercontent.com/4441174/101943536-448cd180-3bb9-11eb-92cd-6ecb29af58f1.png)
