### PR TITLE
Display username in profile page if name is empty

### DIFF
--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -85,7 +85,7 @@ const Settings = ({ userInfo, authenticated }: SettingsProps) => {
       <Metadata title="Your Profile" />
       <Container background={BG_GRADIENT}>
         <Title style={{ marginTop: '2.5rem', color: WHITE, opacity: 0.95 }}>
-          Welcome, {userInfo.name}
+          Welcome, {userInfo.name || userInfo.username}
         </Title>
       </Container>
       <HashTabView


### PR DESCRIPTION
The logged-in user's display name is empty in some cases, such as when you're a student taking a leave of absence. This change will display the PennKey if the user's name is an empty string.
<img width="1552" alt="Screenshot 2024-03-17 at 6 57 46 PM" src="https://github.com/pennlabs/penn-clubs/assets/69180850/cb592eb0-c788-4e9a-ba1c-bd89cb2ad5f8">