### PR TITLE
wip-feature: Allow resend of acceptance/rejection emails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         args: [--config, backend/setup.cfg]
       - id: frontend
         name: Yarn Linter
-        entry: yarn --cwd frontend lint
+        entry: bash -c "cd frontend && yarn lint"
         language: system
         files: ^frontend/
         require_serial: false

--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -222,7 +222,7 @@ const NotificationModal = (props: {
           if (data.email_type.id === 'acceptance' && !data.dry_run) {
             const relevant = submissions.filter(
               (sub) =>
-                sub.notified === false &&
+                (data.allow_resend || !sub.notified) &&
                 sub.status === 'Accepted' &&
                 sub.reason,
             )
@@ -230,7 +230,7 @@ const NotificationModal = (props: {
           } else if (data.email_type.id === 'rejection' && !data.dry_run) {
             const relevant = submissions.filter(
               (sub) =>
-                sub.notified === false &&
+                (data.allow_resend || !sub.notified) &&
                 sub.status.startsWith('Rejected') &&
                 sub.reason,
             )

--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -2,6 +2,7 @@ import { Field, Form, Formik } from 'formik'
 import moment from 'moment-timezone'
 import React, { ReactElement, useEffect, useMemo, useState } from 'react'
 import Select from 'react-select'
+import { toast } from 'react-toastify'
 import styled from 'styled-components'
 
 import { ALLBIRDS_GRAY, CLUBS_BLUE, MD, mediaMaxWidth, SNOW } from '~/constants'
@@ -278,6 +279,13 @@ const NotificationModal = (props: {
               name="allow_resend"
               as={CheckboxField}
               label="Resend Emails"
+              onClick={(e) => {
+                if (e.target.checked) {
+                  toast.warning(
+                    'Resending emails will send emails to all applicants, even if they have already been notified.',
+                  )
+                }
+              }}
               helpText={
                 <strong>
                   If selected, will resend notifications to all applicants

--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -274,6 +274,16 @@ const NotificationModal = (props: {
               label="Dry Run"
               helpText="If selected, will return the number of emails the script would have sent out"
             />
+            <Field
+              name="allow_resend"
+              as={CheckboxField}
+              label="Resend Emails"
+              helpText={
+                <strong>
+                  If selected, will resend notifications to all applicants
+                </strong>
+              }
+            />
             <button type="submit" className="button">
               Submit
             </button>


### PR DESCRIPTION
Creates an option for club admins to resend all acceptance/rejection emails, regardless of whether applicants have been previously notified or not. Resolves #585. 

Still a WIP. To-do: 
- [ ] Add tests
- [x] Create stronger checks against people accidentally pressing this. Maybe we can add a pop-up or change the helpText to deter admins resending emails without good reason to. (CC'ing @julianweng)

What it looks like:
<img width="1161" alt="Screenshot 2023-09-25 at 11 38 18 PM" src="https://github.com/pennlabs/penn-clubs/assets/69180850/81275017-7deb-456d-ad5a-3a6395a83579">