### PR TITLE
Add lots of backend documentation

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -317,8 +317,10 @@ class Club(models.Model):
                             if urls:
                                 ev.url = urls[0]
 
-                        # extract url from location
-                        if ev.location:
+                        # extract url from url or location
+                        if event.url:
+                            ev.url = event.url
+                        elif ev.location:
                             location_urls = extractor.find_urls(ev.location)
                             if location_urls:
                                 ev.url = location_urls[0]

--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -6,6 +6,7 @@ from clubs.views import (
     AdvisorViewSet,
     AssetViewSet,
     BadgeViewSet,
+    ClubEventViewSet,
     ClubFairViewSet,
     ClubViewSet,
     ClubVisitViewSet,
@@ -62,7 +63,7 @@ router.register(r"users", UserViewSet, basename="users")
 
 clubs_router = routers.NestedSimpleRouter(router, r"clubs", lookup="club")
 clubs_router.register(r"members", MemberViewSet, basename="club-members")
-clubs_router.register(r"events", EventViewSet, basename="club-events")
+clubs_router.register(r"events", ClubEventViewSet, basename="club-events")
 clubs_router.register(r"invites", MemberInviteViewSet, basename="club-invites")
 clubs_router.register(r"assets", AssetViewSet, basename="club-assets")
 clubs_router.register(r"notes", NoteViewSet, basename="club-notes")

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -491,6 +491,41 @@ class ClubFairViewSet(viewsets.ModelViewSet):
         Register a club for this club fair.
         Pass in a "club" string parameter with the club code
         and a "status" parameter that is true to register the club, or false to unregister.
+        ---
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        properties:
+                            status:
+                                type: boolean
+                                description: >
+                                    Whether to register or unregister this club for the fair.
+                                    By default, the endpoint will attempt to register the club.
+                            club:
+                                type: string
+                                description: The code of the club that you are trying to register.
+                            answers:
+                                type: array
+                                description: >
+                                    The answers to the required fair questions.
+                                    Each element in the array is an answer to a fair question,
+                                    in the same order of the related fair questions.
+                        required:
+                            - club
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                success:
+                                    type: boolean
+                                    description: Whether or not this club has been registered.
+                                message:
+                                    type: string
+                                    description: A success or error message.
+        ---
         """
         fair = self.get_object()
 
@@ -689,6 +724,35 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         Upload the club logo.
         Marks the club as pending approval since the logo has changed.
         Also create a thumbnail version of the club logo.
+        ---
+        requestBody:
+            content:
+                multipart/form-data:
+                    schema:
+                        type: object
+                        properties:
+                            file:
+                                type: object
+                                format: binary
+        responses:
+            "200":
+                description: Returned if the file was successfully uploaded.
+                content: &upload_resp
+                    application/json:
+                        schema:
+                            properties:
+                                detail:
+                                    type: string
+                                    description: The status of the file upload.
+                                url:
+                                    type: string
+                                    description: >
+                                        The URL of the newly uploaded file.
+                                        Only exists if the file was successfully uploaded.
+            "400":
+                description: Returned if there was an error while uploading the file.
+                content: *upload_resp
+        ---
         """
         # ensure user is allowed to upload image
         club = self.get_object()
@@ -714,6 +778,35 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def upload_file(self, request, *args, **kwargs):
         """
         Upload a file for the club.
+        ---
+        requestBody:
+            content:
+                multipart/form-data:
+                    schema:
+                        type: object
+                        properties:
+                            file:
+                                type: object
+                                format: binary
+        responses:
+            "200":
+                description: Returned if the file was successfully uploaded.
+                content: &upload_resp
+                    application/json:
+                        schema:
+                            properties:
+                                detail:
+                                    type: string
+                                    description: The status of the file upload.
+                                url:
+                                    type: string
+                                    description: >
+                                        The URL of the newly uploaded file.
+                                        Only exists if the file was successfully uploaded.
+            "400":
+                description: Returned if there was an error while uploading the file.
+                content: *upload_resp
+        ---
         """
         # ensure user is allowed to upload file
         club = self.get_object()
@@ -724,6 +817,23 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def children(self, request, *args, **kwargs):
         """
         Return a recursive list of all children that this club is a parent of.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                name:
+                                    type: string
+                                code:
+                                    type: string
+                                children:
+                                    type: array
+                                    description: >
+                                        An array of clubs containing the fields in this object.
+        ---
         """
         club = self.get_object()
         child_tree = find_relationship_helper("children_orgs", club, {club.code})
@@ -733,6 +843,23 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def parents(self, request, *args, **kwargs):
         """
         Return a recursive list of all parents that this club is a child to.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                name:
+                                    type: string
+                                code:
+                                    type: string
+                                children:
+                                    type: array
+                                    description: >
+                                        An array of clubs containing the fields in this object.
+        ---
         """
         club = self.get_object()
         parent_tree = find_relationship_helper("parent_orgs", club, {club.code})
@@ -753,6 +880,15 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def qr(self, request, *args, **kwargs):
         """
         Return a QR code png image representing a link to the club on Penn Clubs.
+        ---
+        responses:
+            "200":
+                description: Return a png image representing a QR code to the fair page.
+                content:
+                    image/png:
+                        schema:
+                            type: binary
+        ---
         """
         club = self.get_object()
 
@@ -792,6 +928,23 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def analytics_pie_charts(self, request, *args, **kwargs):
         """
         Returns demographic information about bookmarks and subscriptions in pie chart format.
+        ---
+        parameters:
+            - name: category
+              in: query
+              type: string
+            - name: metric
+              in: query
+              type: string
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                content:
+                                    type: array
+        ---
         """
         club = self.get_object()
         lower_bound = timezone.now() - datetime.timedelta(days=30 * 6)
@@ -824,6 +977,25 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         """
         Returns a list of all analytics (club visits, favorites,
         subscriptions) for a club.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                max:
+                                    type: integer
+                                    description: >
+                                        The maximum value among all categories.
+                                        Useful when deciding how tall a line chart should be.
+                                visits:
+                                    type: array
+                                favorites:
+                                    type: array
+                                subscriptions:
+                                    type: array
+        ---
         """
         club = self.get_object()
         group = self.request.query_params.get("group", "hour")
@@ -891,6 +1063,21 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def fetch(self, request, *args, **kwargs):
         """
         Fetch the ICS calendar events from the club's ICS calendar URL.
+        ---
+        requestBody: {}
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                success:
+                                    type: boolean
+                                    description: Whether or not events were successfully fetched.
+                                message:
+                                    type: string
+                                    description: A success or error message.
+        ---
         """
         club = self.get_object()
 
@@ -918,6 +1105,9 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def directory(self, request, *args, **kwargs):
         """
         Custom return endpoint for the directory page, allows the page to load faster.
+        ---
+        name: Club Directory List
+        ---
         """
         serializer = ClubMinimalSerializer(
             Club.objects.all().exclude(approved=False).order_by(Lower("name")), many=True
@@ -929,6 +1119,9 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         """
         A special endpoint for SAC affilaited clubs to check if
         they have uploaded a club constitution.
+        ---
+        name: List Club Constitutions
+        ---
         """
         badge = Badge.objects.filter(label="SAC").first()
         if badge:
@@ -954,6 +1147,53 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def bulk(self, request, *args, **kwargs):
         """
         An endpoint to perform certain club edit operations in bulk.
+        ---
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        properties:
+                            action:
+                                type: string
+                                description: The bulk action to perform.
+                            clubs:
+                                type: string
+                                description: >
+                                    A list of club codes, separated by
+                                    comma, newline, space, or tab.
+                            tags:
+                                type: array
+                                items:
+                                    type: object
+                                    parameters:
+                                        id:
+                                            type: number
+                            badges:
+                                type: array
+                                items:
+                                    type: object
+                                    parameters:
+                                        id:
+                                            type: number
+                        required:
+                            - action
+                            - clubs
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                success:
+                                    type: boolean
+                                    description: Whether or not this club has been registered.
+                                message:
+                                    type: string
+                                    description: A success message. Only set if operation passes.
+                                error:
+                                    type: string
+                                    description: An error message. Only set if an error occurs.
+        ---
         """
         if not request.user.is_authenticated or not request.user.has_perm("clubs.manage_club"):
             return Response({"error": "You do not have permission to perform this action."})
@@ -1066,6 +1306,18 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         The list of fields is taken from the associated serializer, with model names overriding
         the serializer names if they exist. Custom fields are also available with certain permission
         levels.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            additionalProperties:
+                                type: object
+                                additionalProperties:
+                                    type: string
+        ---
         """
         # use the title given in the models.py if it exists, fallback to the field name otherwise
         name_to_title = {}
@@ -1114,6 +1366,12 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             return AssetSerializer
         if self.action == "subscription":
             return SubscribeSerializer
+        if self.action == "directory":
+            return ClubMinimalSerializer
+        if self.action == "constitutions":
+            return ClubConstitutionSerializer
+        if self.action == "notes_about":
+            return NoteSerializer
         if self.action in {"list", "fields"}:
             if self.request is not None and (
                 self.request.accepted_renderer.format == "xlsx" or self.action == "fields"
@@ -1273,7 +1531,7 @@ class AdvisorViewSet(viewsets.ModelViewSet):
         return Advisor.objects.filter(club__code=self.kwargs.get("club_code")).order_by("name")
 
 
-class EventViewSet(viewsets.ModelViewSet):
+class ClubEventViewSet(viewsets.ModelViewSet):
     """
     list:
     Return a list of events for this club.
@@ -1303,10 +1561,96 @@ class EventViewSet(viewsets.ModelViewSet):
             return EventWriteSerializer
         return EventSerializer
 
+    def create(self, request, *args, **kwargs):
+        """
+        Do not let non-superusers create events with the FAIR type through the API.
+        """
+        type = request.data.get("type", 0)
+        if type == Event.FAIR and not self.request.user.is_superuser:
+            raise DRFValidationError(
+                detail="Approved activities fair events have already been created. "
+                "See above for events to edit, and "
+                f"please email {settings.FROM_EMAIL} if this is en error."
+            )
+
+        return super().create(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        """
+        Do not let non-superusers delete events with the FAIR type through the API.
+        """
+        event = self.get_object()
+
+        if event.type == Event.FAIR and not self.request.user.is_superuser:
+            raise DRFValidationError(
+                detail="You cannot delete activities fair events. "
+                f"If you would like to do this, email {settings.FROM_EMAIL}."
+            )
+
+        return super().destroy(request, *args, **kwargs)
+
+    def get_queryset(self):
+        qs = Event.objects.all()
+        if self.kwargs.get("club_code") is not None:
+            qs = qs.filter(club__code=self.kwargs["club_code"])
+
+        qs = qs.filter(Q(club__approved=True) | Q(club__ghost=True))
+
+        return (
+            qs.select_related("club", "creator",)
+            .prefetch_related("club__badges")
+            .order_by("start_time")
+        )
+
+
+class EventViewSet(ClubEventViewSet):
+    """
+    list:
+    Return a list of events for the entire site.
+
+    retrieve:
+    Return a single event.
+
+    destroy:
+    Delete an event.
+    """
+
+    def get_operation_id(self, **kwargs):
+        return f"{kwargs['operId']} (Global)"
+
     @action(detail=True, methods=["post"])
     def upload(self, request, *args, **kwargs):
         """
         Upload a picture for the event.
+        ---
+        requestBody:
+            content:
+                multipart/form-data:
+                    schema:
+                        type: object
+                        properties:
+                            file:
+                                type: object
+                                format: binary
+        responses:
+            "200":
+                description: Returned if the file was successfully uploaded.
+                content: &upload_resp
+                    application/json:
+                        schema:
+                            properties:
+                                detail:
+                                    type: string
+                                    description: The status of the file upload.
+                                url:
+                                    type: string
+                                    description: >
+                                        The URL of the newly uploaded file.
+                                        Only exists if the file was successfully uploaded.
+            "400":
+                description: Returned if there was an error while uploading the file.
+                content: *upload_resp
+        ---
         """
         event = Event.objects.get(id=kwargs["id"])
         self.check_object_permissions(request, event)
@@ -1325,6 +1669,47 @@ class EventViewSet(viewsets.ModelViewSet):
         Get the minimal information required for a fair directory listing.
         Groups by the start date of the event, and then the event category.
         Each event's club must have an associated fair badge in order to be displayed.
+        ---
+        parameters:
+            - name: date
+              in: query
+              required: false
+              description: >
+                A date in YYYY-MM-DD format.
+                If specified, will preview how this endpoint looked on the specified date.
+              type: string
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                type: object
+                                properties:
+                                    start_time:
+                                        type: string
+                                        format: date-time
+                                    end_time:
+                                        type: string
+                                        format: date-time
+                                    events:
+                                        type: array
+                                        items:
+                                            type: object
+                                            properties:
+                                                category:
+                                                    type: string
+                                                events:
+                                                    type: array
+                                                    items:
+                                                        type: object
+                                                        properties:
+                                                            name:
+                                                                type: string
+                                                            code:
+                                                                type: string
+        ---
         """
         # accept custom date for preview rendering
         date = request.query_params.get("date")
@@ -1397,47 +1782,6 @@ class EventViewSet(viewsets.ModelViewSet):
         )
 
         return Response(EventSerializer(events, many=True).data)
-
-    def create(self, request, *args, **kwargs):
-        """
-        Do not let non-superusers create events with the FAIR type through the API.
-        """
-        type = request.data.get("type", 0)
-        if type == Event.FAIR and not self.request.user.is_superuser:
-            raise DRFValidationError(
-                detail="Approved activities fair events have already been created. "
-                "See above for events to edit, and "
-                f"please email {settings.FROM_EMAIL} if this is en error."
-            )
-
-        return super().create(request, *args, **kwargs)
-
-    def destroy(self, request, *args, **kwargs):
-        """
-        Do not let non-superusers delete events with the FAIR type through the API.
-        """
-        event = self.get_object()
-
-        if event.type == Event.FAIR and not self.request.user.is_superuser:
-            raise DRFValidationError(
-                detail="You cannot delete activities fair events. "
-                f"If you would like to do this, email {settings.FROM_EMAIL}."
-            )
-
-        return super().destroy(request, *args, **kwargs)
-
-    def get_queryset(self):
-        qs = Event.objects.all()
-        if self.kwargs.get("club_code") is not None:
-            qs = qs.filter(club__code=self.kwargs["club_code"])
-
-        qs = qs.filter(Q(club__approved=True) | Q(club__ghost=True))
-
-        return (
-            qs.select_related("club", "creator",)
-            .prefetch_related("club__badges")
-            .order_by("start_time")
-        )
 
 
 class TestimonialViewSet(viewsets.ModelViewSet):
@@ -1597,6 +1941,9 @@ class UserUUIDAPIView(generics.RetrieveAPIView):
     permission_classes = [IsAuthenticated]
     http_method_names = ["get"]
 
+    def get_operation_id(self, **kwargs):
+        return "Retrieve Calendar Url"
+
     def get_object(self):
         user = self.request.user
         return user
@@ -1728,6 +2075,22 @@ class MembershipRequestOwnerViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"])
     def accept(self, request, *ages, **kwargs):
+        """
+        Accept a membership request as a club officer.
+        ---
+        requestBody: {}
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                success:
+                                    type: boolean
+                                    description: >
+                                        Whether or not this request was successfully accepted.
+        ---
+        """
         request_object = self.get_object()
         Membership.objects.create(person=request_object.person, club=request_object.club)
         request_object.delete()
@@ -1876,11 +2239,19 @@ class BadgeViewSet(viewsets.ModelViewSet):
 
 
 class FavoriteCalendarAPIView(APIView):
-    """
-        get: Return a .ics file of the user's favorite clubs' events.
-    """
-
     def get(self, request, *args, **kwargs):
+        """
+        Return a .ics file of the user's favorite club events.
+        ---
+        responses:
+            "200":
+                description: Return a calendar file in ICS format.
+                content:
+                    text/calendar:
+                        schema:
+                            type: string
+        ---
+        """
         calendar = ICSCal(creator=f"{settings.BRANDING_SITE_NAME} ({settings.DOMAIN})")
         calendar.extra.append(
             ICSParse.ContentLine(name="X-WR-CALNAME", value=f"{settings.BRANDING_SITE_NAME} Events")
@@ -2372,6 +2743,11 @@ class UserUpdateAPIView(generics.RetrieveUpdateAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = UserSerializer
 
+    def get_operation_id(self, **kwargs):
+        if kwargs["action"] == "get":
+            return "Retrieve Self User"
+        return None
+
     def get_object(self):
         user = self.request.user
         prefetch_related_objects(
@@ -2396,10 +2772,26 @@ class MemberInviteViewSet(viewsets.ModelViewSet):
     serializer_class = MembershipInviteSerializer
     http_method_names = ["get", "put", "patch", "delete"]
 
+    def get_operation_id(self, **kwargs):
+        if kwargs["action"] == "resend":
+            return f"{kwargs['operId']} ({kwargs['method']})"
+        return None
+
     @action(detail=True, methods=["put", "patch"])
     def resend(self, request, *args, **kwargs):
         """
         Resend an email invitation that has already been issued.
+        ---
+        requestBody: {}
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            detail:
+                                type: string
+                                description: A success or error message.
+        ---
         """
         invite = self.get_object()
         invite.send_mail(request)
@@ -2588,12 +2980,21 @@ class EmailPreviewContext(dict):
 
 
 class OptionListView(APIView):
-    """
-    Return a list of options, with some options dynamically generated.
-    This response is intended for site-wide global variables.
-    """
-
     def get(self, request):
+        """
+        Return a list of options, with some options dynamically generated.
+        This response is intended for site-wide global variables.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            additionalProperties:
+                                type: string
+        ---
+        """
         # compute base django options
         options = {k: v for k, v in Option.objects.filter(public=True).values_list("key", "value")}
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1910,10 +1910,19 @@ class FavoriteCalendarAPIView(APIView):
             )
 
             # put url in location if location does not exist, otherwise put url in body
-            e.location = event.location or event.url
+            if event.location:
+                e.location = event.location
+            else:
+                e.location = event.url
+            e.url = event.url
             e.description = "{}\n\n{}".format(
                 event.url or "" if not event.location else "", html_to_text(event.description)
             ).strip()
+            e.uid = f"{event.ics_uuid}@{settings.DOMAIN}"
+            e.created = event.created_at
+            e.last_modified = event.updated_at
+            e.categories = [event.club.name]
+
             calendar.events.add(e)
 
         response = HttpResponse(calendar, content_type="text/calendar")

--- a/backend/pennclubs/doc_settings.py
+++ b/backend/pennclubs/doc_settings.py
@@ -3,6 +3,8 @@ import re
 
 from django.conf import settings
 from rest_framework.renderers import JSONOpenAPIRenderer
+from rest_framework.schemas.openapi import AutoSchema
+from rest_framework.utils.formatting import dedent
 
 
 API_DESCRIPTION = """
@@ -17,7 +19,25 @@ falls beneath a certain threshold.
 """
 
 
+class CustomAutoSchema(AutoSchema):
+    """
+    A custom schema to parse documentation from the docstrings of the view, if applicable.
+    """
+
+    def get_operation(self, path, method):
+        output = super().get_operation(path, method)
+        method_name = getattr(self.view, "action", method.lower())
+        docstring = getattr(self.view, method_name, None).__doc__
+        if docstring:
+            docstring = dedent(docstring)
+        return output
+
+
 class CustomJSONOpenAPIRenderer(JSONOpenAPIRenderer):
+    """
+    A custom renderer to add API level metadata to the documentation.
+    """
+
     def render(self, *args, **kwargs):
         output = super().render(*args, **kwargs)
         data = json.loads(output)

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -151,7 +151,8 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.JSONRenderer",
         "rest_framework.renderers.BrowsableAPIRenderer",
         "drf_renderer_xlsx.renderers.XLSXRenderer",
-    )
+    ),
+    "DEFAULT_SCHEMA_CLASS": "pennclubs.doc_settings.CustomAutoSchema",
 }
 
 

--- a/backend/pennclubs/urls.py
+++ b/backend/pennclubs/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     path(
         "openapi/",
         get_schema_view(
-            title="Penn Clubs Documentation",
+            title=f"{settings.BRANDING_SITE_NAME} Documentation",
             public=True,
             renderer_classes=[CustomJSONOpenAPIRenderer],
         ),

--- a/backend/tests/clubs/test_admin.py
+++ b/backend/tests/clubs/test_admin.py
@@ -1,4 +1,3 @@
-import yaml
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -45,49 +44,3 @@ class AdminTestCase(TestCase):
         ]:
             resp = self.client.get(reverse(page))
             self.assertIn(resp.status_code, [200], resp.content)
-
-    def test_openapi_docs(self):
-        """
-        Ensure that openapi schema can be generated correctly.
-        """
-        # test unauthenticated schema
-        resp = self.client.get(reverse("openapi-schema"))
-        self.assertIn(resp.status_code, [200], resp.content)
-
-        # test normal user schema
-        self.client.login(username=self.user2.username, password="test")
-        resp = self.client.get(reverse("openapi-schema"))
-        self.assertIn(resp.status_code, [200], resp.content)
-
-        # test superuser schema
-        self.client.login(username=self.user1.username, password="test")
-        resp = self.client.get(reverse("openapi-schema"))
-        self.assertIn(resp.status_code, [200], resp.content)
-
-        # test to ensure schema is parsable
-        docs = yaml.safe_load(resp.content)
-
-        total_routes = 0
-        missing_descriptions = []
-
-        for path in docs["paths"]:
-            for method in docs["paths"][path]:
-                total_routes += 1
-                description = docs["paths"][path][method]["description"]
-                if not description:
-                    missing_descriptions.append((path, method))
-
-        # ensure that a certain percentage of the api is documented
-        percent_missing = len(missing_descriptions) / total_routes
-        required_percent = 0.75
-        if (1 - percent_missing) < required_percent:
-            formatted_missing = "\n".join("\t{1} {0}".format(*x) for x in missing_descriptions)
-            self.fail(
-                "Too many endpoints are missing API descriptions "
-                f"({(1 - percent_missing):.2%} < minimum {required_percent:.2%}):\n\n"
-                f"{formatted_missing}"
-                f"\n\nThis is an automated test to ensure that at least {required_percent:.2%} of "
-                "the Penn Clubs API is properly documented. \n"
-                "If you are below this threshold, please add some descriptions to the new routes "
-                "that you have added. \nYou can do this by adding a docstring to your ViewSet.",
-            )

--- a/backend/tests/clubs/test_documentation.py
+++ b/backend/tests/clubs/test_documentation.py
@@ -1,0 +1,135 @@
+import ast
+
+import yaml
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from pennclubs.doc_settings import CustomAutoSchema
+
+from .test_security import all_viewset_actions
+
+
+class DocumentationTestCase(TestCase):
+    """
+    Test cases related to ensuring that we have an appropriate amount of backend documentation.
+    """
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_action_parameter_response(self):
+        """
+        Ensure that all actions on viewsets have proper parameters and responses.
+        """
+        # don't add your action to the whitelist unless it returns what the base ModelViewSet
+        # returns and does not accept any additional parameters
+        whitelist = set(
+            [
+                ("ClubViewSet", "constitutions"),
+                ("ClubViewSet", "directory"),
+                ("ClubViewSet", "notes_about"),
+                ("ClubViewSet", "subscription"),
+                ("EventViewSet", "owned"),
+            ]
+        )
+
+        all_cases = set()
+        failed_cases = []
+        for name, obj, node in all_viewset_actions():
+            docs = ast.get_docstring(node)
+            desc, meta = CustomAutoSchema.parse_docstring(docs)
+            all_cases.add((name, node.name))
+            if not desc:
+                failed_cases.append((name, node.name, "missing description"))
+            elif not meta:
+                failed_cases.append((name, node.name, "missing"))
+            elif "requestBody" not in meta:
+                # if not a GET request, the body should be specified
+                if any(
+                    kw.arg == "methods"
+                    and "get" not in [elt.value.lower() for elt in kw.value.elts]
+                    for n in node.decorator_list
+                    for kw in n.keywords
+                ):
+                    failed_cases.append((name, node.name, "missing requestBody"))
+            elif "responses" not in meta:
+                failed_cases.append((name, node.name, "missing responses"))
+
+        failed_cases = [c for c in failed_cases if (c[0], c[1]) not in whitelist]
+
+        if failed_cases:
+            failed_cases_str = "\n".join(
+                f"\t- {cls_name} -> {name} ({status})" for cls_name, name, status in failed_cases
+            )
+            self.fail(
+                "Found one or more action methods on viewsets that do not have YAML "
+                "documentation specified in the docstring. \n"
+                "It is very rare that the action will have the exact same parameters and "
+                "return format as the base ModelViewSet. \n"
+                "DRF cannot detect the parameters and response format for you in these cases, "
+                "you must manually specify them."
+                "\n\n"
+                f"{failed_cases_str}"
+                "\n\n"
+                "To do this, add a YAML OpenAPI string to your docstring surrounded by two "
+                "lines with '---' as their only contents. \n"
+                "You can check out existing examples throughout the codebase "
+                "or in the /api/openapi endpoint."
+            )
+
+        if whitelist - all_cases:
+            missing_str = "\n".join(
+                f"\t- {cls_name} -> {name}" for cls_name, name in whitelist - good_cases
+            )
+            self.fail(
+                "Found one or more whitelist entries that do not exist in the views anymore. "
+                "Remove these entries in order to keep the codebase clean."
+                "\n\n"
+                f"{missing_str}"
+            )
+
+    def test_openapi_docs(self):
+        """
+        Ensure that openapi schema can be generated correctly.
+        """
+        # test unauthenticated schema
+        resp = self.client.get(reverse("openapi-schema"))
+        self.assertIn(resp.status_code, [200], resp.content)
+
+        # test normal user schema
+        self.client.login(username=self.user2.username, password="test")
+        resp = self.client.get(reverse("openapi-schema"))
+        self.assertIn(resp.status_code, [200], resp.content)
+
+        # test superuser schema
+        self.client.login(username=self.user1.username, password="test")
+        resp = self.client.get(reverse("openapi-schema"))
+        self.assertIn(resp.status_code, [200], resp.content)
+
+        # test to ensure schema is parsable
+        docs = yaml.safe_load(resp.content)
+
+        total_routes = 0
+        missing_descriptions = []
+
+        for path in docs["paths"]:
+            for method in docs["paths"][path]:
+                total_routes += 1
+                description = docs["paths"][path][method]["description"]
+                if not description:
+                    missing_descriptions.append((path, method))
+
+        # ensure that a certain percentage of the api is documented
+        percent_missing = len(missing_descriptions) / total_routes
+        required_percent = 0.75
+        if (1 - percent_missing) < required_percent:
+            formatted_missing = "\n".join("\t{1} {0}".format(*x) for x in missing_descriptions)
+            self.fail(
+                "Too many endpoints are missing API descriptions "
+                f"({(1 - percent_missing):.2%} < minimum {required_percent:.2%}):\n\n"
+                f"{formatted_missing}"
+                f"\n\nThis is an automated test to ensure that at least {required_percent:.2%} of "
+                "the Penn Clubs API is properly documented. \n"
+                "If you are below this threshold, please add some descriptions to the new routes "
+                "that you have added. \nYou can do this by adding a docstring to your ViewSet.",
+            )


### PR DESCRIPTION
- Add a method to add OpenAPI specification using docstrings using YAML.
- Apply this method to all of the `@detail` endpoints.
- Add a test to ensure that all `@detail` endpoints have appropriate documentation.
- Ensure that there are no `operationId` conflicts.
- Fix ICS, populate and accept more fields such as uuid, creation/modified time, and url.

[ch2967]