### PR TITLE
Wharton Council Fixes

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -51,6 +51,7 @@ jsonref = "*"
 unittest-xml-reporting = "*"
 tblib = "*"
 pre-commit = "*"
+django-clone = "*"
 
 [requires]
 python_version = "3"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6a63af0d8107d9e40faff0963f06ab2ee56e5d68a4fb4e49b3314ccee6fa307a"
+            "sha256": "ebeb34dcfd58ce86a7aee2ed18042c0fb124d534ee3b168f1943f1e294212b34"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -228,6 +228,14 @@
             ],
             "version": "==0.4.4"
         },
+        "conditional": {
+            "hashes": [
+                "sha256:41144eab07db219340c91af6614753ec757e16f011c5667e96e81f14f6a566f4",
+                "sha256:c9e648217df59c950888c29d0a9bffe4eca92b4870f1477395b82fdedc6293a7"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.4"
+        },
         "constantly": {
             "hashes": [
                 "sha256:586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35",
@@ -306,6 +314,14 @@
             ],
             "index": "pypi",
             "version": "==3.2.8"
+        },
+        "django-clone": {
+            "hashes": [
+                "sha256:148fd7617f281162980b4cc8d658afe477136d664bb20bdb20870c80bacc4fef",
+                "sha256:aeecfd5b7db13014caed3d32dab415b4a73e85d1bf9317f656180e67c2a1db09"
+            ],
+            "index": "pypi",
+            "version": "==3.0.3"
         },
         "django-cors-headers": {
             "hashes": [
@@ -402,6 +418,13 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.3.0"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.18.2"
         },
         "gunicorn": {
             "hashes": [

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -19,6 +19,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from ics import Calendar
+from model_clone.models import CloneModel
 from phonenumber_field.modelfields import PhoneNumberField
 from simple_history.models import HistoricalRecords
 from urlextract import URLExtract
@@ -1517,7 +1518,7 @@ class Profile(models.Model):
         return self.user.username
 
 
-class ClubApplication(models.Model):
+class ClubApplication(CloneModel):
     """
     Represents custom club application.
     """
@@ -1537,6 +1538,11 @@ class ClubApplication(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    _clone_m2o_or_o2m_fields = [
+        "committees",
+        "questions",
+    ]
+
     def __str__(self):
         return "{} created {}: start {}, end {}".format(
             self.club.name,
@@ -1544,6 +1550,12 @@ class ClubApplication(models.Model):
             self.application_start_time,
             self.application_end_time,
         )
+
+    @property
+    def season(self):
+        semester = "Fall" if 8 <= self.application_start_time.month <= 11 else "Spring"
+        year = str(self.application_start_time.year)
+        return f"{semester} {year}"
 
 
 class ApplicationCommittee(models.Model):
@@ -1561,7 +1573,7 @@ class ApplicationCommittee(models.Model):
         return "<ApplicationCommittee: {} in {}>".format(self.name, self.application.pk)
 
 
-class ApplicationQuestion(models.Model):
+class ApplicationQuestion(CloneModel):
     """
     Represents a question of a custom application
     """
@@ -1589,6 +1601,8 @@ class ApplicationQuestion(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True, null=True, blank=True)
     updated_at = models.DateTimeField(auto_now=True, null=True, blank=True)
+
+    _clone_m2o_or_o2m_fields = ["multiple_choice"]
 
 
 class ApplicationMultipleChoice(models.Model):

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ValidationError
 from django.core.mail import EmailMultiAlternatives
 from django.core.validators import validate_email
 from django.db import models, transaction
+from django.db.models import Sum
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -1568,6 +1569,12 @@ class ApplicationCommittee(models.Model):
     application = models.ForeignKey(
         ClubApplication, related_name="committees", on_delete=models.CASCADE,
     )
+
+    def get_word_limit(self):
+        total_limit = self.applicationquestion_set.aggregate(
+            total_limit=Sum("word_limit")
+        )
+        return total_limit["total_limit"] or 0
 
     def __str__(self):
         return "<ApplicationCommittee: {} in {}>".format(self.name, self.application.pk)

--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -271,7 +271,13 @@ class ClubItemPermission(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        if view.action in ["create", "update", "partial_update", "destroy"]:
+        if view.action in [
+            "duplicate",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+        ]:
             if "club_code" not in view.kwargs:
                 return False
             if not request.user.is_authenticated:

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -2570,6 +2570,12 @@ class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
     club = serializers.SlugRelatedField(slug_field="code", read_only=True)
     updated_at = serializers.SerializerMethodField("get_updated_time", read_only=True)
     club_image_url = serializers.SerializerMethodField("get_image_url", read_only=True)
+    season = serializers.CharField(read_only=True)
+    active = serializers.SerializerMethodField("get_active", read_only=True)
+
+    def get_active(self, obj):
+        now = timezone.now()
+        return obj.application_start_time <= now and obj.application_end_time >= now
 
     def get_name(self, obj):
         if obj.name:
@@ -2646,6 +2652,8 @@ class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
         model = ClubApplication
         fields = (
             "id",
+            "season",
+            "active",
             "name",
             "application_start_time",
             "application_end_time",

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -2334,6 +2334,41 @@ class ApplicationQuestionSerializer(ClubRouteMixin, serializers.ModelSerializer)
             "precedence",
         )
 
+    def validate_word_limit(self, value):
+        """
+        For wharton council applications, ensure that the committees have
+        at most 500 words worth of questions
+        """
+
+        data = self.context["request"].data
+
+        if "committees" in data:
+            committees = data["committees"]
+
+            application = ClubApplication.objects.filter(
+                pk=self.context["view"].kwargs.get("application_pk")
+            ).first()
+
+            if not application.is_wharton_council:
+                return value
+
+            for committee in committees:
+                obj = ApplicationCommittee.objects.filter(
+                    application=application, name=committee["name"]
+                ).first()
+
+                current_limit = obj.get_word_limit()
+
+                instance_limit = self.instance.word_limit if self.instance else 0
+
+                if data["word_limit"] + current_limit - instance_limit > 500:
+                    raise serializers.ValidationError(
+                        f"The total word limit of questions in committee \
+                        ''{committee['name']} ' should not exceed 500. \
+                        Current: {current_limit}"
+                    )
+        return value
+
     def create(self, validated_data):
         # remove club from request we do not use it
         validated_data.pop("club")
@@ -2342,6 +2377,7 @@ class ApplicationQuestionSerializer(ClubRouteMixin, serializers.ModelSerializer)
         validated_data["application"] = ClubApplication.objects.filter(
             pk=application_pk
         ).first()
+
         return super().create(validated_data)
 
     def save(self):
@@ -2575,7 +2611,7 @@ class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
 
     def get_active(self, obj):
         now = timezone.now()
-        return obj.application_start_time <= now and obj.application_end_time >= now
+        return obj.application_end_time >= now
 
     def get_name(self, obj):
         if obj.name:

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4552,6 +4552,15 @@ class ClubApplicationViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"])
     def duplicate(self, *args, **kwargs):
+        """
+        Duplicate an application, setting the start and end time arbitrarily.
+        ---
+        requestBody: {}
+        responses:
+            "200":
+                content: {}
+        ---
+        """
         obj = self.get_object()
 
         clone = obj.make_clone()

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -36,6 +36,7 @@ ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
     "channels",
+    "model_clone",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/frontend/components/ClubEditPage/ApplicationsCard.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsCard.tsx
@@ -111,12 +111,11 @@ const ApplicationModal = (props: {
             {questionType !== null &&
               questionType === ApplicationQuestionType.FreeResponse && (
                 <Field
-                  validate={validateWordCount}
                   name="word_limit"
                   as={TextField}
                   type={'number'}
                   helpText={
-                    'Word limit for this free response question (max 500)'
+                    'Word limit for this free response question (maximum total per committee is 500)'
                   }
                 />
               )}
@@ -264,7 +263,7 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
       </ul>
 
       <Text>
-        <b> PSA</b>: To copy over your application from last semester, please
+        <b>TIP</b>: To copy over your application from last semester, please
         click <b> duplicate </b> on the application from the season that you
         would like to copy over and refresh the page. You can then edit this
         application as you please.

--- a/frontend/components/ClubEditPage/ApplicationsCard.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsCard.tsx
@@ -75,6 +75,14 @@ const ApplicationModal = (props: {
   >()
   const [committeeQuestion, setCommitteeQuestion] = useState<boolean>()
 
+  const validateWordCount = (value) => {
+    let errorMsg
+    if (+value > 500) {
+      errorMsg = 'Please enter a valid word count'
+    }
+    return errorMsg
+  }
+
   return (
     <ModalContainer>
       <ModelForm
@@ -103,10 +111,13 @@ const ApplicationModal = (props: {
             {questionType !== null &&
               questionType === ApplicationQuestionType.FreeResponse && (
                 <Field
+                  validate={validateWordCount}
                   name="word_limit"
                   as={TextField}
                   type={'number'}
-                  helpText={'Word limit for this free response question'}
+                  helpText={
+                    'Word limit for this free response question (max 500)'
+                  }
                 />
               )}
             {questionType !== null &&
@@ -204,6 +215,19 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
     }>
   } | null>(null)
 
+  function duplicateApplicationCurrent(id, obj) {
+    if (
+      confirm(
+        `Are you sure you want to duplicate the selected application? Please refresh the page after you select OK`,
+      )
+    ) {
+      doApiRequest(`/clubs/${club.code}/applications/${id}/duplicate/`, {
+        method: 'POST',
+        body: {},
+      })
+    }
+  }
+
   return (
     <BaseCard title={`${OBJECT_NAME_TITLE_SINGULAR} Applications`}>
       <Text>
@@ -233,11 +257,19 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
           <li key={i}>
             <span className=" ml-3 has-text-success">
               <Icon name="check" />
-            </span>{' '}
+            </span>
             {text}
           </li>
         ))}
       </ul>
+
+      <Text>
+        <b> PSA</b>: To copy over your application from last semester, please
+        click <b> duplicate </b> on the application from the season that you
+        would like to copy over and refresh the page. You can then edit this
+        application as you please.
+      </Text>
+
       <ModelForm
         baseUrl={`/clubs/${club.code}/applications/`}
         defaultObject={{ name: `${club.name} Application` }}
@@ -313,23 +345,36 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
             />
           </>
         }
+        confirmDeletion={true}
         tableFields={[
           { name: 'name', label: 'Name' },
+          { name: 'season', label: 'Season' },
           {
             name: 'id',
             label: 'Edit',
-            render: (id) => {
+            converter: (id, object) => {
               return (
                 <>
-                  <button
-                    className="button is-primary is-small"
-                    onClick={() => {
-                      setApplicationName(id)
-                      showModal()
-                    }}
-                  >
-                    Questions
-                  </button>
+                  {object.active ? (
+                    <button
+                      className="button is-primary is-small"
+                      onClick={() => {
+                        setApplicationName(id)
+                        showModal()
+                      }}
+                    >
+                      Questions
+                    </button>
+                  ) : (
+                    <button
+                      className="button is-primary is-small"
+                      onClick={() => {
+                        duplicateApplicationCurrent(id, 1)
+                      }}
+                    >
+                      Duplicate
+                    </button>
+                  )}
                   <a href={`/club/${club.code}/application/${id}`}>
                     <button className="button is-primary is-small ml-3">
                       Preview

--- a/frontend/components/ClubEditPage/ApplicationsCard.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsCard.tsx
@@ -257,7 +257,7 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
           <li key={i}>
             <span className=" ml-3 has-text-success">
               <Icon name="check" />
-            </span>
+            </span>{' '}
             {text}
           </li>
         ))}

--- a/frontend/components/ModelForm.tsx
+++ b/frontend/components/ModelForm.tsx
@@ -174,36 +174,38 @@ export const ModelTable = ({
       }
       return (
         <div className="buttons">
-          {allowEditing && (
-            <button
-              onClick={() => {
-                return onEdit(object)
-              }}
-              className="button is-primary is-small"
-            >
-              <Icon name="edit" alt="edit" /> Edit
-            </button>
-          )}
-          {allowDeletion && (
-            <button
-              onClick={() => {
-                if (confirmDeletion) {
-                  if (
-                    confirm(
-                      `Are you sure you want to ${deleteVerb.toLowerCase()} this ${noun.toLowerCase()}?`,
-                    )
-                  ) {
+          {allowEditing &&
+            (object.active === true || object.active === undefined) && (
+              <button
+                onClick={() => {
+                  return onEdit(object)
+                }}
+                className="button is-primary is-small"
+              >
+                <Icon name="edit" alt="edit" /> Edit
+              </button>
+            )}
+          {allowDeletion &&
+            (object.active === true || object.active === undefined) && (
+              <button
+                onClick={() => {
+                  if (confirmDeletion) {
+                    if (
+                      confirm(
+                        `Are you sure you want to ${deleteVerb.toLowerCase()} this ${noun.toLowerCase()}?`,
+                      )
+                    ) {
+                      onDelete(object)
+                    }
+                  } else {
                     onDelete(object)
                   }
-                } else {
-                  onDelete(object)
-                }
-              }}
-              className="button is-danger is-small"
-            >
-              <Icon name="trash" alt="delete" /> {deleteVerb}
-            </button>
-          )}
+                }}
+                className="button is-danger is-small"
+              >
+                <Icon name="trash" alt="delete" /> {deleteVerb}
+              </button>
+            )}
           {actions && actions(object)}
         </div>
       )

--- a/frontend/pages/club/[club]/application/[application]/index.tsx
+++ b/frontend/pages/club/[club]/application/[application]/index.tsx
@@ -256,13 +256,16 @@ const ApplicationPage = ({
                 doApiRequest('/users/question_response/?format=json', {
                   method: 'POST',
                   body,
-                }).then((resp) => {
-                  if (resp.status === 400) {
-                    setErrors('You have already applied to 2 committees!')
-                  } else {
-                    setSaved(true)
-                  }
                 })
+                  .then((resp) => resp.json())
+                  .then((data) => {
+                    if (data.success === false) {
+                      setSaved(false)
+                      setErrors(data.detail)
+                    } else {
+                      setSaved(true)
+                    }
+                  })
               }
             } else {
               setErrors(submitErrors)

--- a/frontend/pages/club/[club]/application/[application]/index.tsx
+++ b/frontend/pages/club/[club]/application/[application]/index.tsx
@@ -256,9 +256,14 @@ const ApplicationPage = ({
                 doApiRequest('/users/question_response/?format=json', {
                   method: 'POST',
                   body,
+                }).then((resp) => {
+                  if (resp.status === 400) {
+                    setErrors('You have already applied to 2 committees!')
+                  } else {
+                    setSaved(true)
+                  }
                 })
               }
-              setSaved(true)
             } else {
               setErrors(submitErrors)
             }


### PR DESCRIPTION
**Short Summary**

This is a mega PR that aims to address the following [critical] requests from Wharton Council: 

• make sure that it is easy for clubs to create their applications (and maybe even copy them from previous years)
• prevent the problem of them accidentally deleting their application like last semester.
• make sure that each application is limited to 500 words per committee,
• see that each applicant is only allowed to apply to two committees per club.

**Detailed Summary**

- [x] Application duplication,  implemented using `django-clone`. This allows the recursive cloning of `ClubApplication`, and corresponding `ApplicationQuestion`, `ApplicationCommittee`, `ApplicationMultipleChoice` fields to create a "fresh" application.
- [x] Application segmentation by season. This is generated as a `@property` which parses the application's start/end time month and year to generate a more readable string. e.g "Fall 2022"
- [x] Added a confirmation dialog for application deletion
- [x] Prevented ability to modify (edit/delete) applications from earlier seasons by introducing an `active` parameter on `ClubApplication`
- [x] Limit number of applied committees to 2. Note: the 2 applied committees is constant once the limit is hit, i.e once an applicant has submitted applications to committee A and B they can only continue to apply to A and B. I think this is ok design, but definitely should get a stamp on this before merging
- [x] Limit application word count to 500


**Tests/rollout/revert plan**

- I will add test cases for backend functionality (clone/committee applications) before merging