### PR TITLE
Status Reminder Email for Wharton Council

### DIFF
--- a/backend/clubs/management/commands/send_emails.py
+++ b/backend/clubs/management/commands/send_emails.py
@@ -199,7 +199,9 @@ class Command(BaseCommand):
             tf.close()
 
         if action == "update_status_reminder":
-            wc_badge = Badge.objects.filter(pk=15).first()
+            wc_badge = Badge.objects.filter(
+                label="Wharton Council", purpose="org",
+            ).first()
             clubs = Club.objects.filter(badges__in=[wc_badge])
             payloads = []
             for club in clubs:

--- a/backend/clubs/management/commands/wharton_council_application.py
+++ b/backend/clubs/management/commands/wharton_council_application.py
@@ -17,9 +17,7 @@ class Command(BaseCommand):
     web_execute = True
 
     def handle(self, *args, **kwargs):
-        wc_badge = Badge.objects.filter(
-            label="Wharton Council", purpose="org",
-        ).first()
+        wc_badge = Badge.objects.filter(label="Wharton Council", purpose="org",).first()
         eastern = pytz.timezone("America/New_York")
         application_start_time = datetime.datetime(2021, 9, 4, 0, 0, tzinfo=eastern)
         application_end_time = datetime.datetime(2021, 9, 20, 2, 0, tzinfo=eastern)

--- a/backend/clubs/management/commands/wharton_council_application.py
+++ b/backend/clubs/management/commands/wharton_council_application.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         wc_badge = Badge.objects.filter(
-            description="Wharton Council constituent"
+            label="Wharton Council", purpose="org",
         ).first()
         eastern = pytz.timezone("America/New_York")
         application_start_time = datetime.datetime(2021, 9, 4, 0, 0, tzinfo=eastern)

--- a/backend/templates/emails/update_status_reminder.html
+++ b/backend/templates/emails/update_status_reminder.html
@@ -1,0 +1,15 @@
+<!-- TYPES:
+applications_url:
+    type: string
+-->
+{% extends 'emails/base.html' %} {% block content %}
+<h2>Update Application Statuses</h2>
+<p style="font-size: 1.2em">Hi club officers,</p>
+<p style="font-size: 1.2em">
+  We're writing to remind you that you are required to update your club
+  application submissions with the decision you made for candidates: {{
+  applications_url }}.
+</p>
+<p style="font-size: 1.2em">Best,</p>
+<p style="font-size: 1.2em">Penn Clubs</p>
+{% endblock %}

--- a/backend/templates/emails/update_status_reminder.html
+++ b/backend/templates/emails/update_status_reminder.html
@@ -4,12 +4,22 @@ applications_url:
 -->
 {% extends 'emails/base.html' %} {% block content %}
 <h2>Update Application Statuses</h2>
+
 <p style="font-size: 1.2em">Hi club officers,</p>
+
 <p style="font-size: 1.2em">
   We're writing to remind you that you are required to update your club
   application submissions with the decision you made for candidates: {{
   applications_url }}.
 </p>
-<p style="font-size: 1.2em">Best,</p>
-<p style="font-size: 1.2em">Penn Clubs</p>
+
+<p style="font-size: 1.2em">
+  Thanks so much for your cooperation! Feel free to reply to this email if you
+  have any questions.
+</p>
+
+<p style="font-size: 1.2em">
+    Best, </br>
+    Penn Clubs
+</p>
 {% endblock %}


### PR DESCRIPTION
Wharton Council wants us to send out a reminder email to all Wharton Council clubs telling them they have to update their decision statuses for application submissions.