### PR TITLE
fix: Deprecate membership_count

### DIFF
--- a/frontend/components/ClubPage/InfoBox.tsx
+++ b/frontend/components/ClubPage/InfoBox.tsx
@@ -40,9 +40,9 @@ const InfoBox = (props: InfoBoxProps): ReactElement | null => {
       field: 'size',
       icon: 'user',
       alt: 'members',
-      text: `${props.club.membership_count} Registered (${getSizeDisplay(
-        props.club.size,
-      )})`,
+      text: `${
+        props.club.membership_count ?? props.club.members.length
+      } Registered (${getSizeDisplay(props.club.size)})`,
     },
     {
       field: 'accepting_members',

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -169,6 +169,10 @@ export interface Club {
   linkedin: string
   listserv: string
   members: Membership[]
+  /**
+   * @deprecated
+   * use `members.length` instead
+   */
   membership_count: number
   name: string
   recruiting_cycle: ClubRecruitingCycle


### PR DESCRIPTION
`InfoBox` uses `membership_count` which does not exist anymore. `membership_count` should be removed from `Club` type definition. Seems like `InfoBox` is the only component making use of this property, so we might as well delete it, but I marked it as deprecated for safety. See [types.ts](https://github.com/pennlabs/penn-clubs/blob/fix/registered-count/frontend/types.ts#L176).

<img width="386" alt="Screenshot 2023-08-14 at 2 59 01 PM" src="https://github.com/pennlabs/penn-clubs/assets/62971511/7a12d044-19ad-4c0d-a680-217f125ff389">
