### PR TITLE
Minor tweaks to Zoom page

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -328,6 +328,8 @@ class Club(models.Model):
                         if ev.pk is None:
                             ev.type = Event.OTHER
                             for val, lbl in Event.TYPES:
+                                if val in {Event.FAIR}:
+                                    continue
                                 if (
                                     lbl.lower() in ev.name.lower()
                                     or lbl.lower() in ev.description.lower()

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2996,8 +2996,8 @@ class MeetingZoomAPIView(APIView):
             return Response(
                 {
                     "success": True,
-                    "detail": "Your Zoom meeting has been created!"
-                    f"The following accounts have been made hosts: {', '.join(alt_hosts)}",
+                    "detail": "Your Zoom meeting has been created! "
+                    f"The following Zoom accounts have been made hosts: {', '.join(alt_hosts)}",
                 }
             )
         else:

--- a/frontend/utils/sentry.tsx
+++ b/frontend/utils/sentry.tsx
@@ -32,8 +32,10 @@ export function logMessage(msg: string): void {
   Sentry.captureMessage(msg)
 }
 
-export default function withSentry(WrappedComponent) {
-  return class SentryComponent extends React.Component {
+export default function withSentry<T>(
+  WrappedComponent: React.ComponentType<T>,
+): React.ComponentType<T> {
+  return class SentryComponent extends React.Component<T> {
     render() {
       try {
         return <WrappedComponent {...this.props} />


### PR DESCRIPTION
- List all of the upcoming virtual fairs as the subtitle instead of just the most recent one.
- Use toasts for notifications instead of embedded notifications.
- Ensure that an ICS event cannot become an activities fair event.
- Fix minor text spacing issues and update wording to be more clear.

![image](https://user-images.githubusercontent.com/4441174/104507311-880d9d80-55b4-11eb-979d-911c30da57f8.png)
![image](https://user-images.githubusercontent.com/4441174/104507332-8fcd4200-55b4-11eb-9bfe-9e20dfe9b5fc.png)
![image](https://user-images.githubusercontent.com/4441174/104507350-98257d00-55b4-11eb-91fb-4c00f4624fe0.png)

