### PR TITLE
Upsert Application Submissions

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -1695,6 +1695,9 @@ class ApplicationSubmission(models.Model):
     def __str__(self):
         return f"{self.user.first_name}: {self.application.name}"
 
+    class Meta:
+        unique_together = (("user", "application", "committee"),)
+
 
 class ApplicationQuestionResponse(models.Model):
     """
@@ -1722,6 +1725,9 @@ class ApplicationQuestionResponse(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        unique_together = (("question", "submission"),)
 
 
 class QuestionResponse(models.Model):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4479,7 +4479,7 @@ class UserViewSet(viewsets.ModelViewSet):
                     submissions page""",
                 }
             )
-        submission, _ = ApplicationSubmission.objects.update_or_create(
+        submission, _ = ApplicationSubmission.objects.get_or_create(
             user=self.request.user,
             application=application,
             committee=committee,
@@ -4507,11 +4507,11 @@ class UserViewSet(viewsets.ModelViewSet):
             ):
                 text = question_data.get("text", None)
                 if text is not None and text != "":
-                    obj, _ = ApplicationQuestionResponse.objects.get_or_create(
-                        question=question, submission=submission,
+                    obj, _ = ApplicationQuestionResponse.objects.update_or_create(
+                        question=question,
+                        submission=submission,
+                        defaults={"text": text},
                     )
-                    obj.text = text
-                    obj.save()
                     response = Response(ApplicationQuestionResponseSerializer(obj).data)
             elif question_type == ApplicationQuestion.MULTIPLE_CHOICE:
                 multiple_choice_value = question_data.get("multipleChoice", None)
@@ -4519,11 +4519,11 @@ class UserViewSet(viewsets.ModelViewSet):
                     multiple_choice_obj = ApplicationMultipleChoice.objects.filter(
                         question=question, value=multiple_choice_value
                     ).first()
-                    obj, _ = ApplicationQuestionResponse.objects.get_or_create(
-                        question=question, submission=submission,
+                    obj, _ = ApplicationQuestionResponse.objects.update_or_create(
+                        question=question,
+                        submission=submission,
+                        defaults={"multiple_choice": multiple_choice_obj},
                     )
-                    obj.multiple_choice = multiple_choice_obj
-                    obj.save()
                     response = Response(ApplicationQuestionResponseSerializer(obj).data)
         return response
 


### PR DESCRIPTION
Previously, we would create new `ApplicationSubmission` and `ApplicationQuestionResponse` objects every time a user submitted their application; this change ensures that each user will have at most one submission per application per committee.

Going forward, we should be able to remove raw SQL queries like [this](https://github.com/pennlabs/penn-clubs/blob/2814025e7853a02bfe2ac2431a2013f910f00ec7/backend/clubs/views.py#L5290C21-L5299C78) since users won't have multiple submissions associated with an application, but this would be potentially problematic for past applications unless we run a script that drops all submissions that aren't the most recent.