### PR TITLE
Adding escape character to zoom link regex

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3708,7 +3708,7 @@ class MeetingZoomWebhookAPIView(APIView):
                 request.data.get("payload", {}).get("object", {}).get("id", None)
             )
             regex = (
-                rf"https?:\/\/([A-z]*.)?zoom.us/[^\/]*\/{meeting_id}(\?pwd=[A-z,0-9]*)?"
+                rf"https?:\/\/([A-z]*\.)?zoom\.us/[^\/]*\/{meeting_id}(\?pwd=[A-z,0-9]*)?"
             )
             event = Event.objects.filter(url__regex=regex).first()
 


### PR DESCRIPTION

The regex for matching zoom links allowed for non-domain formats.
For example the following could match:   https://fredazoomaus/j/123/pwd=

See the link below for fix invalidation
https://regex101.com/r/xPe7AD/1