### PR TITLE
Improve search and events page on mobile

### DIFF
--- a/frontend/components/SearchBar.tsx
+++ b/frontend/components/SearchBar.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 
 import {
   ALLBIRDS_GRAY,
+  BLACK_ALPHA,
   CLUBS_GREY,
   FOCUS_GRAY,
   H1_TEXT,
@@ -21,25 +22,13 @@ import {
   FULL_NAV_HEIGHT,
   MD,
   mediaMaxWidth,
-  mediaMinWidth,
   NAV_HEIGHT,
-  SEARCH_BAR_MOBILE_HEIGHT,
 } from '../constants/measurements'
 import { BODY_FONT } from '../constants/styles'
 import { Icon } from './common'
 import DropdownFilter, { FilterHeader, SelectableTag } from './DropdownFilter'
 import FilterSearch, { FuseTag } from './FilterSearch'
 import OrderInput from './OrderInput'
-
-const MobileSearchBarSpacer = styled.div`
-  display: block;
-  width: 100%;
-  height: ${SEARCH_BAR_MOBILE_HEIGHT};
-
-  ${mediaMinWidth(MD)} {
-    display: none !important;
-  }
-`
 
 export const SearchbarRightContainer = styled.div`
   width: 80vw;
@@ -63,6 +52,7 @@ const Wrapper = styled.div`
   color: ${H1_TEXT};
 
   ${mediaMaxWidth(MD)} {
+    padding-top: 0px !important;
     position: relative;
     height: auto;
     overflow: visible;
@@ -79,7 +69,7 @@ const SearchWrapper = styled.div`
   }
 `
 
-const Content = styled.div`
+const Content = styled.div<{ show?: boolean }>`
   padding: 36px 17px 12px 17px;
   width: 100%;
 
@@ -87,7 +77,12 @@ const Content = styled.div`
     display: none;
   }
 
+  .mobile-only {
+    display: none;
+  }
+
   ${mediaMaxWidth(MD)} {
+    display: ${({ show }) => (show ? 'block' : 'none')};
     overflow-x: hidden;
     width: 100%;
     margin: 0;
@@ -97,6 +92,27 @@ const Content = styled.div`
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.075);
     background: ${WHITE};
     top: ${NAV_HEIGHT};
+
+    .mobile-only {
+      display: block;
+    }
+  }
+`
+
+const MobileToggle = styled.button`
+  display: none;
+  ${mediaMaxWidth(MD)} {
+    z-index: 999;
+    display: block;
+    position: fixed;
+    top: ${NAV_HEIGHT};
+    right: 16px;
+    background-color: ${WHITE};
+    padding: 5px 8px;
+    border-radius: 0 0 5px 5px;
+    border: 1px solid ${BLACK_ALPHA(0.1)};
+    border-top: 0;
+    cursor: pointer;
   }
 `
 
@@ -472,6 +488,7 @@ const SearchBar = ({
   children,
 }: SearchBarProps): ReactElement => {
   const [scrollAmount, setScrollAmount] = useState<number>(0)
+  const [mobileShow, setMobileShow] = useState<boolean>(false)
 
   useEffect(() => {
     const onScroll = () => {
@@ -489,16 +506,46 @@ const SearchBar = ({
   return (
     <>
       <Wrapper style={{ paddingTop: `${scrollAmount}rem` }}>
-        <Content>
+        <Content show={mobileShow}>
           <SearchBarValueContext.Provider value={searchInput}>
             <SearchBarContext.Provider value={updateSearch}>
               {children}
             </SearchBarContext.Provider>
           </SearchBarValueContext.Provider>
+          <div className="has-text-centered mobile-only">
+            <button
+              type="button"
+              className="button is-light is-small"
+              onClick={(e) => {
+                e.preventDefault()
+                setMobileShow(false)
+              }}
+              onKeyPress={(e) => {
+                if (e.code === 'Space' || e.code === 'Enter') {
+                  e.preventDefault()
+                  setMobileShow(false)
+                }
+              }}
+            >
+              Hide Menu
+            </button>
+          </div>
         </Content>
+        <MobileToggle
+          onClick={(e) => {
+            e.preventDefault()
+            setMobileShow(true)
+          }}
+          onKeyPress={(e) => {
+            if (e.code === 'Space' || e.code === 'Enter') {
+              e.preventDefault()
+              setMobileShow(true)
+            }
+          }}
+        >
+          <Icon name="search" />
+        </MobileToggle>
       </Wrapper>
-
-      <MobileSearchBarSpacer />
     </>
   )
 }

--- a/frontend/pages/events.tsx
+++ b/frontend/pages/events.tsx
@@ -41,6 +41,8 @@ import {
   CLUBS_GREY_LIGHT,
   EVENT_TYPE_COLORS,
   FULL_NAV_HEIGHT,
+  MD,
+  mediaMaxWidth,
   SNOW,
 } from '../constants'
 import renderPage from '../renderPage'
@@ -63,6 +65,12 @@ const CardList = styled.div`
     display: inline-block;
     vertical-align: top;
     width: 400px;
+  }
+
+  ${mediaMaxWidth(MD)} {
+    & .event {
+      width: 100%;
+    }
   }
 `
 
@@ -111,21 +119,20 @@ interface CalendarHeaderProps {
   views: CalendarView[]
 }
 
-const StyledHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+const StyledHeader = styled.div.attrs({ className: 'is-clearfix' })`
   margin: 20px 0;
+  & > .info {
+    float: left;
+  }
   .tools {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    float: right;
     margin: 0;
-    .view-label {
-      font-size: 18px;
-    }
+    margin-left: auto;
     & > *:not(:first-child) {
       margin-left: 20px;
+    }
+    & > div {
+      display: inline-block;
     }
   }
 `
@@ -146,7 +153,7 @@ const EventsViewToolbar = ({
   setViewOption,
   showSyncModal,
 }): ReactElement => (
-  <div style={{ display: 'flex' }}>
+  <>
     <div className="buttons has-addons mt-0 mb-0">
       <button
         id="event-view-list"
@@ -173,7 +180,7 @@ const EventsViewToolbar = ({
         <Icon name="calendar" alt="calendar view" />
       </button>
     </div>
-    <div className="buttons has-addons mt-0 mb-0 ml-5">
+    <div className="buttons has-addons mt-0 mb-0">
       <button
         onClick={() => {
           showSyncModal && showSyncModal()
@@ -183,7 +190,7 @@ const EventsViewToolbar = ({
         <Icon name="refresh" className="mr-1" /> Export
       </button>
     </div>
-  </div>
+  </>
 )
 
 /**
@@ -203,11 +210,13 @@ const CalendarHeader = ({
   ]
   return (
     <StyledHeader>
-      <Title className="title" style={{ color: CLUBS_GREY, margin: 0 }}>
-        Events
-      </Title>
+      <div className="info">
+        <Title className="title" style={{ color: CLUBS_GREY, margin: 0 }}>
+          Events
+        </Title>
+        <div>{label}</div>
+      </div>
       <div className="tools">
-        <div className="view-label">{label}</div>
         <div className="buttons has-addons mt-0 mb-0">
           <button
             className="button is-medium"
@@ -577,25 +586,16 @@ function EventPage({
                 <>
                   {!!liveEvents.length && (
                     <>
-                      <div
-                        style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                        }}
-                      >
-                        <Title
-                          className="title"
-                          style={{ color: CLUBS_GREY, marginTop: '30px' }}
-                        >
-                          Live Events
-                        </Title>
-                        <EventsViewToolbar
-                          viewOption={viewOption}
-                          setViewOption={setViewOption}
-                          showSyncModal={showSyncModal}
-                        />
-                      </div>
+                      <StyledHeader>
+                        <Title className="title info">Live Events</Title>
+                        <div className="tools">
+                          <EventsViewToolbar
+                            viewOption={viewOption}
+                            setViewOption={setViewOption}
+                            showSyncModal={showSyncModal}
+                          />
+                        </div>
+                      </StyledHeader>
                       <CardList>
                         {liveEvents.map((e) => (
                           <EventCard key={e.id} event={e} />
@@ -604,30 +604,18 @@ function EventPage({
                       <br />
                     </>
                   )}
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <Title
-                      className="title"
-                      style={{
-                        color: CLUBS_GREY,
-                        marginTop: !liveEvents.length ? '30px' : 'unset',
-                      }}
-                    >
-                      Upcoming Events
-                    </Title>
+                  <StyledHeader>
+                    <Title className="title info">Upcoming Events</Title>
                     {!liveEvents.length && (
-                      <EventsViewToolbar
-                        viewOption={viewOption}
-                        setViewOption={setViewOption}
-                        showSyncModal={showSyncModal}
-                      />
+                      <div className="tools">
+                        <EventsViewToolbar
+                          viewOption={viewOption}
+                          setViewOption={setViewOption}
+                          showSyncModal={showSyncModal}
+                        />
+                      </div>
                     )}
-                  </div>
+                  </StyledHeader>
                   <CardList>
                     {upcomingEvents.map((e) => (
                       <EventCard key={e.id} event={e} />


### PR DESCRIPTION
- Search bar has a toggle button now instead of always being on.
- Events page buttons use floats instead of flexbox, so they resize better when the screen shrinks.
- Could be improved, but makes the page more usable.

<img src="https://user-images.githubusercontent.com/4441174/103225775-b1fa6b00-48f8-11eb-9bde-aa3b283df9b4.png" width="300px" /> <img src="https://user-images.githubusercontent.com/4441174/103225793-b9ba0f80-48f8-11eb-8baa-1bb0ed718298.png" width="300px" />
![image](https://user-images.githubusercontent.com/4441174/103226093-5381bc80-48f9-11eb-8e63-85db5dad3e4b.png)
![image](https://user-images.githubusercontent.com/4441174/103226108-5b416100-48f9-11eb-937c-c0cacfe5e382.png)