### PR TITLE
Route Progress Bar

### DIFF
--- a/frontend/components/RouteProgressBar.tsx
+++ b/frontend/components/RouteProgressBar.tsx
@@ -56,10 +56,14 @@ const keyframeForState = (state: RouteProgressState): Keyframes | null => {
   }
 }
 
-const ProgressBar = styled.div<{ state: RouteProgressState }>`
+type ProgressBarProps = {
+  state: RouteProgressState | null
+}
+
+const ProgressBar = styled.div<ProgressBarProps>`
   position: absolute;
   height: 100%;
-  animation-name: ${({ state }) => keyframeForState(state)};
+  animation-name: ${({ state }) => (state ? keyframeForState(state) : 'none')};
   animation-duration: ${LONG_ANIMATION_DURATION};
   animation-timing-function: ease-in-out;
   animation-fill-mode: forwards;

--- a/frontend/components/RouteProgressBar.tsx
+++ b/frontend/components/RouteProgressBar.tsx
@@ -78,7 +78,7 @@ const ProgressBarContainer = styled.div`
 `
 
 type RouteProgressBarProps = {
-  fireThreshold: number
+  fireThreshold?: number
 }
 
 const RouteProgressBar = ({

--- a/frontend/components/RouteProgressBar.tsx
+++ b/frontend/components/RouteProgressBar.tsx
@@ -1,0 +1,115 @@
+import { useRouter } from 'next/router'
+import React, { ReactElement, ReactPortal, useEffect, useState } from 'react'
+import ReactDOM from 'react-dom'
+import styled, { Keyframes, keyframes } from 'styled-components'
+
+import { CLUBS_BLUE, CLUBS_RED, LONG_ANIMATION_DURATION } from '~/constants'
+
+enum RouteProgressState {
+  ROUTE_CHANGE_START = 'START',
+  ROUTE_CHANGE_COMPLETE = 'COMPLETE',
+  ROUTE_CHANGE_ERROR = 'ERROR',
+}
+
+const keyframeForState = (state: RouteProgressState): Keyframes | null => {
+  switch (state) {
+    case RouteProgressState.ROUTE_CHANGE_START:
+      return keyframes`
+      0% {
+        width: 0%;
+        background: transparent;
+      }
+      100% {
+        width: 35%;
+        background: ${CLUBS_BLUE};
+      }
+      `
+    case RouteProgressState.ROUTE_CHANGE_COMPLETE:
+      return keyframes`
+      0% {
+        width: 35%;
+        background: ${CLUBS_BLUE};
+      }
+      50% {
+        width: 100%;
+        background: ${CLUBS_BLUE};
+      }
+      100% {
+        width: 100%;
+        background: transparent;
+      }
+      `
+    case RouteProgressState.ROUTE_CHANGE_ERROR:
+      return keyframes`
+      0% {
+        width: 35%;
+        background: ${CLUBS_BLUE};
+      }
+      50% {
+        width: 100%;
+        background: ${CLUBS_RED};
+      }
+      100% {
+        width: 100%;
+        background: transparent;
+      }`
+  }
+}
+
+const ProgressBar = styled.div<{ state: RouteProgressState }>`
+  position: absolute;
+  height: 100%;
+  animation-name: ${({ state }) => keyframeForState(state)};
+  animation-duration: ${LONG_ANIMATION_DURATION};
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+`
+
+const ProgressBarContainer = styled.div`
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 3px;
+  z-index: 1002;
+`
+
+const RouteProgressBar = (): ReactPortal | ReactElement => {
+  const container =
+    typeof window !== 'undefined'
+      ? document.querySelector("nav[aria-label='main navigation']")
+      : null
+  const router = useRouter()
+  const [state, setState] = useState<RouteProgressState | null>(null)
+
+  useEffect(() => {
+    const genHandler = (state: RouteProgressState) => () => setState(state)
+    const handlers = {
+      routeChangeStart: genHandler(RouteProgressState.ROUTE_CHANGE_START),
+      routeChangeComplete: genHandler(RouteProgressState.ROUTE_CHANGE_COMPLETE),
+      routeChangeError: genHandler(RouteProgressState.ROUTE_CHANGE_ERROR),
+    }
+    for (const key in handlers) {
+      router.events.on(key, handlers[key])
+    }
+    return () => {
+      for (const key in handlers) {
+        router.events.off(key, handlers[key])
+      }
+    }
+  }, [])
+
+  return container ? (
+    ReactDOM.createPortal(
+      <ProgressBarContainer>
+        <ProgressBar state={state} />
+      </ProgressBarContainer>,
+      container,
+    )
+  ) : (
+    <ProgressBarContainer>
+      <ProgressBar state={null} />
+    </ProgressBarContainer>
+  )
+}
+
+export default RouteProgressBar

--- a/frontend/components/RouteProgressBar.tsx
+++ b/frontend/components/RouteProgressBar.tsx
@@ -11,7 +11,7 @@ enum RouteProgressState {
   ROUTE_CHANGE_ERROR = 'ERROR',
 }
 
-const keyframeForState = (state: RouteProgressState): Keyframes | null => {
+const keyframeForState = (state: RouteProgressState): Keyframes => {
   switch (state) {
     case RouteProgressState.ROUTE_CHANGE_START:
       return keyframes`

--- a/frontend/components/RouteProgressBar.tsx
+++ b/frontend/components/RouteProgressBar.tsx
@@ -77,7 +77,13 @@ const ProgressBarContainer = styled.div`
   z-index: 1002;
 `
 
-const RouteProgressBar = (): ReactPortal | ReactElement => {
+type RouteProgressBarProps = {
+  fireThreshold: number
+}
+
+const RouteProgressBar = ({
+  fireThreshold = 250,
+}: RouteProgressBarProps): ReactPortal | ReactElement => {
   const container =
     typeof window !== 'undefined'
       ? document.querySelector("nav[aria-label='main navigation']")
@@ -87,9 +93,18 @@ const RouteProgressBar = (): ReactPortal | ReactElement => {
 
   useEffect(() => {
     const genHandler = (state: RouteProgressState) => () => setState(state)
+    let timeout: number | null = null
     const handlers = {
-      routeChangeStart: genHandler(RouteProgressState.ROUTE_CHANGE_START),
-      routeChangeComplete: genHandler(RouteProgressState.ROUTE_CHANGE_COMPLETE),
+      routeChangeStart: () => {
+        timeout = window.setTimeout(
+          genHandler(RouteProgressState.ROUTE_CHANGE_START),
+          fireThreshold,
+        )
+      },
+      routeChangeComplete: () => {
+        if (timeout != null) clearTimeout(timeout)
+        setState(RouteProgressState.ROUTE_CHANGE_COMPLETE)
+      },
       routeChangeError: genHandler(RouteProgressState.ROUTE_CHANGE_ERROR),
     }
     for (const key in handlers) {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -6,8 +6,15 @@ import 'react-toastify/dist/ReactToastify.min.css'
 import { AppProps } from 'next/app'
 import { ReactElement } from 'react'
 
+import RouteProgressBar from '~/components/RouteProgressBar'
+
 const App = ({ Component, pageProps }: AppProps): ReactElement => {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Component {...pageProps} />
+      <RouteProgressBar />
+    </>
+  )
 }
 
 export default App


### PR DESCRIPTION
Some pages take a bit to load and I thought it might be a good idea to entertain the user with a progress bar while the page is loading new resources.

This uses next.js's router events to simulate "progress" (which really isn't, it's just a pseudo-progress based on start-complete state events) and its real purpose is to just tell the user that nothing is really frozen, it's just stuff happening in the background.

Inspired by YouTube I guess?

![penn-clubs-route-loading](https://user-images.githubusercontent.com/62971511/107964312-7d4b8b80-6fec-11eb-98b2-947696eeed2a.gif)

If you want a higher resolution preview, here's the original screen recording: https://user-images.githubusercontent.com/62971511/107964328-8177a900-6fec-11eb-85f2-d70fb937c4be.mov