### PR TITLE
Optimize assorted Django operations

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -840,9 +840,8 @@ class ClubFair(models.Model):
             "code", flat=True
         )
 
-        new_events = []
-
         # Create new events in bulk
+        new_events = []
         for club in club_query:
             event_code = f"fair-{club.code}-{self.id}-{suffix}"
             if event_code not in existing_events:
@@ -856,7 +855,6 @@ class ClubFair(models.Model):
                         end_time=end_time,
                     )
                 )
-
         Event.objects.bulk_create(new_events)
 
         # Return all event objects

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -5515,9 +5515,10 @@ class ApplicationSubmissionViewSet(viewsets.ModelViewSet):
 
         submission_objs = ApplicationSubmission.objects.filter(pk__in=pks)
 
-        # Invalidate submission viewset cache
         if not submission_objs.exists():
             return Response({"detail": "No submissions found"})
+
+        # Invalidate submission viewset cache
         app_id = submission_objs.first().application.id
         key = f"applicationsubmissions:{app_id}"
         cache.delete(key)

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -5453,14 +5453,15 @@ class ApplicationSubmissionViewSet(viewsets.ModelViewSet):
         submission_pks = self.request.data.get("submissions", [])
         status = self.request.data.get("status", None)
         if (
-            status in map(lambda x: x[0], ApplicationSubmission.STATUS_TYPES)
+            status
+            in [status_type[0] for status_type in ApplicationSubmission.STATUS_TYPES]
             and len(submission_pks) > 0
         ):
             # Invalidate submission viewset cache
             submissions = ApplicationSubmission.objects.filter(pk__in=submission_pks)
-            app_id = submissions.first().application.id if submissions.first() else None
-            if not app_id:
+            if not submissions.exists():
                 return Response({"detail": "No submissions found"})
+            app_id = submissions.first().application.id
             key = f"applicationsubmissions:{app_id}"
             cache.delete(key)
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -5452,15 +5452,14 @@ class ApplicationSubmissionViewSet(viewsets.ModelViewSet):
         """
         submission_pks = self.request.data.get("submissions", [])
         status = self.request.data.get("status", None)
-        if (
-            status
-            in [status_type[0] for status_type in ApplicationSubmission.STATUS_TYPES]
-            and len(submission_pks) > 0
-        ):
-            # Invalidate submission viewset cache
+        if len(submission_pks) > 0 and status in [
+            status_type[0] for status_type in ApplicationSubmission.STATUS_TYPES
+        ]:
             submissions = ApplicationSubmission.objects.filter(pk__in=submission_pks)
             if not submissions.exists():
                 return Response({"detail": "No submissions found"})
+
+            # Invalidate submission viewset cache
             app_id = submissions.first().application.id
             key = f"applicationsubmissions:{app_id}"
             cache.delete(key)
@@ -5524,7 +5523,6 @@ class ApplicationSubmissionViewSet(viewsets.ModelViewSet):
         key = f"applicationsubmissions:{app_id}"
         cache.delete(key)
 
-        # Update reasons in a single query
         for submission in submission_objs:
             submission.reason = reasons[submission.pk]
         ApplicationSubmission.objects.bulk_update(submission_objs, ["reason"])

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -613,9 +613,11 @@ class ClubFairViewSet(viewsets.ModelViewSet):
         ---
         """
         now = timezone.now()
+        start_time = now - datetime.timedelta(minutes=2)
+        end_time = now + datetime.timedelta(minutes=2)
         fair = ClubFair.objects.filter(
-            start_time__lte=now + datetime.timedelta(minutes=2),
-            end_time__gte=now - datetime.timedelta(minutes=2),
+            start_time__lte=start_time,
+            end_time__gte=end_time,
         ).first()
         if fair is None:
             return Response([])
@@ -1023,8 +1025,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     )
     permission_classes = [ClubPermission | IsSuperuser]
 
-    haha = ClubsSearchFilter()
-    filter_backends = [filters.SearchFilter, haha, ClubsOrderingFilter]
+    filter_backends = [filters.SearchFilter, ClubsSearchFilter, ClubsOrderingFilter]
     search_fields = ["name", "subtitle", "code", "terms"]
     ordering_fields = ["favorite_count", "name"]
     ordering = "featured"

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -543,6 +543,7 @@ class ClubsOrderingFilter(RandomOrderingFilter):
         if "featured" in ordering:
             if queryset.model == Club:
                 return queryset.order_by("-rank", "-favorite_count", "-id")
+
             return queryset.order_by(
                 "-club__rank", "-club__favorite_count", "-club__id"
             )
@@ -618,10 +619,11 @@ class ClubFairViewSet(viewsets.ModelViewSet):
             start_time__lte=now + datetime.timedelta(minutes=2),
             end_time__gte=now - datetime.timedelta(minutes=2),
         ).first()
+
         if fair is None:
             return Response([])
-        else:
-            return Response([ClubFairSerializer(instance=fair).data])
+
+        return Response([ClubFairSerializer(instance=fair).data])
 
     @action(detail=True, methods=["get"])
     def live(self, *args, **kwargs):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -5516,7 +5516,7 @@ class ApplicationSubmissionViewSet(viewsets.ModelViewSet):
         submission_objs = ApplicationSubmission.objects.filter(pk__in=pks)
 
         # Invalidate submission viewset cache
-        if submission_objs.exists():
+        if not submission_objs.exists():
             return Response({"detail": "No submissions found"})
         app_id = submission_objs.first().application.id
         key = f"applicationsubmissions:{app_id}"

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -5516,10 +5516,7 @@ class ApplicationSubmissionViewSet(viewsets.ModelViewSet):
         submission_objs = ApplicationSubmission.objects.filter(pk__in=pks)
 
         # Invalidate submission viewset cache
-        if (
-            not submission_objs.exists()
-            or submission_objs.first().application.id is None
-        ):
+        if submission_objs.exists():
             return Response({"detail": "No submissions found"})
         app_id = submission_objs.first().application.id
         key = f"applicationsubmissions:{app_id}"

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -190,19 +190,20 @@ from clubs.utils import fuzzy_lookup_club, html_to_text
 
 
 def file_upload_endpoint_helper(request, code):
-    obj = get_object_or_404(Club, code=code)
-    if "file" in request.data and isinstance(request.data["file"], UploadedFile):
-        asset = Asset.objects.create(
-            creator=request.user,
-            club=obj,
-            file=request.data["file"],
-            name=request.data["file"].name,
-        )
-    else:
+    club = get_object_or_404(Club, code=code)
+
+    if "file" not in request.data or not isinstance(request.data["file"], UploadedFile):
         return Response(
             {"detail": "No image file was uploaded!"},
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+    asset = Asset.objects.create(
+        creator=request.user,
+        club=club,
+        file=request.data["file"],
+        name=request.data["file"].name,
+    )
     return Response({"detail": "Club file uploaded!", "id": asset.id})
 
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2985,16 +2985,13 @@ class MembershipRequestViewSet(viewsets.ModelViewSet):
         """
         If a membership request object already exists, reuse it.
         """
-        club = request.data.get("club", None)
-        obj = MembershipRequest.objects.filter(
-            club__code=club, person=request.user
-        ).first()
-        if obj is not None:
-            obj.withdrew = False
-            obj.save(update_fields=["withdrew"])
-            return Response(UserMembershipRequestSerializer(obj).data)
-
-        return super().create(request, *args, **kwargs)
+        club_code = request.data.get("club", None)
+        obj, _ = MembershipRequest.objects.update_or_create(
+            club__code=club_code,
+            person=request.user,
+            defaults={"withdrew": False},
+        )
+        return Response(UserMembershipRequestSerializer(obj).data)
 
     def destroy(self, request, *args, **kwargs):
         """

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -149,6 +149,13 @@ export class MyChart extends PennLabsChart {
       secret: fyhSecret,
       cmd: ["python", "manage.py", "import_paideia_events"],
     });
+
+    new CronJob(this, 'update-club-favorite-membership-counts', {
+      schedule: cronTime.everyDayAt(12),
+      image: backendImage,
+      secret: fyhSecret,
+      cmd: ["python", "manage.py", "update_club_counts"],
+    });
   }
 }
 


### PR DESCRIPTION
Meant to generally optimize our usage of the Django ORM, with a focus on taking full advantage of major upgrades in #605. 

Changelog: 

- Use subqueries to update membership & favorite counts in `update_club_counts`. Shows a ~70% speedup in local benchmarks (n=2000 memberships/favorites). 
- Use bulk updates when updating decision reasons for application submissions.
- Use bulk create when creating activities fairs for registered clubs. 
    - Concerned with how `bulk_create` plays with `AutoField` primary keys (like we have for the `Events` model). But, the documentation mentions that pSQL should be fine.[1] 
    - I'm assuming the order of the returned `Events` objects doesn't matter. Would appreciate a second set of eyes.
 - Use `qs.exists()` to check existence instead of `qs.first() is not None` whenever possible. 
 - Avoid fetching objects from DB into memory whenever possible.
 
[1] https://docs.djangoproject.com/en/5.0/ref/models/querysets/#bulk-create