### PR TITLE
General Improvements / Fixes

### DIFF
--- a/backend/clubs/admin.py
+++ b/backend/clubs/admin.py
@@ -14,6 +14,7 @@ from clubs.models import (
     AdminNote,
     Advisor,
     ApplicationCommittee,
+    ApplicationCycle,
     ApplicationMultipleChoice,
     ApplicationQuestion,
     ApplicationQuestionResponse,
@@ -404,12 +405,17 @@ class ZoomMeetingVisitAdmin(admin.ModelAdmin):
     list_filter = (("leave_time", admin.EmptyFieldListFilter),)
 
 
+class ApplicationSubmissionAdmin(admin.ModelAdmin):
+    list_display = ("user", "id", "created_at", "status", "archived")
+    list_filter = ("archived",)
+
+
 admin.site.register(Asset)
 admin.site.register(ApplicationCommittee)
 admin.site.register(ApplicationMultipleChoice)
 admin.site.register(ApplicationQuestion)
 admin.site.register(ApplicationQuestionResponse)
-admin.site.register(ApplicationSubmission)
+admin.site.register(ApplicationSubmission, ApplicationSubmissionAdmin)
 admin.site.register(Advisor, AdvisorAdmin)
 admin.site.register(Club, ClubAdmin)
 admin.site.register(ClubFair, ClubFairAdmin)
@@ -443,3 +449,4 @@ admin.site.register(NoteTag)
 admin.site.register(Year, YearAdmin)
 admin.site.register(ZoomMeetingVisit, ZoomMeetingVisitAdmin)
 admin.site.register(AdminNote)
+admin.site.register(ApplicationCycle)

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -1535,6 +1535,9 @@ class ApplicationCycle(models.Model):
     start_date = models.DateTimeField(null=True)
     end_date = models.DateTimeField(null=True)
 
+    def __str__(self):
+        return self.name
+
 
 class ClubApplication(CloneModel):
     """
@@ -1575,9 +1578,9 @@ class ClubApplication(CloneModel):
             self.application_end_time,
         )
 
-    @property
+    @cached_property
     def season(self):
-        semester = "Fall" if 8 <= self.application_start_time.month <= 11 else "Spring"
+        semester = "Fall" if 8 <= self.application_start_time.month <= 12 else "Spring"
         year = str(self.application_start_time.year)
         return f"{semester} {year}"
 
@@ -1688,6 +1691,9 @@ class ApplicationSubmission(models.Model):
     notified = models.BooleanField(default=False)
 
     created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.user.first_name}: {self.application.name}"
 
 
 class ApplicationQuestionResponse(models.Model):

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1661,6 +1661,7 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
             "instagram",
             "is_ghost",
             "is_request",
+            "is_wharton",
             "linkedin",
             "listserv",
             "members",
@@ -2585,6 +2586,7 @@ class ApplicationSubmissionCSVSerializer(serializers.ModelSerializer):
 
 class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
     name = serializers.SerializerMethodField("get_name")
+    cycle = serializers.SerializerMethodField("get_cycle")
     committees = ApplicationCommitteeSerializer(
         many=True, required=False, read_only=True
     )
@@ -2592,8 +2594,10 @@ class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
     club = serializers.SlugRelatedField(slug_field="code", read_only=True)
     updated_at = serializers.SerializerMethodField("get_updated_time", read_only=True)
     club_image_url = serializers.SerializerMethodField("get_image_url", read_only=True)
-    season = serializers.CharField(read_only=True)
     active = serializers.SerializerMethodField("get_active", read_only=True)
+
+    def get_cycle(self, obj):
+        return obj.application_cycle.name if obj.application_cycle else obj.season
 
     def get_active(self, obj):
         now = timezone.now()
@@ -2683,9 +2687,9 @@ class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
         model = ClubApplication
         fields = (
             "id",
-            "season",
             "active",
             "name",
+            "cycle",
             "acceptance_email",
             "rejection_email",
             "application_start_time",

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1937,12 +1937,18 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         return super().update(request, *args, **kwargs)
 
     @method_decorator(cache_page(60 * 60))
-    def list(self, request, *args, **kwargs):
+    def list(self, *args, **kwargs):
         """
-        Return a list of all clubs.
-        Note that some fields are removed in order to improve response time.
+        Return a list of all clubs. Responses cached for 1 hour
         """
-        return super().list(request, *args, **kwargs)
+        return super().list(*args, **kwargs)
+
+    @method_decorator(cache_page(60 * 60))
+    def retrieve(self, request, *args, **kwargs):
+        """
+        Retrieve data about a specific club. Responses cached for 1 hour
+        """
+        return super().retrieve(request, *args, **kwargs)
 
     def perform_destroy(self, instance):
         """
@@ -4546,10 +4552,12 @@ class UserViewSet(viewsets.ModelViewSet):
 
         response = (
             ApplicationQuestionResponse.objects.filter(
-                submission__user=self.request.user
+                submission__user=self.request.user, submission__archived=False
             )
             .filter(question__prompt=question.prompt)
             .order_by("-updated_at")
+            .select_related("submission", "multiple_choice", "question")
+            .prefetch_related("question__committees", "question__multiple_choice")
             .first()
         )
 
@@ -4569,6 +4577,8 @@ class ClubApplicationViewSet(viewsets.ModelViewSet):
     create: Create an application for the club.
 
     list: Retrieve a list of applications of the club.
+
+    current: Retrieve a list of active applications of the club.
 
     send_emails: Send out acceptance/rejection emails
     """
@@ -4635,6 +4645,12 @@ class ClubApplicationViewSet(viewsets.ModelViewSet):
         ).select_related("user", "committee")
 
         dry_run = self.request.data.get("dry_run")
+
+        if not dry_run:
+            # Invalidate submission viewset cache
+            key = f"applicationsubmissions:{app.id}"
+            cache.delete(key)
+
         email_type = self.request.data.get("email_type")["id"]
 
         subject = f"Application Update for {app.name}"
@@ -4697,6 +4713,27 @@ class ClubApplicationViewSet(viewsets.ModelViewSet):
             }
         )
 
+    @action(detail=False, methods=["get"])
+    def current(self, *args, **kwargs):
+        """
+        Return the ongoing application(s) for this club
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            allOf:
+                                - $ref: "#/components/schemas/ClubApplication"
+        ---
+        """
+        qs = self.get_queryset()
+        return Response(
+            ClubApplicationSerializer(
+                qs.filter(application_end_time__gte=timezone.now()), many=True
+            ).data
+        )
+
     @action(detail=True, methods=["post"])
     def duplicate(self, *args, **kwargs):
         """
@@ -4736,7 +4773,14 @@ class ClubApplicationViewSet(viewsets.ModelViewSet):
         return ClubApplicationSerializer
 
     def get_queryset(self):
-        return ClubApplication.objects.filter(club__code=self.kwargs["club_code"])
+
+        return (
+            ClubApplication.objects.filter(club__code=self.kwargs["club_code"],)
+            .select_related("application_cycle", "club")
+            .prefetch_related(
+                "questions__multiple_choice", "questions__committees", "committees",
+            )
+        )
 
 
 class WhartonApplicationAPIView(generics.ListAPIView):
@@ -4774,6 +4818,9 @@ class WhartonApplicationAPIView(generics.ListAPIView):
     @method_decorator(cache_page(60 * 20))
     @method_decorator(vary_on_cookie)
     def list(self, *args, **kwargs):
+        """
+        Cache responses for 20 minutes. Vary cache by user.
+        """
         return super().list(*args, **kwargs)
 
 
@@ -4874,9 +4921,25 @@ class ApplicationSubmissionViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         )
         return submissions
 
-    @method_decorator(cache_page(60 * 60))
     def list(self, *args, **kwargs):
-        return super().list(*args, **kwargs)
+        """
+        Manually cache responses (to support invalidation)
+        Responses are invalidated on status / reason updates
+        """
+
+        app_id = self.kwargs["application_pk"]
+        key = f"applicationsubmissions:{app_id}"
+
+        cached = cache.get(key)
+        if cached is not None:
+            return Response(cached)
+        else:
+            serializer = self.get_serializer_class()
+            qs = self.get_queryset()
+            data = serializer(qs, many=True).data
+            cache.set(key, data, 60 * 60)
+
+        return Response(data)
 
     @action(detail=False, methods=["get"])
     def export(self, *args, **kwargs):
@@ -4966,7 +5029,7 @@ class ApplicationSubmissionViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
                         schema:
                             type: object
                             properties:
-                                output:
+                                detail:
                                     type: string
 
         ---
@@ -4977,10 +5040,17 @@ class ApplicationSubmissionViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             status in map(lambda x: x[0], ApplicationSubmission.STATUS_TYPES)
             and len(submission_pks) > 0
         ):
-            ApplicationSubmission.objects.filter(pk__in=submission_pks).update(
-                status=status
-            )
-        return Response([])
+            # Invalidate submission viewset cache
+            submissions = ApplicationSubmission.objects.filter(pk__in=submission_pks)
+            app_id = submissions.first().application.id if submissions.first() else None
+            if not app_id:
+                return Response([])
+            key = f"applicationsubmissions:{app_id}"
+            cache.delete(key)
+
+            submissions.update(status=status)
+
+        return Response({"detail": "Successfully updated submissions' status"})
 
     @action(detail=False, methods=["post"])
     def reason(self, *args, **kwargs):
@@ -5021,6 +5091,15 @@ class ApplicationSubmissionViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         reasons = list(map(lambda x: x["reason"], submissions))
 
         submission_objs = ApplicationSubmission.objects.filter(pk__in=pks)
+
+        # Invalidate submission viewset cache
+        app_id = (
+            submission_objs.first().application.id if submission_objs.first() else None
+        )
+        if not app_id:
+            return Response({"detail": "No submissions found"})
+        key = f"applicationsubmissions:{app_id}"
+        cache.delete(key)
 
         for idx, obj in enumerate(submission_objs):
             obj.reason = reasons[idx]
@@ -5107,6 +5186,13 @@ class ApplicationQuestionViewSet(viewsets.ModelViewSet):
         return ApplicationQuestion.objects.filter(
             application__pk=self.kwargs["application_pk"]
         ).order_by("precedence")
+
+    @method_decorator(cache_page(60 * 60))
+    def list(self, *args, **kwargs):
+        """
+        Cache responses for one hour
+        """
+        return super().list(*args, **kwargs)
 
     @action(detail=False, methods=["post"])
     def precedence(self, *args, **kwargs):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4924,7 +4924,7 @@ class ApplicationSubmissionViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def list(self, *args, **kwargs):
         """
         Manually cache responses (to support invalidation)
-        Responses are invalidated on status / reason updates
+        Responses are invalidated on status / reason updates and email sending
         """
 
         app_id = self.kwargs["application_pk"]
@@ -5044,7 +5044,7 @@ class ApplicationSubmissionViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             submissions = ApplicationSubmission.objects.filter(pk__in=submission_pks)
             app_id = submissions.first().application.id if submissions.first() else None
             if not app_id:
-                return Response([])
+                return Response({"detail": "No submissions found"})
             key = f"applicationsubmissions:{app_id}"
             cache.delete(key)
 

--- a/frontend/components/ClubEditPage/ApplicationsCard.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsCard.tsx
@@ -263,14 +263,23 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
         ))}
       </ul>
 
+      {!club.is_wharton && (
+        <Text>
+          <b>TIP</b>: To copy over your application from last semester, please
+          click <b> duplicate </b> on the application from the season that you
+          would like to copy over and refresh the page. You can then edit this
+          application as you please.
+        </Text>
+      )}
+
       <Text>
-        <b>TIP</b>: To copy over your application from last semester, please
-        click <b> duplicate </b> on the application from the season that you
-        would like to copy over and refresh the page. You can then edit this
-        application as you please.
+        If your club is affiliated with the Wharton Council Centralised
+        Application, please note that editable applications will be provisioned
+        by the system administrator.{' '}
       </Text>
 
       <ModelForm
+        allowCreation={!club.is_wharton}
         baseUrl={`/clubs/${club.code}/applications/`}
         defaultObject={{ name: `${club.name} Application` }}
         onChange={(data) => {
@@ -364,7 +373,7 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
         confirmDeletion={true}
         tableFields={[
           { name: 'name', label: 'Name' },
-          { name: 'season', label: 'Season' },
+          { name: 'cycle', label: 'Cycle' },
           {
             name: 'id',
             label: 'Edit',
@@ -382,14 +391,16 @@ export default function ApplicationsCard({ club }: Props): ReactElement {
                       Questions
                     </button>
                   ) : (
-                    <button
-                      className="button is-primary is-small"
-                      onClick={() => {
-                        duplicateApplicationCurrent(id, 1)
-                      }}
-                    >
-                      Duplicate
-                    </button>
+                    !club.is_wharton && (
+                      <button
+                        className="button is-primary is-small"
+                        onClick={() => {
+                          duplicateApplicationCurrent(id, 1)
+                        }}
+                      >
+                        Duplicate
+                      </button>
+                    )
                   )}
                   <a href={`/club/${club.code}/application/${id}`}>
                     <button className="button is-primary is-small ml-3">

--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -210,9 +210,6 @@ const NotificationModal = (props: {
                 sub.status === 'Accepted' &&
                 sub.reason,
             )
-            for (const x of relevant) {
-              x.notified = true
-            }
             updateSubmissions(relevant)
           } else if (data.email_type.id === 'rejection' && !data.dry_run) {
             const relevant = submissions.filter(
@@ -221,9 +218,6 @@ const NotificationModal = (props: {
                 sub.status.startsWith('Rejected') &&
                 sub.reason,
             )
-            for (const x of relevant) {
-              x.notified = true
-            }
             updateSubmissions(relevant)
           }
           doApiRequest(

--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -17,7 +17,7 @@ import {
   ApplicationSubmission,
   Club,
 } from '~/types'
-import { doApiRequest, getApiUrl } from '~/utils'
+import { doApiRequest, getApiUrl, getSemesterFromDate } from '~/utils'
 
 import { Checkbox, Loading, Modal, Text } from '../common'
 import { Icon } from '../common/Icon'
@@ -97,6 +97,8 @@ const SubmissionSelect = (props: any) => {
 type Application = {
   id: number
   name: string
+  cycle: string
+  application_end_time: string
 }
 
 const ModalContainer = styled.div`
@@ -185,8 +187,9 @@ const NotificationModal = (props: {
   submissions: Array<ApplicationSubmission>
   club: string
   application: Application | null
+  updateSubmissions: (arr: Array<ApplicationSubmission>) => void
 }): ReactElement => {
-  const { submissions, club, application } = props
+  const { submissions, club, application, updateSubmissions } = props
   const initialValues = { dry_run: true }
   const [submitMessage, setSubmitMessage] = useState<
     string | ReactElement | null
@@ -199,7 +202,30 @@ const NotificationModal = (props: {
     <ModalContainer>
       <Formik
         initialValues={initialValues}
-        onSubmit={(data) => {
+        onSubmit={(data: any) => {
+          if (data.email_type.id === 'acceptance' && !data.dry_run) {
+            const relevant = submissions.filter(
+              (sub) =>
+                sub.notified === false &&
+                sub.status === 'Accepted' &&
+                sub.reason,
+            )
+            for (const x of relevant) {
+              x.notified = true
+            }
+            updateSubmissions(relevant)
+          } else if (data.email_type.id === 'rejection' && !data.dry_run) {
+            const relevant = submissions.filter(
+              (sub) =>
+                sub.notified === false &&
+                sub.status.startsWith('Rejected') &&
+                sub.reason,
+            )
+            for (const x of relevant) {
+              x.notified = true
+            }
+            updateSubmissions(relevant)
+          }
           doApiRequest(
             `/clubs/${club}/applications/${
               application!.id
@@ -245,10 +271,6 @@ const NotificationModal = (props: {
             {submitMessage !== null && (
               <div className="mt-2 mb-2 notification is-info is-light">
                 {submitMessage}
-                <p>
-                  Optionally refresh the page for your changes to be reflected
-                  below
-                </p>
               </div>
             )}
           </Form>
@@ -262,8 +284,9 @@ const ReasonModal = (props: {
   submissions: Array<ApplicationSubmission> | null
   club: string
   application: Application | null
+  updateSubmissions: (s: { name: string }) => void
 }): ReactElement => {
-  const { submissions, club, application } = props
+  const { submissions, club, application, updateSubmissions } = props
   const [submitMessage, setSubmitMessage] = useState<
     string | ReactElement | null
   >(null)
@@ -272,11 +295,12 @@ const ReasonModal = (props: {
     <ModalContainer>
       <Formik
         initialValues={initialValues}
-        onSubmit={(data) => {
-          const data_: any[] = []
+        onSubmit={(data: { name: string }) => {
+          const data_: { id: number; reason: string }[] = []
           for (const [key, value] of Object.entries(data)) {
-            data_.push({ id: key, reason: value })
+            data_.push({ id: Number(key), reason: value })
           }
+          updateSubmissions(data)
           doApiRequest(
             `/clubs/${club}/applications/${application?.id}/submissions/reason/?format=json`,
             {
@@ -320,10 +344,6 @@ const ReasonModal = (props: {
             {submitMessage !== null && (
               <div className="mt-2 mb-2 notification is-info is-light">
                 {submitMessage}
-                <p>
-                  Optionally refresh the page for your changes to be reflected
-                  below
-                </p>
               </div>
             )}
           </Form>
@@ -367,7 +387,10 @@ export default function ApplicationsPage({
       .then((applications) => {
         if (applications.length !== 0) {
           setApplications(applications)
-          setCurrentApplication(applications[0])
+          setCurrentApplication({
+            ...applications[0],
+            name: format_app_name(applications[0]),
+          })
         }
       })
   }, [])
@@ -447,6 +470,16 @@ export default function ApplicationsPage({
     [responseTableFields],
   )
 
+  const format_app_name: (application: Application) => any = (application) => (
+    <span>
+      {application.name} {' - '}
+      <span className="has-text-weight-semibold">
+        {application.cycle ||
+          getSemesterFromDate(application.application_end_time)}
+      </span>
+    </span>
+  )
+
   return (
     <>
       <StyledHeader style={{ marginBottom: '2px' }}>Applications</StyledHeader>
@@ -457,22 +490,31 @@ export default function ApplicationsPage({
       </Text>
       <Select
         options={applications.map((application) => {
-          return { value: application.id, label: application.name }
+          return {
+            ...application,
+            value: application.id,
+            label: format_app_name(application),
+          }
         })}
         value={
           currentApplication != null
             ? {
+                ...currentApplication,
                 value: currentApplication.id,
                 label: currentApplication.name,
               }
             : null
         }
-        onChange={(v: { value: number; label: string } | null) =>
+        onChange={(
+          v: {
+            value: number
+            label: string
+            cycle: string
+            application_end_time: string
+          } | null,
+        ) =>
           v != null &&
-          setCurrentApplication({
-            id: v.value,
-            name: v.label,
-          })
+          setCurrentApplication({ ...v, id: v.value, name: v.label })
         }
       />
       <br></br>
@@ -732,9 +774,19 @@ export default function ApplicationsPage({
           <NotificationModal
             club={club.code}
             application={currentApplication}
-            submissions={selectedSubmissions.map(
-              (i) => submissions[currentApplication!.id][i],
-            )}
+            submissions={submissions[currentApplication!.id]}
+            updateSubmissions={(arr: Array<ApplicationSubmission>) => {
+              if (currentApplication != null) {
+                for (const submission of arr) {
+                  const item = submissions[currentApplication.id].find(
+                    (sub) => sub.pk === submission.pk,
+                  )!
+                  const idx = submissions[currentApplication.id].indexOf(item)
+                  submissions[currentApplication.id][idx].notified = true
+                }
+                setSubmissions(submissions)
+              }
+            }}
           />
         </Modal>
       )}
@@ -751,6 +803,18 @@ export default function ApplicationsPage({
           <ReasonModal
             club={club.code}
             application={currentApplication}
+            updateSubmissions={(s: { name: string }) => {
+              if (currentApplication != null) {
+                for (const [id, value] of Object.entries(s)) {
+                  const item = submissions[currentApplication.id].find(
+                    (sub) => sub.pk === Number(id),
+                  )!
+                  const idx = submissions[currentApplication.id].indexOf(item)
+                  submissions[currentApplication.id][idx].reason = value
+                }
+                setSubmissions(submissions)
+              }
+            }}
             submissions={selectedSubmissions.map(
               (i) =>
                 submissions[currentApplication!.id].find(

--- a/frontend/pages/club/[club]/apply.tsx
+++ b/frontend/pages/club/[club]/apply.tsx
@@ -147,7 +147,8 @@ const ApplyPage = ({ club, applications }: Props): ReactElement => {
                 <Subtitle>
                   {app.name}{' '}
                   <span className="has-text-grey">
-                    for {getSemesterFromDate(app.application_end_time)}
+                    for{' '}
+                    {app.cycle || getSemesterFromDate(app.application_end_time)}
                   </span>
                 </Subtitle>
                 <div>
@@ -194,7 +195,10 @@ ApplyPage.getInitialProps = async ({ query, req }: NextPageContext) => {
   }
   const [clubReq, appReq] = await Promise.all([
     doApiRequest(`/clubs/${query.club}/?format=json`, data),
-    doApiRequest(`/clubs/${query.club}/applications/?format=json`, data),
+    doApiRequest(
+      `/clubs/${query.club}/applications/current/?format=json`,
+      data,
+    ),
   ])
   const clubRes = await clubReq.json()
   const appRes = await appReq.json()

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -72,6 +72,7 @@ export interface ClubApplication {
   name: string
   application_start_time: string
   application_end_time: string
+  cycle: string
   result_release_time: string
   external_url: string
 }
@@ -164,6 +165,7 @@ export interface Club {
   is_member: MembershipRank | false
   is_request: boolean
   is_subscribe: boolean
+  is_wharton: boolean
   linkedin: string
   listserv: string
   members: Membership[]

--- a/frontend/utils.tsx
+++ b/frontend/utils.tsx
@@ -425,6 +425,10 @@ export function getSemesterFromDate(date: Date | string): string {
     date = new Date(date)
   }
 
+  if (date == null) {
+    return ''
+  }
+
   const year = date.getFullYear()
   const sem = date.getMonth() >= 6 ? 'Fall' : 'Spring'
   return `${sem} ${year}`


### PR DESCRIPTION
This PR is aimed at building upon #566 and adding a bunch of cleanup / efficiency improvements. A list of changes is below:

- Admin page supports better querying over application submissions and application cycles
- The @property season is now deprecated, with existing code migrated to use application cycles instead; season is used as a fallback to preserve backwards compatibility
- Caching is added to the `retrieve` endpoint for the generic club API. (`clubs/<club_code>`).
- Fixed a bug in the `/questions` endpoint which included archived submissions
- Added an endpoint (`/current`) to `ClubApplicationViewSet` used to retrieve ongoing applications. This is used in `club/<club_code>/apply` to only show the active application.
- Prefetching added to `ClubApplicationViewset`
- Rework caching for application submissions to be done manually. This is changed to allow cache invalidation. It is important that the cache is invalidated when submission statuses/reasons are updated or emails are sent out (notified field is modified). With a simple `@cache_page` decorator, there is no scope for manual invalidation.
- Manually cache application questions, with invalidation upon addition of new questions to a particular application.
- Disable Wharton Council clubs abilities to create and duplicate applications (via the frontend).  A system administrator (like myself) will need to run a semesterly script to create applications -- these will be editable of course.
- Include application cycle in the displayed application names.
- Reactive updating for `notified` and `reason` fields in the application submission view. Previously needed to refresh. I was lazy with lifting state.