### PR TITLE
Add club applications frontend

### DIFF
--- a/backend/clubs/management/commands/daily_notifications.py
+++ b/backend/clubs/management/commands/daily_notifications.py
@@ -90,7 +90,8 @@ class Command(BaseCommand):
         if queued_clubs.exists():
             context = {
                 "num_clubs": queued_clubs.count(),
-                "url": f"https://{settings.DOMAIN}/renew#Queue",
+                "url": f"https://{settings.DOMAIN}/admin#queue",
+                "clubs": list(queued_clubs.order_by("name").values_list("name", flat=True)),
             }
             count = queued_clubs.count()
             send_mail_helper(

--- a/backend/clubs/management/commands/daily_notifications.py
+++ b/backend/clubs/management/commands/daily_notifications.py
@@ -74,12 +74,13 @@ class Command(BaseCommand):
             )
             return False
 
-        emails = list(group.user_set.all().values_list("email", flat=True))
+        emails = [e for e in group.user_set.all().values_list("email", flat=True) if e]
 
         if not emails:
             self.stdout.write(
                 self.style.WARNING(
-                    f"There are no users in the '{group_name}' group. No emails will be sent out."
+                    f"There are no users or no associated emails in the '{group_name}' group. "
+                    "No emails will be sent out."
                 )
             )
             return False

--- a/backend/clubs/management/commands/daily_notifications.py
+++ b/backend/clubs/management/commands/daily_notifications.py
@@ -7,32 +7,62 @@ from clubs.models import Club, send_mail_helper
 
 
 class Command(BaseCommand):
-    help = "Script that runs at 9AM each day to send out relevant notification emails."
+    help = "This script runs each morning to send out relevant notification emails."
     web_execute = True
 
     def handle(self, *args, **kwargs):
-        # send notification to OSA for clubs pending approval
+        self.send_approval_queue_reminder()
+
+    def send_approval_queue_reminder(self):
+        """
+        Send notification to approval authority for clubs awaiting approval.
+        """
         now = timezone.now()
+        group_name = "Approvers"
 
         # only send notifications if it is currently a weekday
-        if now.isoweekday() in range(1, 6):
-            # get users in group to send notification to
-            group = Group.objects.filter(name="Approvers").first()
-            if group is not None:
-                emails = list(group.user_set.all().values_list("email", flat=True))
+        if now.isoweekday() not in range(1, 6):
+            return False
 
-                # get clubs that need approval
-                queued_clubs = Club.objects.filter(active=True, approved__isnull=True)
-                if queued_clubs.exists():
-                    context = {
-                        "num_clubs": queued_clubs.count(),
-                        "url": "https://pennclubs.com/renew#Queue",
-                    }
-                    send_mail_helper(
-                        "approval_queue_reminder",
-                        "{} clubs awaiting review on {}".format(
-                            queued_clubs.count(), settings.BRANDING_SITE_NAME
-                        ),
-                        emails,
-                        context,
-                    )
+        # get users in group to send notification to
+        group = Group.objects.filter(name=group_name).first()
+        if group is None:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"There is no Django admin group named '{group_name}' in the database. "
+                    "Cannot send out approval queue notification emails!"
+                )
+            )
+            return False
+
+        emails = list(group.user_set.all().values_list("email", flat=True))
+
+        if not emails:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"There are no users in the '{group_name}' group. No emails will be sent out."
+                )
+            )
+            return False
+
+        # get clubs that need approval
+        queued_clubs = Club.objects.filter(active=True, approved__isnull=True)
+        if queued_clubs.exists():
+            context = {
+                "num_clubs": queued_clubs.count(),
+                "url": f"https://{settings.DOMAIN}/renew#Queue",
+            }
+            count = queued_clubs.count()
+            send_mail_helper(
+                "approval_queue_reminder",
+                "{} clubs awaiting review on {}".format(count, settings.BRANDING_SITE_NAME),
+                emails,
+                context,
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Sent approval queue reminder for {count} clubs to {', '.join(emails)}"
+                )
+            )
+
+        return True

--- a/backend/clubs/management/commands/populate.py
+++ b/backend/clubs/management/commands/populate.py
@@ -11,6 +11,7 @@ from clubs.models import (
     Advisor,
     Badge,
     Club,
+    ClubApplication,
     ClubFair,
     Event,
     Major,
@@ -494,6 +495,19 @@ class Command(BaseCommand):
         if created:
             contents = get_image(event_image_url)
             event.image.save("image.png", ContentFile(contents))
+
+        # create a club application
+        club = Club.objects.get(code="pppjo")
+        ClubApplication.objects.get_or_create(
+            name="Test Application",
+            club=club,
+            defaults={
+                "application_start_time": now + datetime.timedelta(days=1),
+                "application_end_time": now + datetime.timedelta(days=3),
+                "result_release_time": now + datetime.timedelta(weeks=1),
+                "external_url": "https://pennlabs.org/apply/",
+            },
+        )
 
         # 10am today
         even_base = now.replace(hour=14, minute=0, second=0, microsecond=0)

--- a/backend/clubs/management/commands/populate.py
+++ b/backend/clubs/management/commands/populate.py
@@ -159,6 +159,7 @@ you can procrastinate on the application and ultimately miss the deadline!""",
  See www.google.com for more details. Alternatively, contact example@example.com.""",
         "active": True,
         "approved": True,
+        "accepting_members": True,
         "tags": [{"name": "Professional"}, {"name": "Undergraduate"}],
     },
     {
@@ -497,12 +498,23 @@ class Command(BaseCommand):
             event.image.save("image.png", ContentFile(contents))
 
         # create a club application
+        club = Club.objects.get(code="empty-club")
+        ClubApplication.objects.get_or_create(
+            name="Test Application",
+            club=club,
+            defaults={
+                "application_start_time": now - datetime.timedelta(weeks=10),
+                "application_end_time": now - datetime.timedelta(weeks=9),
+                "result_release_time": now - datetime.timedelta(weeks=8),
+                "external_url": "https://pennclubs.com/",
+            },
+        )
         club = Club.objects.get(code="pppjo")
         ClubApplication.objects.get_or_create(
             name="Test Application",
             club=club,
             defaults={
-                "application_start_time": now + datetime.timedelta(days=1),
+                "application_start_time": now - datetime.timedelta(days=1),
                 "application_end_time": now + datetime.timedelta(days=3),
                 "result_release_time": now + datetime.timedelta(weeks=1),
                 "external_url": "https://pennlabs.org/apply/",

--- a/backend/clubs/management/commands/rank.py
+++ b/backend/clubs/management/commands/rank.py
@@ -10,11 +10,17 @@ from clubs.models import Club, ClubFair, Membership
 
 
 class Command(BaseCommand):
-    help = "Precomputes ranking information for all clubs on Penn Clubs. \
-            This script should be run periodically to keep the rankings fresh."
+    help = (
+        "Precomputes ranking information for all clubs on Penn Clubs. "
+        "This script should be run periodically approximately once per day to keep rankings fresh. "
+        "Also updates club attributes that vary depending on different events."
+    )
     web_execute = True
 
     def handle(self, *args, **kwargs):
+        self.rank()
+
+    def rank(self):
         count = 0
         for club in Club.objects.all():
             ranking = 0

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -52,6 +52,11 @@ def send_mail_helper(name, subject, emails, context):
     if not all(isinstance(email, str) for email in emails):
         raise ValueError("The to email argument must be a list of strings!")
 
+    # emulate django behavior of silently returning without recipients
+    emails = [email for email in emails if email]
+    if not emails:
+        return
+
     # load email template
     prefix = {"fyh": "fyh_emails"}.get(settings.BRANDING, "emails")
     html_content = render_to_string(f"{prefix}/{name}.html", context)

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1822,8 +1822,7 @@ class NoteTagSerializer(serializers.ModelSerializer):
         fields = ("id", "name")
 
 
-class ClubApplicationSerializer(serializers.ModelSerializer):
-    club = serializers.SlugRelatedField(queryset=Club.objects.all(), slug_field="code")
+class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
     name = serializers.SerializerMethodField("get_name")
 
     def get_name(self, obj):
@@ -1851,7 +1850,7 @@ class ClubApplicationSerializer(serializers.ModelSerializer):
     class Meta:
         model = ClubApplication
         fields = (
-            "club",
+            "id",
             "name",
             "application_start_time",
             "application_end_time",

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2987,7 +2987,7 @@ class UserViewSet(viewsets.ModelViewSet):
 
 class ClubApplicationViewSet(viewsets.ModelViewSet):
     """
-    create: Creat an application of the club.
+    create: Create an application for the club.
 
     list: Retrieve a list of applications of the club.
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3004,7 +3004,11 @@ class ClubApplicationViewSet(viewsets.ModelViewSet):
         return ClubApplicationSerializer
 
     def get_queryset(self):
-        return ClubApplication.objects.filter(club__code=self.kwargs["club_code"])
+        now = timezone.now()
+
+        return ClubApplication.objects.filter(
+            club__code=self.kwargs["club_code"], result_release_time__gte=now
+        ).order_by("application_end_time")
 
 
 class MassInviteAPIView(APIView):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -71,6 +71,7 @@ from clubs.models import (
     Tag,
     Testimonial,
     Year,
+    get_mail_type_annotation,
 )
 from clubs.permissions import (
     AssetPermission,
@@ -3124,34 +3125,6 @@ class EmailInvitesAPIView(generics.ListAPIView):
         )
 
 
-class EmailPreviewContext(dict):
-    """
-    A dict class to keep track of which variables were actually used by the template.
-    """
-
-    def __init__(self, *args, **kwargs):
-        self._called = set()
-        super().__init__(*args, **kwargs)
-
-    def __getitem__(self, k):
-        try:
-            preview = super().__getitem__(k)
-        except KeyError:
-            preview = None
-
-        if preview is None:
-            preview = "[{}]".format(k.replace("_", " ").title())
-
-        self._called.add((k, preview))
-        return preview
-
-    def __contains__(self, k):
-        return True
-
-    def get_used_variables(self):
-        return sorted(self._called)
-
-
 class OptionListView(APIView):
     def get(self, request):
         """
@@ -3335,6 +3308,38 @@ class ScriptExecutionView(APIView):
             return Response({"output": output.getvalue()})
 
 
+def get_initial_context_from_types(types):
+    """
+    Generate a sample context given the specified types.
+    """
+    # this allows for tuples to work properly
+    context = collections.OrderedDict()
+
+    for name, value in types.items():
+        is_array = value["type"] == "array"
+        if is_array:
+            value = value["items"]
+
+        if value["type"] == "string":
+            context[name] = value.get("default", f"[{name}]")
+        elif value["type"] == "number":
+            context[name] = int(value.get("default", 0))
+        elif value["type"] == "boolean":
+            context[name] = bool(value.get("default", False))
+        elif value["type"] == "object":
+            context[name] = get_initial_context_from_types(value["properties"])
+        elif value["type"] == "tuple":
+            context[name] = tuple(get_initial_context_from_types(value["properties"]).values())
+        else:
+            raise ValueError(f"Unknown email variable type '{value['type']}'!")
+
+        # if is array, duplicate value three times as a sample
+        if is_array:
+            context[name] = [context[name]] * 3
+
+    return context
+
+
 def email_preview(request):
     """
     Debug endpoint used for previewing how email templates will look.
@@ -3345,35 +3350,30 @@ def email_preview(request):
 
     email = None
     text_email = None
-    context = None
 
     if "email" in request.GET:
         email_path = os.path.basename(request.GET.get("email"))
 
         # initial values
-        initial_context = {
-            "name": "[Club Name]",
-            "sender": {"username": "[Sender Username]", "email": "[Sender Email]"},
-            "role": 0,
-        }
+        types = get_mail_type_annotation(email_path)
+        initial_context = get_initial_context_from_types(types) if types is not None else {}
 
         # set specified values
         for param, value in request.GET.items():
             if param not in {"email"}:
                 # parse non-string representations
-                if value.strip().lower() == "true":
+                if value.strip().lower() in {"true", "yes"}:
                     value = True
-                elif value.strip().lower() == "false":
+                elif value.strip().lower() in {"false", "no"}:
                     value = False
                 elif value.isdigit():
                     value = int(value)
-                elif value.startswith("{"):
+                elif value.startswith(("{", "[")):
                     value = json.loads(value)
 
                 initial_context[param] = value
 
-        context = EmailPreviewContext(initial_context)
-        email = render_to_string(f"{prefix}/{email_path}.html", context)
+        email = render_to_string(f"{prefix}/{email_path}.html", initial_context)
         text_email = html_to_text(email)
 
     return render(
@@ -3383,6 +3383,6 @@ def email_preview(request):
             "templates": email_templates,
             "email": email,
             "text_email": text_email,
-            "variables": context.get_used_variables() if context is not None else [],
+            "variables": list(sorted(initial_context.items())),
         },
     )

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3350,13 +3350,15 @@ def email_preview(request):
 
     email = None
     text_email = None
+    initial_context = {}
 
     if "email" in request.GET:
         email_path = os.path.basename(request.GET.get("email"))
 
         # initial values
         types = get_mail_type_annotation(email_path)
-        initial_context = get_initial_context_from_types(types) if types is not None else {}
+        if types is not None:
+            initial_context = get_initial_context_from_types(types)
 
         # set specified values
         for param, value in request.GET.items():

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -180,6 +180,7 @@ EDIT_URL = "https://{domain}/club/{club}/edit"
 FLYER_URL = "https://{domain}/club/{club}/flyer"
 QUESTION_URL = "https://{domain}/club/{club}/edit#questions"
 RENEWAL_URL = "https://{domain}/club/{club}/renew"
+APPLY_URL = "https://{domain}/club/{club}/apply"
 
 
 # File upload settings

--- a/backend/templates/emails/application_deadline_reminder.html
+++ b/backend/templates/emails/application_deadline_reminder.html
@@ -1,0 +1,24 @@
+<!-- TYPES:
+clubs:
+    type: array
+    items:
+        type: tuple
+        properties:
+            code:
+                type: string
+            name:
+                type: string
+-->
+{% extends 'emails/base.html' %}
+
+{% block content %}
+    <p style="font-size: 1.2em">There are {{ clubs|length }} clubs that you have subscribed to with an application deadline
+        in 3 days.</p>
+    <ul style="font-size: 1.2em">
+        {% for code, name in clubs %}
+        <li><a href="https://pennclubs.com/club/{code}/apply">{name}</a></li>
+        {% endfor %}
+    </ul>
+    <p style="font-size: 1.2em">This is an automated message. If you would not like to receive these notifications,
+        unsubscribe from the clubs that you no longer wish to hear updates from.</p>
+{% endblock %}

--- a/backend/templates/emails/application_deadline_reminder.html
+++ b/backend/templates/emails/application_deadline_reminder.html
@@ -12,8 +12,9 @@ clubs:
 {% extends 'emails/base.html' %}
 
 {% block content %}
-    <p style="font-size: 1.2em">There are {{ clubs|length }} clubs that you have subscribed to with an application deadline
-        in 3 days.</p>
+    <h2>Upcoming Application Deadlines</h2>
+    <p style="font-size: 1.2em">There are <b>{{ clubs|length }} clubs</b> that you have subscribed to with an application deadline
+        in <b>3 days</b>.</p>
     <ul style="font-size: 1.2em">
         {% for code, name in clubs %}
         <li><a href="https://pennclubs.com/club/{code}/apply">{name}</a></li>

--- a/backend/templates/emails/application_deadline_reminder.html
+++ b/backend/templates/emails/application_deadline_reminder.html
@@ -4,9 +4,9 @@ clubs:
     items:
         type: tuple
         properties:
-            code:
-                type: string
             name:
+                type: string
+            url:
                 type: string
 -->
 {% extends 'emails/base.html' %}
@@ -16,8 +16,8 @@ clubs:
     <p style="font-size: 1.2em">There are <b>{{ clubs|length }} clubs</b> that you have subscribed to with an application deadline
         in <b>3 days</b>.</p>
     <ul style="font-size: 1.2em">
-        {% for code, name in clubs %}
-        <li><a href="https://pennclubs.com/club/{code}/apply">{name}</a></li>
+        {% for name, url in clubs %}
+        <li><a href="{{ url }}">{{ name }}</a></li>
         {% endfor %}
     </ul>
     <p style="font-size: 1.2em">This is an automated message. If you would not like to receive these notifications,

--- a/backend/templates/emails/approval_queue_reminder.html
+++ b/backend/templates/emails/approval_queue_reminder.html
@@ -1,3 +1,9 @@
+<!-- TYPES:
+num_clubs:
+    type: number
+url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/approval_queue_reminder.html
+++ b/backend/templates/emails/approval_queue_reminder.html
@@ -3,11 +3,20 @@ num_clubs:
     type: number
 url:
     type: string
+clubs:
+    type: array
+    items:
+        type: string
 -->
 {% extends 'emails/base.html' %}
 
 {% block content %}
     <p style="font-size: 1.2em">There are {{ num_clubs }} clubs waiting for your approval on Penn Clubs.</p>
+    <ul>
+        {% for club in clubs %}
+        <li>{club}</li>
+        {% endfor %}
+    </ul>
     <a style="text-decoration: none; padding: 5px 20px; font-size: 1.5em; margin-top: 20px; color: white; background-color: green; border-radius: 3px; font-weight: bold" href="{{ url }}">
         Review Clubs
     </a>

--- a/backend/templates/emails/approval_status.html
+++ b/backend/templates/emails/approval_status.html
@@ -1,3 +1,19 @@
+<!-- TYPES:
+change:
+    type: boolean
+approved:
+    type: boolean
+name:
+    type: string
+approved_comment:
+    type: string
+edit_url:
+    type: string
+view_url:
+    type: string
+year:
+    type: number
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/confirmation.html
+++ b/backend/templates/emails/confirmation.html
@@ -1,3 +1,7 @@
+<!-- TYPES:
+name:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/fair.html
+++ b/backend/templates/emails/fair.html
@@ -1,3 +1,11 @@
+<!-- TYPES:
+flyer_url:
+    type: string
+name:
+    type: string
+url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/fair_feedback_general.html
+++ b/backend/templates/emails/fair_feedback_general.html
@@ -1,3 +1,4 @@
+<!-- TYPES: {} -->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/fair_feedback_officers.html
+++ b/backend/templates/emails/fair_feedback_officers.html
@@ -1,3 +1,13 @@
+<!-- TYPES:
+name:
+    type: string
+num_subscriptions:
+    type: number
+prefix:
+    type: string
+subscriptions_url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/fair_info.html
+++ b/backend/templates/emails/fair_info.html
@@ -1,3 +1,15 @@
+<!-- TYPES:
+fair_url:
+    type: string
+guide_url:
+    type: string
+name:
+    type: string
+prefix:
+    type: string
+zoom_url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/fair_reminder.html
+++ b/backend/templates/emails/fair_reminder.html
@@ -1,3 +1,13 @@
+<!-- TYPES:
+guide_url:
+    type: string
+name:
+    type: string
+prefix:
+    type: string
+zoom_url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/invite.html
+++ b/backend/templates/emails/invite.html
@@ -1,3 +1,18 @@
+<!-- TYPES:
+name:
+    type: string
+role:
+    type: number
+url:
+    type: string
+sender:
+    type: object
+    properties:
+        get_full_name:
+            type: string
+        email:
+            type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/owner.html
+++ b/backend/templates/emails/owner.html
@@ -1,3 +1,11 @@
+<!-- TYPES:
+name:
+    type: string
+url:
+    type: string
+view_url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/postfair.html
+++ b/backend/templates/emails/postfair.html
@@ -1,3 +1,9 @@
+<!-- TYPES:
+name:
+    type: string
+url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/question.html
+++ b/backend/templates/emails/question.html
@@ -1,3 +1,11 @@
+<!-- TYPES:
+name:
+    type: string
+question:
+    type: string
+url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/remind.html
+++ b/backend/templates/emails/remind.html
@@ -1,3 +1,9 @@
+<!-- TYPES:
+name:
+    type: string
+url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/renew.html
+++ b/backend/templates/emails/renew.html
@@ -1,3 +1,9 @@
+<!-- TYPES:
+name:
+    type: string
+url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/renewal_reminder.html
+++ b/backend/templates/emails/renewal_reminder.html
@@ -1,3 +1,11 @@
+<!-- TYPES:
+name:
+    type: string
+url:
+    type: string
+year:
+    type: number
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/request.html
+++ b/backend/templates/emails/request.html
@@ -1,3 +1,11 @@
+<!-- TYPES:
+club_name:
+    type: string
+edit_url:
+    type: string
+full_name:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/emails/zoom_reminder.html
+++ b/backend/templates/emails/zoom_reminder.html
@@ -1,3 +1,13 @@
+<!-- TYPES:
+guide_url:
+    type: string
+name:
+    type: string
+prefix:
+    type: string
+zoom_url:
+    type: string
+-->
 {% extends 'emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/approval_queue_reminder.html
+++ b/backend/templates/fyh_emails/approval_queue_reminder.html
@@ -3,11 +3,20 @@ num_clubs:
     type: number
 url:
     type: string
+clubs:
+    type: array
+    items:
+        type: string
 -->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}
     <p style="font-size: 1.2em">There are {{ num_clubs }} clubs waiting for your approval on Hub@Penn.</p>
+    <ul>
+        {% for club in clubs %}
+        <li>{club}</li>
+        {% endfor %}
+    </ul>
     <a style="text-decoration: none; padding: 5px 20px; font-size: 1.5em; margin-top: 20px; color: white; background-color: green; border-radius: 3px; font-weight: bold" href="{{ url }}">
         Review Clubs
     </a>

--- a/backend/templates/fyh_emails/approval_queue_reminder.html
+++ b/backend/templates/fyh_emails/approval_queue_reminder.html
@@ -1,3 +1,9 @@
+<!-- TYPES:
+num_clubs:
+    type: number
+url:
+    type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/approval_status.html
+++ b/backend/templates/fyh_emails/approval_status.html
@@ -1,3 +1,17 @@
+<!-- TYPES:
+change:
+    type: boolean
+approved:
+    type: boolean
+name:
+    type: string
+approved_comment:
+    type: string
+edit_url:
+    type: string
+view_url:
+    type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/confirmation.html
+++ b/backend/templates/fyh_emails/confirmation.html
@@ -1,3 +1,7 @@
+<!-- TYPES:
+name:
+    type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/intro.html
+++ b/backend/templates/fyh_emails/intro.html
@@ -1,4 +1,10 @@
 <!-- SUBJECT: A Message to Penn Staff about Hub@Penn -->
+<!-- TYPES:
+resources:
+    type: array
+    items:
+        type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/intro_remind.html
+++ b/backend/templates/fyh_emails/intro_remind.html
@@ -1,4 +1,10 @@
 <!-- SUBJECT: Deadline: Submit Hub@Penn Resource by December 2 -->
+<!-- TYPES:
+resources:
+    type: array
+    items:
+        type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/invite.html
+++ b/backend/templates/fyh_emails/invite.html
@@ -1,3 +1,18 @@
+<!-- TYPES:
+name:
+    type: string
+role:
+    type: number
+url:
+    type: string
+sender:
+    type: object
+    properties:
+        get_full_name:
+            type: string
+        email:
+            type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/owner.html
+++ b/backend/templates/fyh_emails/owner.html
@@ -1,3 +1,11 @@
+<!-- TYPES:
+name:
+    type: string
+url:
+    type: string
+view_url:
+    type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/question.html
+++ b/backend/templates/fyh_emails/question.html
@@ -1,3 +1,11 @@
+<!-- TYPES:
+name:
+    type: string
+question:
+    type: string
+url:
+    type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/remind.html
+++ b/backend/templates/fyh_emails/remind.html
@@ -1,3 +1,9 @@
+<!-- TYPES:
+name:
+    type: string
+url:
+    type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/fyh_emails/second_round.html
+++ b/backend/templates/fyh_emails/second_round.html
@@ -1,4 +1,12 @@
 <!-- SUBJECT: Please Add Your University Resource to the New Hub@Penn Platform -->
+<!-- TYPES:
+recipient_string:
+    type: string
+resources:
+    type: array
+    items:
+        type: string
+-->
 {% extends 'fyh_emails/base.html' %}
 
 {% block content %}

--- a/backend/templates/preview.html
+++ b/backend/templates/preview.html
@@ -33,6 +33,7 @@
         }
         #templates a
         {
+            display: inline-block;
             padding: 6px 10px;
             border-radius: 3px;
             text-decoration: none;

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1231,7 +1231,7 @@ class ClubTestCase(TestCase):
             },
             {"query": "founded__lt=2000", "results": ["pppjo"]},
             {"query": "tags=Professional&founded__lt=2000", "results": ["pppjo"]},
-            {"query": "accepting_members=true", "results": ["pppjo"]},
+            {"query": "accepting_members=true", "results": ["pppjo", "empty-club"]},
             {
                 "query": f"size__or={Club.SIZE_MEDIUM},{Club.SIZE_LARGE}",
                 "results": ["pppjo", "lorem-ipsum"],

--- a/frontend/components/ClubEditPage.tsx
+++ b/frontend/components/ClubEditPage.tsx
@@ -34,11 +34,13 @@ import {
   OBJECT_NAME_TITLE_SINGULAR,
   OBJECT_TAB_MEMBERSHIP_LABEL,
   OBJECT_TAB_RECRUITMENT_LABEL,
+  SHOW_APPLICATIONS,
   SHOW_MEMBERSHIP_REQUEST,
   SITE_NAME,
 } from '../utils/branding'
 import AdvisorCard from './ClubEditPage/AdvisorCard'
 import AnalyticsCard from './ClubEditPage/AnalyticsCard'
+import ApplicationsCard from './ClubEditPage/ApplicationsCard'
 import ClubFairCard from './ClubEditPage/ClubFairCard'
 import DeleteClubCard from './ClubEditPage/DeleteClubCard'
 import EnableSubscriptionCard from './ClubEditPage/EnableSubscriptionCard'
@@ -285,6 +287,7 @@ const ClubForm = ({
         label: OBJECT_TAB_RECRUITMENT_LABEL,
         content: (
           <>
+            {SHOW_APPLICATIONS && <ApplicationsCard club={club} />}
             <QRCodeCard club={club} />
             <EnableSubscriptionCard
               notify={notify}

--- a/frontend/components/ClubEditPage/ApplicationsCard.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsCard.tsx
@@ -2,6 +2,7 @@ import { Field } from 'formik'
 import { ReactElement } from 'react'
 
 import { Club, ClubApplicationRequired } from '../../types'
+import { getSemesterFromDate } from '../../utils'
 import {
   OBJECT_NAME_SINGULAR,
   OBJECT_NAME_TITLE_SINGULAR,
@@ -90,7 +91,14 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
             />
           </>
         }
-        tableFields={[{ name: 'name', label: 'Name' }]}
+        tableFields={[
+          { name: 'name', label: 'Name' },
+          {
+            name: 'application_end_time',
+            label: 'Semester',
+            converter: (date: string): string => getSemesterFromDate(date),
+          },
+        ]}
         noun="Application"
       />
     </BaseCard>

--- a/frontend/components/ClubEditPage/ApplicationsCard.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsCard.tsx
@@ -1,0 +1,98 @@
+import { Field } from 'formik'
+import { ReactElement } from 'react'
+
+import { Club, ClubApplicationRequired } from '../../types'
+import {
+  OBJECT_NAME_SINGULAR,
+  OBJECT_NAME_TITLE_SINGULAR,
+} from '../../utils/branding'
+import { Icon, Text } from '../common'
+import { DateTimeField, TextField } from '../FormComponents'
+import ModelForm from '../ModelForm'
+import BaseCard from './BaseCard'
+
+type Props = {
+  club: Club
+}
+
+export default function ApplicationsCard({ club }: Props): ReactElement {
+  return (
+    <BaseCard title={`${OBJECT_NAME_TITLE_SINGULAR} Applications`}>
+      {club.application_required === ClubApplicationRequired.Open && (
+        <div className="notification is-warning">
+          <Icon name="alert-triangle" /> Your {OBJECT_NAME_SINGULAR} currently
+          has it application status set to open membership. Adding{' '}
+          {OBJECT_NAME_SINGULAR} applications here will have no effect on what
+          the student sees.
+        </div>
+      )}
+      <Text>
+        You can use the interface below to add {OBJECT_NAME_SINGULAR}{' '}
+        applications.
+      </Text>
+      <ul className="mb-3">
+        {[
+          <>
+            Display your application links in a centralized repository of{' '}
+            {OBJECT_NAME_SINGULAR} applications.
+          </>,
+          <>
+            Subscribed students will automatically receive email reminders about
+            application deadlines.
+          </>,
+          <>
+            Automatically update membership and recruiting statuses based on
+            when your applications open and close.
+          </>,
+        ].map((text, i) => (
+          <li key={i}>
+            <span className=" ml-3 has-text-success">
+              <Icon name="check" />
+            </span>{' '}
+            {text}
+          </li>
+        ))}
+      </ul>
+      <ModelForm
+        baseUrl={`/clubs/${club.code}/applications/`}
+        defaultObject={{ name: `${club.name} Application` }}
+        fields={
+          <>
+            <Field
+              name="name"
+              as={TextField}
+              helpText="A name for this application, used for identifying it if you have multiple applications per semester."
+            />
+            <Field
+              name="application_start_time"
+              as={DateTimeField}
+              required={true}
+              helpText="The date when your application opens."
+            />
+            <Field
+              name="application_end_time"
+              as={DateTimeField}
+              required={true}
+              helpText="The date when your application closes."
+            />
+            <Field
+              name="result_release_time"
+              as={DateTimeField}
+              required={true}
+              helpText={`The latest date that your ${OBJECT_NAME_SINGULAR} will be releasing admission results.`}
+            />
+            <Field
+              name="external_url"
+              as={TextField}
+              type="url"
+              required={true}
+              helpText={`The external URL where students can apply for your ${OBJECT_NAME_SINGULAR}.`}
+            />
+          </>
+        }
+        tableFields={[{ name: 'name', label: 'Name' }]}
+        noun="Application"
+      />
+    </BaseCard>
+  )
+}

--- a/frontend/components/ClubEditPage/EventsCard.tsx
+++ b/frontend/components/ClubEditPage/EventsCard.tsx
@@ -281,18 +281,18 @@ const eventTableFields = [
   {
     name: 'start_time',
     label: 'Start Time',
-    converter: (a) => <TimeAgo date={a} />,
+    converter: (a: string): ReactElement => <TimeAgo date={a} />,
   },
   {
     name: 'type',
     label: 'Type',
-    converter: (a) =>
+    converter: (a: ClubEventType): string =>
       (EVENT_TYPES.find((v) => v.value === a) || { label: 'Unknown' }).label,
   },
   {
     name: 'is_ics_event',
     label: 'ICS',
-    converter: (a) => <Icon name={a ? 'check' : 'x'} />,
+    converter: (a: boolean): ReactElement => <Icon name={a ? 'check' : 'x'} />,
   },
 ]
 

--- a/frontend/components/ClubEditPage/MembersCard.tsx
+++ b/frontend/components/ClubEditPage/MembersCard.tsx
@@ -85,7 +85,9 @@ export default function MembersCard({ club }: MembersCardProps): ReactElement {
             name: 'email',
           },
         ]}
-        currentTitle={(obj) => `${obj.name} (${obj.email})`}
+        currentTitle={(obj) =>
+          obj != null ? `${obj.name} (${obj.email})` : 'Kicked Member'
+        }
       />
       <div style={{ marginTop: '1em' }}>
         <a

--- a/frontend/components/ClubPage/Actions.tsx
+++ b/frontend/components/ClubPage/Actions.tsx
@@ -10,7 +10,7 @@ import Linkify from 'react-linkify'
 import styled from 'styled-components'
 
 import { BORDER, MEDIUM_GRAY, WHITE } from '../../constants/colors'
-import { CLUB_EDIT_ROUTE } from '../../constants/routes'
+import { CLUB_APPLY_ROUTE, CLUB_EDIT_ROUTE } from '../../constants/routes'
 import { Club, ClubApplicationRequired, UserInfo } from '../../types'
 import { apiCheckPermission, doApiRequest } from '../../utils'
 import {
@@ -21,7 +21,7 @@ import {
   SITE_NAME,
 } from '../../utils/branding'
 import { logException, logMessage } from '../../utils/sentry'
-import { BookmarkIcon, Contact, Modal, SubscribeIcon } from '../common'
+import { BookmarkIcon, Contact, Icon, Modal, SubscribeIcon } from '../common'
 import { AuthCheckContext } from '../contexts'
 
 const Wrapper = styled.span`
@@ -150,18 +150,26 @@ const Actions = ({
           {SHOW_MEMBERSHIP_REQUEST &&
             !inClub &&
             club.members.length > 0 &&
-            (!isMembershipOpen || club.accepting_members) && (
-              <ActionButton
-                className="button is-success"
-                onClick={requestMembership}
+            (isMembershipOpen ? (
+              club.accepting_members && (
+                <ActionButton
+                  className="button is-success"
+                  onClick={requestMembership}
+                >
+                  {isRequested ? 'Withdraw Request' : 'Request Membership'}
+                </ActionButton>
+              )
+            ) : (
+              <Link
+                href={CLUB_APPLY_ROUTE()}
+                as={CLUB_APPLY_ROUTE(code)}
+                passHref
               >
-                {isRequested
-                  ? 'Withdraw Request'
-                  : isMembershipOpen
-                  ? 'Request Membership'
-                  : "I'm a Member"}
-              </ActionButton>
-            )}
+                <ActionButton className="button is-success">
+                  <Icon name="edit" /> Apply
+                </ActionButton>
+              </Link>
+            ))}
           {canEdit && (
             <Link href={CLUB_EDIT_ROUTE()} as={CLUB_EDIT_ROUTE(code)} passHref>
               <ActionButton className="button is-success">

--- a/frontend/components/ClubPage/Actions.tsx
+++ b/frontend/components/ClubPage/Actions.tsx
@@ -17,6 +17,7 @@ import {
   FIELD_PARTICIPATION_LABEL,
   OBJECT_NAME_SINGULAR,
   OBJECT_NAME_TITLE_SINGULAR,
+  SHOW_APPLICATIONS,
   SHOW_MEMBERSHIP_REQUEST,
   SITE_NAME,
 } from '../../utils/branding'
@@ -274,24 +275,24 @@ const Actions = ({
           {SHOW_MEMBERSHIP_REQUEST &&
             !inClub &&
             club.members.length > 0 &&
-            (isMembershipOpen ? (
-              club.accepting_members && (
-                <RequestMembershipButton
-                  club={club}
-                  updateRequests={updateRequests}
-                />
-              )
-            ) : (
-              <Link
-                href={CLUB_APPLY_ROUTE()}
-                as={CLUB_APPLY_ROUTE(code)}
-                passHref
-              >
-                <ActionButton className="button is-success">
-                  <Icon name="edit" /> Apply
-                </ActionButton>
-              </Link>
-            ))}
+            (isMembershipOpen
+              ? club.accepting_members && (
+                  <RequestMembershipButton
+                    club={club}
+                    updateRequests={updateRequests}
+                  />
+                )
+              : SHOW_APPLICATIONS && (
+                  <Link
+                    href={CLUB_APPLY_ROUTE()}
+                    as={CLUB_APPLY_ROUTE(code)}
+                    passHref
+                  >
+                    <ActionButton className="button is-success">
+                      <Icon name="edit" /> Apply
+                    </ActionButton>
+                  </Link>
+                ))}
           {canEdit && (
             <Link href={CLUB_EDIT_ROUTE()} as={CLUB_EDIT_ROUTE(code)} passHref>
               <ActionButton className="button is-success">

--- a/frontend/components/ModelForm.tsx
+++ b/frontend/components/ModelForm.tsx
@@ -77,6 +77,9 @@ type ModelFormProps = {
 export const doFormikInitialValueFixes = (currentObject: {
   [key: string]: any
 }): { [key: string]: any } => {
+  if (currentObject == null) {
+    return {}
+  }
   return Object.entries(currentObject).reduce((prev, [key, val]) => {
     if (key.endsWith('_url')) {
       const otherKey = key.substr(0, key.length - 4)
@@ -349,6 +352,7 @@ export const ModelForm = (props: ModelFormProps): ReactElement => {
             .then((resp) => {
               if (resp.ok) {
                 object._status = true
+                // eslint-disable-next-line camelcase
                 object._error_message = null
                 return resp.json().then((resp) => {
                   Object.keys(resp).forEach((key) => {
@@ -382,6 +386,7 @@ export const ModelForm = (props: ModelFormProps): ReactElement => {
                 Object.keys(resp).forEach((key) => {
                   object[key] = resp[key]
                 })
+                // eslint-disable-next-line camelcase
                 object._error_message = null
               } else {
                 // eslint-disable-next-line camelcase

--- a/frontend/components/Settings/FairsTab.tsx
+++ b/frontend/components/Settings/FairsTab.tsx
@@ -1,0 +1,101 @@
+import { Field } from 'formik'
+import React, { ReactElement } from 'react'
+
+import { ClubFair, MembershipRank } from '../../types'
+import {
+  MEMBERSHIP_ROLE_NAMES,
+  OBJECT_NAME_SINGULAR,
+} from '../../utils/branding'
+import { Text } from '../common'
+import {
+  DateTimeField,
+  DynamicQuestionField,
+  RichTextField,
+  TextField,
+} from '../FormComponents'
+import ModelForm from '../ModelForm'
+
+type FairsTabProps = {
+  fairs: ClubFair[]
+}
+
+const FairsTab = ({ fairs }: FairsTabProps): ReactElement => {
+  return (
+    <>
+      <Text>
+        You can use this page to manage {OBJECT_NAME_SINGULAR} fairs. Since your
+        account has the required permissions, you are able to view this page.
+      </Text>
+      <ModelForm
+        baseUrl="/clubfairs/"
+        initialData={fairs}
+        fields={
+          <>
+            <Field name="name" as={TextField} required />
+            <Field name="organization" as={TextField} required />
+            <Field
+              name="contact"
+              as={TextField}
+              required
+              type="email"
+              helpText="The email address that students should contact for questions related to this activities fair."
+            />
+            <Field
+              name="start_time"
+              as={DateTimeField}
+              helpText="When your activities fair will start. If you have multiple time slots, this should be the beginning of the earliest slot."
+              required
+            />
+            <Field
+              name="end_time"
+              as={DateTimeField}
+              helpText="When your activities fair will end. If you have multiple time slots, this should be the end of the latest slot."
+              required
+            />
+            <Field
+              name="time"
+              label="Display Time"
+              as={TextField}
+              helpText="If you do not specify this field, it will automatically be generated from the start and end time. This field exists so that you can specify a more accurate description of the start and end times."
+            />
+            <Field
+              name="registration_start_time"
+              as={DateTimeField}
+              helpText="If this is not specified, registration will be open immediately."
+            />
+            <Field
+              name="registration_end_time"
+              as={DateTimeField}
+              helpText="After this time, registrations will no longer be accepted."
+              required
+            />
+            <Field
+              name="information"
+              as={RichTextField}
+              helpText="This will be shown to students on the fair page."
+            />
+            <Field
+              name="registration_information"
+              as={RichTextField}
+              helpText={`This will be shown to ${OBJECT_NAME_SINGULAR} ${MEMBERSHIP_ROLE_NAMES[
+                MembershipRank.Officer
+              ].toLowerCase()}s on the registration page.`}
+            />
+            <Field
+              name="questions"
+              as={DynamicQuestionField}
+              helpText="The questions you enter here will be required during fair registration."
+            />
+          </>
+        }
+        tableFields={[
+          { name: 'name', label: 'Name' },
+          { name: 'organization', label: 'Organization' },
+        ]}
+        noun="Fair"
+      />
+    </>
+  )
+}
+
+export default FairsTab

--- a/frontend/constants/routes.ts
+++ b/frontend/constants/routes.ts
@@ -14,6 +14,10 @@ export const CLUB_RENEW_ROUTE = (slug?: string): string =>
   slug
     ? `/${OBJECT_URL_SLUG}/${slug}/renew`
     : `/${OBJECT_URL_SLUG}/[club]/renew`
+export const CLUB_APPLY_ROUTE = (slug?: string): string =>
+  slug
+    ? `/${OBJECT_URL_SLUG}/${slug}/apply`
+    : `/${OBJECT_URL_SLUG}/[club]/apply`
 export const CLUB_ORG_ROUTE = (slug?: string): string =>
   slug ? `/${OBJECT_URL_SLUG}/${slug}/org` : `/${OBJECT_URL_SLUG}/[club]/org`
 export const CLUB_ALUMNI_ROUTE = (slug?: string): string =>

--- a/frontend/cypress/integration/request_spec.js
+++ b/frontend/cypress/integration/request_spec.js
@@ -23,16 +23,7 @@ describe('Membership request tests', () => {
     })
 
     // request membership
-    cy.visit('/club/pppjo/')
-
-    // scroll through page
-    cy.scrollTo('bottom', { duration: 500 })
-
-    // ensure benjamin franklin is a member
-    cy.contains('Benjamin Franklin')
-    
-    // scroll back to top
-    cy.scrollTo('top', { duration: 500 })
+    cy.visit('/club/pppjo/apply')
 
     // click request button
     cy.contains('.button:visible', /(I'm a Member|Request Membership)/).click()

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -11,6 +11,8 @@ import {
   TextField,
 } from '../components/FormComponents'
 import { fixDeserialize } from '../components/reports/ReportForm'
+import FairsTab from '../components/Settings/FairsTab'
+import QueueTab from '../components/Settings/QueueTab'
 import TabView from '../components/TabView'
 import { BG_GRADIENT, WHITE } from '../constants'
 import renderPage from '../renderPage'
@@ -258,6 +260,16 @@ function AdminPage({
         </div>
       ),
     },
+    {
+      name: 'queue',
+      label: 'Approval Queue',
+      content: () => <QueueTab />,
+    },
+    {
+      name: 'fair',
+      label: 'Fair Management',
+      content: () => <FairsTab fairs={[]} />,
+    },
   ]
 
   return (
@@ -277,6 +289,6 @@ AdminPage.getInitialProps = async (ctx: NextPageContext) => {
   return doBulkLookup(['tags', 'badges', 'clubfairs', 'scripts'], ctx)
 }
 
-AdminPage.permissions = []
+AdminPage.permissions = ['clubs.approve_club']
 
 export default renderPage(AdminPage)

--- a/frontend/pages/club/[club]/apply.tsx
+++ b/frontend/pages/club/[club]/apply.tsx
@@ -1,0 +1,53 @@
+import { NextPageContext } from 'next'
+import Link from 'next/link'
+import { ReactElement } from 'react'
+
+import ClubMetadata from '../../../components/ClubMetadata'
+import { Container, Text, Title } from '../../../components/common'
+import { CLUB_ROUTE } from '../../../constants'
+import renderPage from '../../../renderPage'
+import { Club } from '../../../types'
+import { doApiRequest } from '../../../utils'
+
+type Props = {
+  club: Club
+}
+
+const ApplyPage = ({ club }: Props): ReactElement => {
+  return (
+    <>
+      <ClubMetadata club={club} />
+      <Container paddingTop>
+        <div className="is-clearfix">
+          <Title className="is-pulled-left">{club.name} Application</Title>
+          <Link href={CLUB_ROUTE()} as={CLUB_ROUTE(club.code)}>
+            <a className="button is-pulled-right is-secondary is-medium">
+              Back
+            </a>
+          </Link>
+        </div>
+        <hr />
+        <div className="has-text-centered">
+          <Text>This page is still under construction. Check back soon!</Text>
+          <img
+            src="/static/img/underconstruction.png"
+            alt="Under Construction"
+            style={{ maxWidth: 600 }}
+          />
+        </div>
+      </Container>
+    </>
+  )
+}
+
+ApplyPage.getInitialProps = async ({ query, req }: NextPageContext) => {
+  const data = {
+    headers: req ? { cookie: req.headers.cookie } : undefined,
+  }
+  const clubReq = await doApiRequest(`/clubs/${query.club}/?format=json`, data)
+  const clubRes = await clubReq.json()
+
+  return { club: clubRes }
+}
+
+export default renderPage(ApplyPage)

--- a/frontend/pages/club/[club]/apply.tsx
+++ b/frontend/pages/club/[club]/apply.tsx
@@ -1,19 +1,62 @@
 import { NextPageContext } from 'next'
 import Link from 'next/link'
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
+import TimeAgo from 'react-timeago'
 
+import { CLUB_APPLICATIONS } from '../../../components/ClubEditPage/ClubEditCard'
 import ClubMetadata from '../../../components/ClubMetadata'
-import { Container, Text, Title } from '../../../components/common'
+import { RequestMembershipButton } from '../../../components/ClubPage/Actions'
+import {
+  Container,
+  Icon,
+  Subtitle,
+  Text,
+  Title,
+} from '../../../components/common'
 import { CLUB_ROUTE } from '../../../constants'
 import renderPage from '../../../renderPage'
-import { Club } from '../../../types'
-import { doApiRequest } from '../../../utils'
+import { Club, ClubApplication, ClubApplicationRequired } from '../../../types'
+import { doApiRequest, getSemesterFromDate } from '../../../utils'
+import { logEvent } from '../../../utils/analytics'
+import {
+  OBJECT_NAME_SINGULAR,
+  SITE_ID,
+  SITE_NAME,
+} from '../../../utils/branding'
 
 type Props = {
   club: Club
+  applications: ClubApplication[]
 }
 
-const ApplyPage = ({ club }: Props): ReactElement => {
+const ApplyPage = ({ club, applications }: Props): ReactElement => {
+  const [updatedIsRequest, setUpdatedIsRequest] = useState<boolean>(
+    club.is_request,
+  )
+
+  const isOpenMembership =
+    club.application_required === ClubApplicationRequired.Open
+
+  const btn = (
+    <RequestMembershipButton
+      club={{ ...club, is_request: updatedIsRequest }}
+      updateRequests={async (code: string) => {
+        logEvent('request', code)
+        if (updatedIsRequest) {
+          await doApiRequest(`/requests/${club.code}/?format=json`, {
+            method: 'DELETE',
+          })
+        } else {
+          await doApiRequest(`/requests/?format=json`, {
+            method: 'POST',
+            body: { club: code },
+          })
+        }
+        setUpdatedIsRequest((upd) => !upd)
+      }}
+    />
+  )
+
   return (
     <>
       <ClubMetadata club={club} />
@@ -27,14 +70,93 @@ const ApplyPage = ({ club }: Props): ReactElement => {
           </Link>
         </div>
         <hr />
-        <div className="has-text-centered">
-          <Text>This page is still under construction. Check back soon!</Text>
-          <img
-            src="/static/img/underconstruction.png"
-            alt="Under Construction"
-            style={{ maxWidth: 600 }}
-          />
-        </div>
+        {isOpenMembership ? (
+          <>
+            <Subtitle>Open Membership</Subtitle>
+            <Text>
+              This {OBJECT_NAME_SINGULAR} has open membership and no application
+              is required to join the {OBJECT_NAME_SINGULAR}. You can request to
+              be added as a member to this {OBJECT_NAME_SINGULAR} on {SITE_NAME}
+              . The {OBJECT_NAME_SINGULAR} is currently{' '}
+              {club.accepting_members ? 'accepting' : 'not accepting'} new
+              members.
+            </Text>
+          </>
+        ) : (
+          <>
+            <Subtitle>
+              {
+                CLUB_APPLICATIONS.find(
+                  (app) => app.value === club.application_required,
+                )?.label
+              }
+            </Subtitle>
+            <Text>
+              {club.name} requires an application process to join the{' '}
+              {OBJECT_NAME_SINGULAR}. You can subscribe to this{' '}
+              {OBJECT_NAME_SINGULAR} to get notified when applications open and
+              close.
+            </Text>
+          </>
+        )}
+        <Text>
+          {club.how_to_get_involved.length > 0
+            ? club.how_to_get_involved
+            : `This ${OBJECT_NAME_SINGULAR} has no additional details on how to get involved.`}
+        </Text>
+        {isOpenMembership ? (
+          btn
+        ) : (
+          <>
+            {applications.length <= 0 && (
+              <div className="notification is-info">
+                <Icon name="alert-circle" /> There are no applications available
+                for <b>{club.name}</b> at the moment. This{' '}
+                {OBJECT_NAME_SINGULAR} may not be recruiting at the moment or
+                have not entered their application information into {SITE_NAME}.
+              </div>
+            )}
+            {applications.map((app) => (
+              <div className="box" key={app.id}>
+                <Subtitle>
+                  {app.name}{' '}
+                  <span className="has-text-grey">
+                    for {getSemesterFromDate(app.application_end_time)}
+                  </span>
+                </Subtitle>
+                <div>
+                  <b>Open Time:</b>{' '}
+                  {new Date(app.application_start_time).toLocaleString()} (
+                  <TimeAgo date={app.application_start_time} />)
+                </div>
+                <div>
+                  <b>Close Time:</b>{' '}
+                  {new Date(app.application_end_time).toLocaleString()} (
+                  <TimeAgo date={app.application_end_time} />)
+                </div>
+                <div>
+                  <b>Results Released By:</b>{' '}
+                  {new Date(app.result_release_time).toLocaleString()} (
+                  <TimeAgo date={app.result_release_time} />)
+                </div>
+                <a
+                  href={app.external_url}
+                  rel="noopener noreferrer"
+                  className="button is-success mt-3"
+                >
+                  <Icon name="edit" /> Apply
+                </a>
+              </div>
+            ))}
+            <Subtitle>Already a member?</Subtitle>
+            <Text>
+              Are you an existing member of {club.name}, but not on {SITE_ID}{' '}
+              yet? Use the button below to request to be added to this{' '}
+              {OBJECT_NAME_SINGULAR} on {SITE_NAME}.
+            </Text>
+            {btn}
+          </>
+        )}
       </Container>
     </>
   )
@@ -44,10 +166,14 @@ ApplyPage.getInitialProps = async ({ query, req }: NextPageContext) => {
   const data = {
     headers: req ? { cookie: req.headers.cookie } : undefined,
   }
-  const clubReq = await doApiRequest(`/clubs/${query.club}/?format=json`, data)
+  const [clubReq, appReq] = await Promise.all([
+    doApiRequest(`/clubs/${query.club}/?format=json`, data),
+    doApiRequest(`/clubs/${query.club}/applications/?format=json`, data),
+  ])
   const clubRes = await clubReq.json()
+  const appRes = await appReq.json()
 
-  return { club: clubRes }
+  return { club: clubRes, applications: appRes }
 }
 
 export default renderPage(ApplyPage)

--- a/frontend/pages/fairs.tsx
+++ b/frontend/pages/fairs.tsx
@@ -1,17 +1,10 @@
-import { Field } from 'formik'
 import { NextPageContext } from 'next'
 import React, { ReactElement } from 'react'
 
 import ClubFairCard from '../components/ClubEditPage/ClubFairCard'
 import { Contact, Container, Metadata, Text, Title } from '../components/common'
 import AuthPrompt from '../components/common/AuthPrompt'
-import {
-  DateTimeField,
-  DynamicQuestionField,
-  RichTextField,
-  TextField,
-} from '../components/FormComponents'
-import { ModelForm } from '../components/ModelForm'
+import FairsTab from '../components/Settings/FairsTab'
 import TabView from '../components/TabView'
 import { BG_GRADIENT, WHITE } from '../constants'
 import renderPage from '../renderPage'
@@ -54,83 +47,7 @@ function FairsPage({ userInfo, fairs, memberships }): ReactElement {
     },
     {
       name: 'Management',
-      content: () => (
-        <>
-          <Text>
-            You can use this page to manage {OBJECT_NAME_SINGULAR} fairs. Since
-            your account has the required permissions, you are able to view this
-            page.
-          </Text>
-          <ModelForm
-            baseUrl="/clubfairs/"
-            initialData={fairs}
-            fields={
-              <>
-                <Field name="name" as={TextField} required />
-                <Field name="organization" as={TextField} required />
-                <Field
-                  name="contact"
-                  as={TextField}
-                  required
-                  type="email"
-                  helpText="The email address that students should contact for questions related to this activities fair."
-                />
-                <Field
-                  name="start_time"
-                  as={DateTimeField}
-                  helpText="When your activities fair will start. If you have multiple time slots, this should be the beginning of the earliest slot."
-                  required
-                />
-                <Field
-                  name="end_time"
-                  as={DateTimeField}
-                  helpText="When your activities fair will end. If you have multiple time slots, this should be the end of the latest slot."
-                  required
-                />
-                <Field
-                  name="time"
-                  label="Display Time"
-                  as={TextField}
-                  helpText="If you do not specify this field, it will automatically be generated from the start and end time. This field exists so that you can specify a more accurate description of the start and end times."
-                />
-                <Field
-                  name="registration_start_time"
-                  as={DateTimeField}
-                  helpText="If this is not specified, registration will be open immediately."
-                />
-                <Field
-                  name="registration_end_time"
-                  as={DateTimeField}
-                  helpText="After this time, registrations will no longer be accepted."
-                  required
-                />
-                <Field
-                  name="information"
-                  as={RichTextField}
-                  helpText="This will be shown to students on the fair page."
-                />
-                <Field
-                  name="registration_information"
-                  as={RichTextField}
-                  helpText={`This will be shown to ${OBJECT_NAME_SINGULAR} ${MEMBERSHIP_ROLE_NAMES[
-                    MembershipRank.Officer
-                  ].toLowerCase()}s on the registration page.`}
-                />
-                <Field
-                  name="questions"
-                  as={DynamicQuestionField}
-                  helpText="The questions you enter here will be required during fair registration."
-                />
-              </>
-            }
-            tableFields={[
-              { name: 'name', label: 'Name' },
-              { name: 'organization', label: 'Organization' },
-            ]}
-            noun="Fair"
-          />
-        </>
-      ),
+      content: () => <FairsTab fairs={fairs} />,
       disabled: !canSeeFairStatus,
     },
   ]

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -64,6 +64,14 @@ export interface ClubEvent {
   url: string | null
 }
 
+export interface ClubApplication {
+  name: string
+  application_start_time: string
+  application_end_time: string
+  result_release_time: string
+  external_url: string
+}
+
 export enum ClubSize {
   Small = 1,
   Medium = 2,

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -65,6 +65,7 @@ export interface ClubEvent {
 }
 
 export interface ClubApplication {
+  id: number
   name: string
   application_start_time: string
   application_end_time: string

--- a/frontend/utils.tsx
+++ b/frontend/utils.tsx
@@ -373,3 +373,18 @@ export function getCurrentSchoolYear(): number {
   }
   return year
 }
+
+/**
+ * Given a date, return a semester string corresponding to that date.
+ * For example, if 1/8/2021 was passed in, the return result should be "Spring 2021".
+ * Does not support the summer semester.
+ */
+export function getSemesterFromDate(date: Date | string): string {
+  if (typeof date === 'string') {
+    date = new Date(date)
+  }
+
+  const year = date.getFullYear()
+  const sem = date.getMonth() >= 6 ? 'Fall' : 'Spring'
+  return `${sem} ${year}`
+}

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -68,6 +68,8 @@ const sites = {
     SHOW_LEAVE_CONFIRMATION: true,
     // show the searchbar at the top of the page instead of the sidebar
     SHOW_SEARCHBAR_TOP: false,
+    // show applications
+    SHOW_APPLICATIONS: true,
 
     MEMBERSHIP_ROLE_NAMES: { 0: 'Owner', 10: 'Officer', 20: 'Member' },
     OBJECT_MEMBERSHIP_LABEL: 'Members',
@@ -179,6 +181,8 @@ const sites = {
     SHOW_ADDITIONAL_LINKS: false,
     SHOW_LEAVE_CONFIRMATION: false,
     SHOW_SEARCHBAR_TOP: true,
+    SHOW_APPLICATIONS: false,
+
     MEMBERSHIP_ROLE_NAMES: { 0: 'Owner', 10: 'Editor' },
     OBJECT_MEMBERSHIP_LABEL: 'Staff',
     OBJECT_MEMBERSHIP_LABEL_LOWERCASE: 'staff',
@@ -262,6 +266,7 @@ export const SHOW_ACCESSIBILITY = sites[site].SHOW_ACCESSIBILITY
 export const SHOW_ADDITIONAL_LINKS = sites[site].SHOW_ADDITIONAL_LINKS
 export const SHOW_LEAVE_CONFIRMATION = sites[site].SHOW_LEAVE_CONFIRMATION
 export const SHOW_SEARCHBAR_TOP = sites[site].SHOW_SEARCHBAR_TOP
+export const SHOW_APPLICATIONS = sites[site].SHOW_APPLICATIONS
 
 export const OBJECT_MEMBERSHIP_LABEL = sites[site].OBJECT_MEMBERSHIP_LABEL
 export const OBJECT_MEMBERSHIP_LABEL_LOWERCASE =


### PR DESCRIPTION
- Add more logging to daily notifications script, refactor to be more Pythonic.
  - Handle edge case where email recipient is blank.
  - Add emails for applications 3 days before an application is due.
  - Refactor email templates to specify the input types with an HTML comment.
- Add club officer frontend for CRUDing club applications.
- Add more tabs to the admin dashboard (duplicate existing tabs).

![image](https://user-images.githubusercontent.com/4441174/104043604-0aa7ee80-51aa-11eb-9f71-117c634d25b7.png)
