### PR TITLE
Invite page redesign

### DIFF
--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -352,7 +352,7 @@ class InvitePermission(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        if view.action in ["retrieve", "update", "partial_update"]:
+        if view.action in {"retrieve", "update", "partial_update", "destroy"}:
             return request.user.is_authenticated
         else:
             if not request.user.is_authenticated:

--- a/frontend/cypress/integration/invite_spec.js
+++ b/frontend/cypress/integration/invite_spec.js
@@ -40,7 +40,7 @@ describe('Invitation tests', () => {
       cy.login('bfranklin', 'test')
 
       cy.visit(`/invite/${invite['code']}/${invite['id']}/${invite['token']}`)
-      cy.contains('Invitation for Penn Pre-Professional Juggling Organization')
+      cy.contains('Penn Pre-Professional Juggling Organization has invited you')
     })
   })
 

--- a/frontend/pages/invite/[club]/[invite]/[token]/index.tsx
+++ b/frontend/pages/invite/[club]/[invite]/[token]/index.tsx
@@ -105,6 +105,9 @@ const Invite = ({
     }
     doApiRequest(`/clubs/${query.club}/invites/${query.invite}/?format=json`, {
       method: 'DELETE',
+      body: {
+        token: query.token,
+      },
     }).then((resp) => {
       if (resp.ok) {
         router.push(CLUB_ROUTE(), CLUB_ROUTE(query.club))

--- a/frontend/pages/invite/[club]/[invite]/[token]/index.tsx
+++ b/frontend/pages/invite/[club]/[invite]/[token]/index.tsx
@@ -99,6 +99,24 @@ const Invite = ({
     })
   }
 
+  const decline = () => {
+    if (query.invite === 'example') {
+      router.push(CLUB_ROUTE(), CLUB_ROUTE(query.club))
+    }
+    doApiRequest(`/clubs/${query.club}/invites/${query.invite}/?format=json`, {
+      method: 'DELETE',
+    }).then((resp) => {
+      if (resp.ok) {
+        router.push(CLUB_ROUTE(), CLUB_ROUTE(query.club))
+      } else {
+        resp.json().then((data) => {
+          setInviter(null)
+          setError(data)
+        })
+      }
+    })
+  }
+
   if (!authenticated) {
     return (
       <>
@@ -182,7 +200,7 @@ const Invite = ({
             </button>
             <button
               className="button is-medium is-light"
-              // TODO: implement decline behavior
+              onClick={() => decline()}
             >
               Decline Invitation
             </button>

--- a/frontend/pages/invite/[club]/[invite]/[token]/index.tsx
+++ b/frontend/pages/invite/[club]/[invite]/[token]/index.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ReactElement, useState } from 'react'
 import renderPage from 'renderPage'
+import styled from 'styled-components'
 import { Club } from 'types'
 import { doApiRequest, formatResponse } from 'utils'
 import {
@@ -14,6 +15,7 @@ import {
   SHOW_MEMBERS,
 } from 'utils/branding'
 
+import { CLUBS_NAVY } from '~/constants/colors'
 import { CLUB_ROUTE } from '~/constants/routes'
 
 type Query = {
@@ -36,6 +38,30 @@ type Inviter = {
 }
 
 type Error = { [key: string]: string } | string
+
+const InvitePageContainer = styled.div`
+  display: grid;
+  margin: auto;
+  padding: 30px 50px;
+  min-height: calc(100vh - 3.25rem);
+  color: rgb(31, 32, 73);
+
+  place-items: center;
+  grid-template-columns: 1fr 350px;
+  gap: 50px;
+  max-width: 900px;
+
+  @media only screen and (max-width: 900px) {
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: center;
+    padding: 30px;
+    grid-template-columns: 1fr;
+    img {
+      margin-bottom: 15px;
+    }
+  }
+`
 
 const Invite = ({
   club,
@@ -88,7 +114,7 @@ const Invite = ({
         <Metadata title={`${OBJECT_NAME_TITLE_SINGULAR} Invite`} />
         <h1 className="title is-2">404 Not Found</h1>
         {error != null ? (
-          <p>An error occured while processing your invitation.</p>
+          <p>An error occurred while processing your invitation.</p>
         ) : (
           <p>
             The {inviter == null ? 'invite' : OBJECT_NAME_SINGULAR} you are
@@ -106,50 +132,65 @@ const Invite = ({
   const { name, code, image_url: image } = club
 
   return (
-    <div style={{ padding: '30px 50px' }} className="has-text-centered">
+    <>
       <ClubMetadata club={club} />
-      {/* &#x1F389; is the confetti emoji. */}
-      <h2 className="title is-2">&#x1F389; Invitation for {name} &#x1F389;</h2>
-      <div className="title is-4" style={{ fontWeight: 'normal' }}>
-        <b>{inviter.name}</b> has invited you, <b>{inviter.email}</b>, to join{' '}
-        <Link href={CLUB_ROUTE()} as={CLUB_ROUTE(code)}>
-          <a>{name}</a>
-        </Link>
-        .
-      </div>
-      {image && (
-        <img
-          src={image}
-          alt={name}
-          style={{ maxHeight: 100, marginBottom: 15 }}
-        />
-      )}
-      <p style={{ marginBottom: 15 }}>
-        By accepting this invitation, you will be able to view the contact
-        information of other members and internal {OBJECT_NAME_SINGULAR}{' '}
-        documents.
-      </p>
-      {SHOW_MEMBERS && (
-        <p>
-          <label>
-            <input
-              type="checkbox"
-              checked={isPublic}
-              onChange={() => setIsPublic(!isPublic)}
-            />{' '}
-            Make my membership to this ${OBJECT_NAME_SINGULAR} public. Outsiders
-            will be able to see my name and role in {name}.
-          </label>
-        </p>
-      )}
-      <br />
-      <button
-        className="button is-large is-success"
-        onClick={() => accept(isPublic)}
-      >
-        Accept Invitation
-      </button>
-    </div>
+      <InvitePageContainer>
+        <div>
+          <h2
+            className="title is-2"
+            style={{
+              color: CLUBS_NAVY,
+            }}
+          >
+            You’re Invited!
+          </h2>
+          <div
+            className="title is-4"
+            style={{ fontWeight: 'normal', color: CLUBS_NAVY }}
+          >
+            <b>{inviter.name}</b> has invited you, <b>{inviter.email}</b>, to
+            join{' '}
+            <Link href={CLUB_ROUTE()} as={CLUB_ROUTE(code)}>
+              <a>{name}</a>
+            </Link>
+            .
+          </div>
+          <p style={{ marginBottom: 15, color: CLUBS_NAVY }}>
+            By accepting this invitation, you will be able to view the contact
+            information of other members and internal {OBJECT_NAME_SINGULAR}{' '}
+            documents.
+          </p>
+          {SHOW_MEMBERS && (
+            <p style={{ marginBottom: 15, color: CLUBS_NAVY }}>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={isPublic}
+                  onChange={() => setIsPublic(!isPublic)}
+                />{' '}
+                Make my membership to this {OBJECT_NAME_SINGULAR} public.
+                Outsiders will be able to see my name and role in {name}.
+              </label>
+            </p>
+          )}
+          <div className="buttons">
+            <button
+              className="button is-medium is-link"
+              onClick={() => accept(isPublic)}
+            >
+              Accept Invitation
+            </button>
+            <button
+              className="button is-medium is-light"
+              // TODO: implement decline behavior
+            >
+              Decline Invitation
+            </button>
+          </div>
+        </div>
+        {image && <img src={image} alt={name} style={{ maxWidth: 300 }} />}
+      </InvitePageContainer>
+    </>
   )
 }
 

--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -18,6 +18,7 @@ import {
   BULMA_PRIMARY,
   BULMA_SUCCESS,
   BULMA_WARNING,
+  SNOW,
   WHITE,
 } from './constants/colors'
 import { NAV_HEIGHT } from './constants/measurements'
@@ -68,6 +69,7 @@ const ToastStyle = styled.div`
 
 const Wrapper = styled.div`
   min-height: calc(100vh - ${NAV_HEIGHT});
+  background: ${SNOW};
 `
 
 const GlobalStyle = createGlobalStyle`


### PR DESCRIPTION
Redesign according to: https://www.figma.com/file/VVeUyX2YmUc4hhGh2a9pSk/Invite-Page?node-id=0%3A1
Related clubhouse story: https://app.clubhouse.io/pennlabs/story/2934/invite-page-redesign

Desktop(>900px):
![Screen Shot 2021-02-07 at 5 05 12 AM](https://user-images.githubusercontent.com/62971511/107128575-1ea65380-6902-11eb-8cab-6fe711821d64.png)
Mobile(<900px):
![Screen Shot 2021-02-07 at 5 07 20 AM](https://user-images.githubusercontent.com/62971511/107128604-5dd4a480-6902-11eb-829a-bf936c550d0b.png)

* Still needs a way to handle decline invitation
