### PR TITLE
Weekly Hub Changes

### DIFF
--- a/backend/templates/fyh_emails/ics_calendar_ingestation.html
+++ b/backend/templates/fyh_emails/ics_calendar_ingestation.html
@@ -1,0 +1,24 @@
+<!-- SUBJECT: New iCal Feature on Hub@Penn! -->
+<!-- TYPES: {} -->
+{% extends 'fyh_emails/base.html' %}
+
+{% block content %}
+    <h2>Feature Update</h2>
+    <p style="font-size: 1.2em">
+    	Along with Penn Labs, we’ve been working hard to improve functionality on Hub@Penn. We are happy to launch <b>iCal integration</b> functionality. You can now sync your iCal with your resource card, making it easy for anyone viewing your resource on Hub@Penn to see upcoming events.
+    </p>
+    <p style="font-size: 1.2em">
+    	We’ve put together a short tutorial video on how to sync an iCal with your resource on Hub@Penn:
+    </p>
+    <a href="https://www.youtube.com/watch?v=fsxWKX7vTNU"><img alt="watch video" src="https://i.imgur.com/FfpFsiP.png"
+        width="100%" /></a>
+    <p style="font-size: 1.2em">
+    	This calendar integration is optional, and you can always add individual events to your resource as you see fit.
+    </p>
+    <p style="font-size: 1.2em">
+    	Please feel free to reach out with any questions.
+    </p>
+    <p style="font-size: 1.2em">
+    	Hub@Penn Team
+    </p>
+{% endblock %}

--- a/frontend/components/ClubEditPage/ClubEditCard.tsx
+++ b/frontend/components/ClubEditPage/ClubEditCard.tsx
@@ -479,9 +479,12 @@ export default function ClubEditCard({
         },
         {
           name: 'target_years',
-          label: 'Degree Type',
+          label: SITE_ID === 'fyh' ? 'Degree Type' : 'Target Years',
           type: 'multiselect',
-          placeholder: `Select degree type relevant to your ${OBJECT_NAME_SINGULAR}!`,
+          placeholder:
+            SITE_ID === 'fyh'
+              ? `Select degree type relevant to your ${OBJECT_NAME_SINGULAR}!`
+              : `Select graduation years relevant to your ${OBJECT_NAME_SINGULAR}!`,
           choices: years,
           hidden: !showTargetFields,
         },

--- a/frontend/components/ClubEditPage/ClubEditCard.tsx
+++ b/frontend/components/ClubEditPage/ClubEditCard.tsx
@@ -479,8 +479,9 @@ export default function ClubEditCard({
         },
         {
           name: 'target_years',
+          label: 'Degree Type',
           type: 'multiselect',
-          placeholder: `Select graduation years relevant to your ${OBJECT_NAME_SINGULAR}!`,
+          placeholder: `Select degree type relevant to your ${OBJECT_NAME_SINGULAR}!`,
           choices: years,
           hidden: !showTargetFields,
         },


### PR DESCRIPTION
- [x] ICS calendar ingest email template
- [x] Target Year -> Degree Type on `/create`
- [ ] Changes Degree Type options to Undergraduate and Graduate (will do this on Django api once changes are deployed)
- [ ] Filter Loggings (pushed to this week, probably can be done by Wednesday, earlier the better)