### PR TITLE
Allow modification of zoom URL

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -399,7 +399,9 @@ class Club(models.Model):
             return len(modified_events)
         return 0
 
-    def send_virtual_fair_email(self, request=None, email="setup", fair=None, emails=None):
+    def send_virtual_fair_email(
+        self, request=None, email="setup", fair=None, emails=None, extra=False
+    ):
         """
         Send an email to all club officers about setting up their club for the virtual fair.
 
@@ -452,6 +454,7 @@ class Club(models.Model):
             "num_subscriptions": self.subscribe_set.count(),
             "fair": fair,
             "events": events,
+            "extra": extra,
         }
 
         if emails:

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -474,10 +474,20 @@ class EventWriteSerializer(EventSerializer):
                         has_linked_account = True
 
                 # if we've linked a zoom account and entering a zoom link, we're fine
-                if ("upenn.zoom.us" not in parsed_url.netloc or not has_linked_account) and new_url:
+                if not has_linked_account and new_url:
                     raise serializers.ValidationError(
-                        "You should not change the meeting link manually for fair events! "
-                        "Use the Zoom setup page instead."
+                        {
+                            "url": "You should link your Zoom account on the "
+                            "Zoom setup page before changing this field."
+                        }
+                    )
+
+                if "upenn.zoom.us" not in parsed_url.netloc and new_url:
+                    raise serializers.ValidationError(
+                        {
+                            "url": "You should use a Penn Zoom account for the meeting link! "
+                            "Use the Zoom setup page to do this for you."
+                        }
                     )
 
         return super().update(instance, validated_data)

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1338,6 +1338,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
                     "are you sure your URL is correct?",
                 }
             )
+
         return Response({"success": True, "message": f"Fetched {num_events} events!"})
 
     @action(detail=False, methods=["get"])

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2942,6 +2942,8 @@ class UserPermissionAPIView(APIView):
 def zoom_api_call(user, verb, url, *args, **kwargs):
     """
     Perform an API call to Zoom with various checks.
+
+    If the call returns a token expired event, refresh the token and try the call one more time.
     """
     if not settings.SOCIAL_AUTH_ZOOM_OAUTH2_KEY:
         raise DRFValidationError("Server is not configured with Zoom OAuth2 credentials.")
@@ -3063,6 +3065,7 @@ class MeetingZoomWebhookAPIView(APIView):
         )
 
     def post(self, request):
+        # security check to make sure request contains zoom provided token
         if settings.ZOOM_VERIFICATION_TOKEN:
             authorization = request.META.get("HTTP_AUTHORIZATION")
             if authorization != settings.ZOOM_VERIFICATION_TOKEN:

--- a/backend/templates/emails/fair_info.html
+++ b/backend/templates/emails/fair_info.html
@@ -52,6 +52,11 @@ events:
     </p>
     
     <a style="text-decoration: none; padding: 5px 20px; font-size: 1.5em; margin-top: 25px; color: white; background-color: green; border-radius: 3px; font-weight: bold" href="{{ zoom_url }}">Setup Your Booth</a>
+    
+    <p style="font-size: 1.2em">
+        Reminder that if your club is not going to participate in the Jan 27 morning session, you MUST upload a multimedia alternative to your club page by noon on the day you're scheduled for.
+        To learn how to do this, you can follow <a href="{{ media_guide_url }}">this guide</a>.
+    </p>
 
     <p style="font-size: 1.2em">
         For more information about the fair, check out the <a href="{{ guide_url }}">officer guide</a>.

--- a/backend/templates/emails/fair_info.html
+++ b/backend/templates/emails/fair_info.html
@@ -30,6 +30,8 @@ events:
         properties:
             time:
                 type: string
+extra:
+    type: boolean
 -->
     <h2>[{{ prefix }}] {{ fair.name }} Setup and Information</h2>
     <p style="font-size: 1.2em">
@@ -53,10 +55,12 @@ events:
     
     <a style="text-decoration: none; padding: 5px 20px; font-size: 1.5em; margin-top: 25px; color: white; background-color: green; border-radius: 3px; font-weight: bold" href="{{ zoom_url }}">Setup Your Booth</a>
     
+    {% if extra %}
     <p style="font-size: 1.2em">
         Reminder that if your club is not going to participate in the Jan 27 morning session, you MUST upload a multimedia alternative to your club page by noon on the day you're scheduled for.
         To learn how to do this, you can follow <a href="{{ media_guide_url }}">this guide</a>.
     </p>
+    {% endif %}
 
     <p style="font-size: 1.2em">
         For more information about the fair, check out the <a href="{{ guide_url }}">officer guide</a>.

--- a/frontend/pages/zoom.tsx
+++ b/frontend/pages/zoom.tsx
@@ -685,6 +685,16 @@ const ZoomPage = ({
                               setLoading(false)
                             })
                         })
+                        .catch(() => {
+                          toast.error(
+                            <>
+                              An error occured while trying to add your meeting.
+                              Please contact <Contact /> for assistance.
+                            </>,
+                            { hideProgressBar: true },
+                          )
+                          setLoading(false)
+                        })
                     }}
                   >
                     {zoomId ? (

--- a/frontend/pages/zoom.tsx
+++ b/frontend/pages/zoom.tsx
@@ -727,6 +727,17 @@ const ZoomPage = ({
                               .then(setUserMeetings)
                               .then(() => setLoading(false))
                           })
+                          .catch(() => {
+                            toast.error(
+                              <>
+                                An error occured while trying to delete your
+                                meeting. Please contact <Contact /> for
+                                assistance.
+                              </>,
+                              { hideProgressBar: true },
+                            )
+                            setLoading(false)
+                          })
                       }}
                     >
                       <Icon name="trash" /> Remove Meeting


### PR DESCRIPTION
- If the user has linked their Zoom account and the URL is a Zoom URL, then we should allow them to perform any modifications they want.
- Add a catch statement if the fix meeting fails so that the user isn't wondering what went wrong.