### PR TITLE
Style Toastify notifications

### DIFF
--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -219,7 +219,7 @@ function renderPage<T>(
               <ToastContainer
                 limit={3}
                 position="bottom-center"
-                autoClose={2000}
+                autoClose={3000}
                 hideProgressBar={true}
               />
             </ToastStyle>

--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -216,7 +216,12 @@ function renderPage<T>(
               </AuthCheckContext.Provider>
             </OptionsContext.Provider>
             <ToastStyle>
-              <ToastContainer position="bottom-center" hideProgressBar={true} />
+              <ToastContainer
+                limit={3}
+                position="bottom-center"
+                autoClose={2000}
+                hideProgressBar={true}
+              />
             </ToastStyle>
             <GlobalStyle />
           </>


### PR DESCRIPTION
Adds a limit to the # of pop-up notifications on screen at once. Also closes previous notifications faster. Here's a [before](https://github.com/pennlabs/penn-clubs/assets/69180850/2aa85098-b5dd-49a0-8134-86de3ede181e) vs [after](https://github.com/pennlabs/penn-clubs/assets/69180850/7cbbc573-6c44-4105-be6e-5b26bf7d0d68).

Requesting a review to make sure this is a desired change.