### PR TITLE
Bump debounce timeout to 400ms

### DIFF
--- a/frontend/components/SearchBar.tsx
+++ b/frontend/components/SearchBar.tsx
@@ -353,7 +353,7 @@ export const SearchBarTextItem = ({
           }
           return { ...inpt, [param]: nameInput }
         }),
-      200,
+      400,  // debounce search input
     )
     storeTimeout(timeoutId)
   }, [nameInput])

--- a/frontend/components/SearchBar.tsx
+++ b/frontend/components/SearchBar.tsx
@@ -353,7 +353,7 @@ export const SearchBarTextItem = ({
           }
           return { ...inpt, [param]: nameInput }
         }),
-      400,  // debounce search input
+      400,
     )
     storeTimeout(timeoutId)
   }, [nameInput])


### PR DESCRIPTION
Bumps debounce timeout to 400ms. Tested locally & the search still felt snappy and responsive. 

There's definitely a more data-driven way to do this, but 400ms seems to check out. Supposedly [the average characters per minute for an adult is 200](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjZwdvs3oCFAxV5ElkFHYoADUwQFnoECA0QAw&url=https%3A%2F%2Fwww.typingpal.com%2Fen%2Fdocumentation%2Fschool-edition%2Fpedagogical-resources%2Ftyping-speed&usg=AOvVaw20sNp_Pgw5UaKZz5_WTKSu&opi=89978449), which means 300ms per keystroke. Our previous debounce timeout was below this, so we were effectively querying for every keystroke. 