### PR TITLE
Use school year instead of calendar year

### DIFF
--- a/frontend/components/ClubEditPage/RenewCard.tsx
+++ b/frontend/components/ClubEditPage/RenewCard.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react'
 
 import { CLUB_RENEW_ROUTE } from '../../constants'
 import { Club } from '../../types'
+import { getCurrentSchoolYear } from '../../utils'
 import {
   APPROVAL_AUTHORITY,
   OBJECT_NAME_SINGULAR,
@@ -15,7 +16,7 @@ type RenewCardProps = {
 }
 
 export default function RenewCard({ club }: RenewCardProps): ReactElement {
-  const year = new Date().getFullYear()
+  const year = getCurrentSchoolYear()
 
   return (
     <BaseCard title={`Renew ${OBJECT_NAME_TITLE_SINGULAR} Approval`}>

--- a/frontend/components/ClubPage/ClubApprovalDialog.tsx
+++ b/frontend/components/ClubPage/ClubApprovalDialog.tsx
@@ -4,7 +4,11 @@ import styled from 'styled-components'
 
 import { MEDIUM_GRAY } from '../../constants'
 import { Club, ClubFair, MembershipRank, UserInfo } from '../../types'
-import { apiCheckPermission, doApiRequest } from '../../utils'
+import {
+  apiCheckPermission,
+  doApiRequest,
+  getCurrentSchoolYear,
+} from '../../utils'
 import {
   APPROVAL_AUTHORITY,
   APPROVAL_AUTHORITY_URL,
@@ -42,9 +46,9 @@ type ConfirmParams = {
   message: ReactElement | string
 }
 
-const ClubApprovalDialog = ({ club, userInfo }: Props): ReactElement | null => {
+const ClubApprovalDialog = ({ club }: Props): ReactElement | null => {
   const router = useRouter()
-  const year = new Date().getFullYear()
+  const year = getCurrentSchoolYear()
   const [comment, setComment] = useState<string>(club.approved_comment || '')
   const [loading, setLoading] = useState<boolean>(false)
   const [confirmModal, setConfirmModal] = useState<ConfirmParams | null>(null)

--- a/frontend/components/ClubPage/ListRenewalDialog.tsx
+++ b/frontend/components/ClubPage/ListRenewalDialog.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { ReactElement } from 'react'
 
 import { DIRECTORY_ROUTE, USER_RENEWAL } from '../../constants'
-import { useSetting } from '../../utils'
+import { getCurrentSchoolYear } from '../../utils'
 import {
   APPROVAL_AUTHORITY,
   OBJECT_NAME_PLURAL,
@@ -12,8 +12,7 @@ import {
 } from '../../utils/branding'
 
 const ListRenewalDialog = (): ReactElement => {
-  const year = new Date().getFullYear()
-  const fairName = useSetting('FAIR_NAME')
+  const year = getCurrentSchoolYear()
 
   return (
     <div className="notification is-info is-clearfix">

--- a/frontend/components/Settings/RenewTab.tsx
+++ b/frontend/components/Settings/RenewTab.tsx
@@ -3,7 +3,7 @@ import { ReactElement, useEffect, useState } from 'react'
 
 import { CREATE_ROUTE, DIRECTORY_ROUTE } from '../../constants'
 import { UserInfo, UserMembership } from '../../types'
-import { doApiRequest } from '../../utils'
+import { doApiRequest, getCurrentSchoolYear } from '../../utils'
 import {
   APPROVAL_AUTHORITY,
   OBJECT_NAME_PLURAL,
@@ -32,7 +32,7 @@ const RenewTab = ({ className }: ClubTabProps): ReactElement => {
     return <Loading />
   }
 
-  const year = new Date().getFullYear()
+  const year = getCurrentSchoolYear()
 
   return (
     <>

--- a/frontend/pages/club/[club]/renew.tsx
+++ b/frontend/pages/club/[club]/renew.tsx
@@ -31,6 +31,7 @@ import {
 import {
   apiCheckPermission,
   doApiRequest,
+  getCurrentSchoolYear,
   isClubFieldShown,
 } from '../../../utils'
 import {
@@ -229,7 +230,7 @@ const RenewPage = (props: RenewPageProps): ReactElement => {
     return <ResourceCreationPage {...props} />
   }
 
-  const year = new Date().getFullYear()
+  const year = getCurrentSchoolYear()
 
   const steps = [
     {

--- a/frontend/pages/user/[user]/index.tsx
+++ b/frontend/pages/user/[user]/index.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../../constants'
 import renderPage from '../../../renderPage'
 import { MembershipRank, UserInfo, UserProfile } from '../../../types'
-import { doApiRequest } from '../../../utils'
+import { doApiRequest, getCurrentSchoolYear } from '../../../utils'
 import { OBJECT_NAME_PLURAL, OBJECT_NAME_TITLE } from '../../../utils/branding'
 
 type UserProfilePageProps = {
@@ -35,10 +35,7 @@ type UserProfilePageProps = {
 }
 
 const GraduationYearTag = ({ year }: { year: number | null }): ReactElement => {
-  let now = new Date().getFullYear()
-  if (new Date().getMonth() > 7) {
-    now += 1
-  }
+  const now = getCurrentSchoolYear() + 1
   if (year == null || typeof year !== 'number') {
     return <span className="tag is-light ml-1">Unknown</span>
   }

--- a/frontend/utils.tsx
+++ b/frontend/utils.tsx
@@ -360,3 +360,16 @@ export function intersperse<T, U>(
     [arr[0]],
   )
 }
+
+/**
+ * Return the starting year of the current school year that we are in.
+ * For example, if we are in Fall 2019 or Spring 2020, the current school year should be 2019.
+ */
+export function getCurrentSchoolYear(): number {
+  const now = new Date()
+  let year = now.getFullYear()
+  if (now.getMonth() < 6) {
+    year -= 1
+  }
+  return year
+}


### PR DESCRIPTION
- The approval process should be performed every school year, not every calendar year.
- Update the calculations to calculate the proper school year during a winter semester.