### PR TITLE
Redirect on error

### DIFF
--- a/frontend/pages/error.tsx
+++ b/frontend/pages/error.tsx
@@ -1,0 +1,71 @@
+import Head from 'next/head'
+import styled from 'styled-components'
+
+import { Text } from '~/components/common'
+import { BODY_FONT } from '~/constants'
+import { SITE_LOGO, SITE_NAME } from '~/utils/branding'
+
+const Main = styled.main`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100vw;
+
+  padding: 0 20px;
+  box-sizing: border-box;
+
+  font-family: ${BODY_FONT};
+`
+
+const ErrorPage: React.FC = () => {
+  return (
+    <>
+      <Head>
+        <title>Error | Penn Clubs</title>
+        <style global>
+          {`
+            body {
+              margin: 0;
+            }
+          `}
+        </style>
+      </Head>
+      <Main>
+        <div>
+          <img
+            src={SITE_LOGO}
+            alt={`${SITE_NAME} Logo`}
+            style={{
+              width: '120px',
+            }}
+          />
+          <Text
+            style={{
+              fontWeight: 'bold',
+              fontSize: '2rem',
+            }}
+          >
+            Aw, Snap!
+          </Text>
+          <Text
+            style={{
+              fontSize: '1rem',
+              color: '#5a6978',
+            }}
+          >
+            We are currently experiencing some issues trying to load this page.
+            <br />
+            If you believe this is a critical issue, please contact us at{' '}
+            <a href="mailto:contact@pennclubs.com" style={{ color: '#3273dc' }}>
+              contact@pennclubs.com
+            </a>
+            .
+          </Text>
+        </div>
+      </Main>
+    </>
+  )
+}
+
+export default ErrorPage

--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -362,7 +362,7 @@ function renderPage<T>(
         auth.authenticated = true
       }
       return { ...pageProps, ...auth, options, permissions }
-    } catch (error) 
+    } catch (error) {
       if (ctx.res) {
         ctx.res.writeHead(307, { Location: '/error' })
         ctx.res.end()

--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -350,18 +350,26 @@ function renderPage<T>(
       }
     }
 
-    const [res, [pageProps, permissions], options] = await Promise.all([
-      fetchSettings(),
-      originalPageProps(),
-      fetchOptions(),
-    ])
-
-    const auth = { authenticated: false, userInfo: undefined }
-    if (res.ok) {
-      auth.userInfo = await res.json()
-      auth.authenticated = true
+    try {
+      const [res, [pageProps, permissions], options] = await Promise.all([
+        fetchSettings(),
+        originalPageProps(),
+        fetchOptions(),
+      ])
+      const auth = { authenticated: false, userInfo: undefined }
+      if (res.ok) {
+        auth.userInfo = await res.json()
+        auth.authenticated = true
+      }
+      return { ...pageProps, ...auth, options, permissions }
+    } catch (error) 
+      if (ctx.res) {
+        ctx.res.writeHead(307, { Location: '/error' })
+        ctx.res.end()
+        return false
+      }
+      return {}
     }
-    return { ...pageProps, ...auth, options, permissions }
   }
 
   return RenderPage


### PR DESCRIPTION
Rather than showing WSOD(white screen of death),
`renderPage` will attempt to redirect the user to the page below on fetch error.

![Screenshot 2023-09-24 at 12 28 18 AM](https://github.com/pennlabs/penn-clubs/assets/62971511/56398dbf-bd90-49f4-8a8f-ed851136827f)