### PR TITLE
Make backend documentation a bit nicer

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -546,7 +546,7 @@ class MembershipSerializer(ClubRouteMixin, serializers.ModelSerializer):
             "club_code", self.context["view"].kwargs.get("code")
         )
         membership = Membership.objects.filter(person=user, club__code=club_code).first()
-        if user.is_superuser:
+        if user.has_perm("clubs.manage_club"):
             return value
         if membership is None:
             raise serializers.ValidationError("You must be a member of this club to modify roles!")

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -464,6 +464,18 @@ class ClubFairViewSet(viewsets.ModelViewSet):
     """
     list:
     Return a list of ongoing and upcoming club fairs.
+
+    create:
+    Schedule a new club fair.
+
+    update:
+    Update some attributes related to an existing club fair. All fields must be specified.
+
+    partial_update:
+    Update some attributes related to an existing club fair. Only specified fields are updated.
+
+    destroy:
+    Delete a club fair.
     """
 
     permission_classes = [ClubFairPermission | IsSuperuser]
@@ -576,6 +588,9 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
     list:
     Return a list of clubs with partial information for each club.
+
+    create:
+    Add a new club record. After creation, the club will need to go through the approval process.
 
     update:
     Update all fields in the club.
@@ -1740,7 +1755,10 @@ class MembershipRequestViewSet(viewsets.ModelViewSet):
 class MembershipRequestOwnerViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     """
     list:
-    Return a list of users who have sent membership request to the club
+    Return a list of users who have sent membership request to the club.
+
+    destroy:
+    Delete a membership request for a specific user.
     """
 
     serializer_class = MembershipRequestSerializer

--- a/backend/pennclubs/doc_settings.py
+++ b/backend/pennclubs/doc_settings.py
@@ -1,0 +1,61 @@
+import json
+import re
+
+from django.conf import settings
+from rest_framework.renderers import JSONOpenAPIRenderer
+
+
+API_DESCRIPTION = """
+This is the documentation for the backend that powers the Penn Clubs and Hub@Penn websites.
+The backend is written with [Django](https://www.djangoproject.com/) and the
+[Django Rest Framework](https://www.django-rest-framework.org/).
+
+This documentation is intended to help frontend developers and external
+developers know which parameters they should be passing to various endpoints.
+There are test cases that will fail if the documentation on the API
+falls beneath a certain threshold.
+"""
+
+
+class CustomJSONOpenAPIRenderer(JSONOpenAPIRenderer):
+    def render(self, *args, **kwargs):
+        output = super().render(*args, **kwargs)
+        data = json.loads(output)
+
+        # add api level metadata
+        info = data.get("info", {})
+        info.update(
+            {
+                "x-logo": {
+                    "url": "https://i.imgur.com/tVsRNxJ.pngg",
+                    "altText": "Penn Labs Logo",
+                    "href": "https://pennlabs.org/",
+                },
+                "contact": {
+                    "name": f"{settings.BRANDING_SITE_NAME} Support",
+                    "email": re.search(r"<(.*)>", settings.FROM_EMAIL).group(1),
+                },
+                "description": API_DESCRIPTION.strip(),
+            }
+        )
+        data["info"] = info
+
+        # categorize api endpoints
+        categories = set()
+        for path in data["paths"]:
+            category = re.match(r"/api/(.*?)/", path).group(1).replace("_", " ").title()
+            categories.add(category)
+
+            for key in data["paths"][path]:
+                oper_id = data["paths"][path][key]["operationId"]
+                data["paths"][path][key]["operationId"] = re.sub(
+                    r"([A-Z])", r" \1", oper_id
+                ).title()
+                data["paths"][path][key]["tags"] = [category]
+
+        # order tag groups
+        categories = list(sorted(categories))
+        data["tags"] = [{"name": cat, "description": ""} for cat in categories]
+        data["x-tagGroups"] = [{"name": settings.BRANDING_SITE_NAME, "tags": categories}]
+
+        return json.dumps(data, indent=4 if settings.DEBUG else None).encode("utf-8")

--- a/backend/pennclubs/urls.py
+++ b/backend/pennclubs/urls.py
@@ -5,6 +5,8 @@ from django.urls import include, path
 from django.views.generic import TemplateView
 from rest_framework.schemas import get_schema_view
 
+from .doc_settings import CustomJSONOpenAPIRenderer
+
 
 admin.site.site_header = "Clubs Backend Admin"
 
@@ -25,7 +27,11 @@ urlpatterns = [
     path("accounts/", include("accounts.urls", namespace="accounts")),
     path(
         "openapi/",
-        get_schema_view(title="Penn Clubs Documentation", public=True),
+        get_schema_view(
+            title="Penn Clubs Documentation",
+            public=True,
+            renderer_classes=[CustomJSONOpenAPIRenderer],
+        ),
         name="openapi-schema",
     ),
     path(

--- a/backend/templates/redoc.html
+++ b/backend/templates/redoc.html
@@ -5,6 +5,7 @@
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="https://pennlabs.org/icons/icon-48x48.png">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
     <!-- ReDoc doesn't change outer page styles -->
     <style>

--- a/backend/tests/clubs/test_admin.py
+++ b/backend/tests/clubs/test_admin.py
@@ -79,13 +79,15 @@ class AdminTestCase(TestCase):
 
         # ensure that a certain percentage of the api is documented
         percent_missing = len(missing_descriptions) / total_routes
-        required_percent = 0.25
-        if percent_missing > required_percent:
+        required_percent = 0.75
+        if (1 - percent_missing) < required_percent:
             formatted_missing = "\n".join("\t{1} {0}".format(*x) for x in missing_descriptions)
             self.fail(
-                "Too many endpoints missing API descriptions ({}% > {}%):\n{}".format(
-                    round(percent_missing * 100, 2),
-                    round(required_percent * 100, 2),
-                    formatted_missing,
-                )
+                "Too many endpoints are missing API descriptions "
+                f"({(1 - percent_missing):.2%} < minimum {required_percent:.2%}):\n\n"
+                f"{formatted_missing}"
+                f"\n\nThis is an automated test to ensure that at least {required_percent:.2%} of "
+                "the Penn Clubs API is properly documented. \n"
+                "If you are below this threshold, please add some descriptions to the new routes "
+                "that you have added. \nYou can do this by adding a docstring to your ViewSet.",
             )

--- a/backend/tests/clubs/test_commands.py
+++ b/backend/tests/clubs/test_commands.py
@@ -1,3 +1,8 @@
+"""
+Test management commands that are under the clubs app here.
+These management commands can be executed with "./manage.py <command>".
+"""
+
 import csv
 import datetime
 import os

--- a/backend/tests/clubs/test_models.py
+++ b/backend/tests/clubs/test_models.py
@@ -1,3 +1,7 @@
+"""
+Test cases related to models and their fields in the clubs models.py.
+"""
+
 import datetime
 
 import pytz


### PR DESCRIPTION
- Add metadata and images.
- Categorize endpoints roughly based on the URL.
- Convert camel case to title case.

![image](https://user-images.githubusercontent.com/4441174/102668531-1fb8d100-415a-11eb-9b0a-474562591a49.png)