### PR TITLE
Notify club owners upon deletion

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1988,13 +1988,11 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         """
         Set archived boolean to be True so that the club appears to have been deleted
         """
-        now = timezone.now()
-
         club = self.get_object()
 
         instance.archived = True
         instance.archived_by = self.request.user
-        instance.archived_on = now
+        instance.archived_on = timezone.now()
         instance.save()
 
         # Send notice to club officers and executor

--- a/backend/templates/emails/club_deletion.html
+++ b/backend/templates/emails/club_deletion.html
@@ -1,0 +1,17 @@
+<!-- TYPES:
+name:
+    type: string
+branding_site_name: 
+    type: string
+branding_site_email: 
+    type: string
+-->
+{% extends 'emails/base.html' %}
+
+{% block content %}
+    <h2><b>{{ name }}</b> has been marked as deleted on {{ branding_site_name }}</h2>
+    <p style="font-size: 1.2em; color: #8B2222">
+        <b>Oh no!</b> Your club has <b>been removed</b> from {{ branding_site_name }} by the <b>Office of Student Affairs</b>.
+    </p>
+    <p style="font-size: 1.2em">If you believe this is an error, please contact <a href="mailto:{{ branding_site_email }}">{{ branding_site_email }}</a>.</p>
+{% endblock %}


### PR DESCRIPTION
We've seen a couple cases where a club is deleted but its owners aren't notified. This PR adds support for sending emails to club owners (and the executors of deletions) upon deletion requests. 

Not sure whether the email template looks fine (and I'm not sure how to check, either). Also unsure whether this should be a method in `models`. 