### PR TITLE
Whitelist dev localhost from CSRF

### DIFF
--- a/backend/pennclubs/settings/development.py
+++ b/backend/pennclubs/settings/development.py
@@ -4,6 +4,9 @@ from pennclubs.settings.base import *  # noqa: F401, F403
 from pennclubs.settings.base import INSTALLED_APPS, MIDDLEWARE
 
 
+# Enable debug mode
+DEBUG = True
+
 # Development extensions
 INSTALLED_APPS += ["django_extensions", "debug_toolbar"]
 
@@ -12,6 +15,9 @@ INTERNAL_IPS = ["127.0.0.1"]
 
 # Allow http callback for DLA
 os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
+
+# Allow requests from frontend
+CSRF_TRUSTED_ORIGINS = ["http://localhost:3000"]
 
 # Use console email backend during development
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"


### PR DESCRIPTION
Fixes CSRF breaking in dev due to Django 4.0: [https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins](https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins)