### PR TITLE
Check ticket holds before completing checkout

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4872,6 +4872,7 @@ class TicketViewSet(viewsets.ModelViewSet):
             )
 
     @action(detail=False, methods=["post"])
+    @update_holds
     @transaction.atomic
     def complete_checkout(self, request, *args, **kwargs):
         """

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4912,9 +4912,7 @@ class TicketViewSet(viewsets.ModelViewSet):
         )
 
         # Guard against holds expiring before the capture context
-        tickets = cart.tickets.select_for_update(skip_locked=True).filter(
-            holder=self.request.user, owner__isnull=True
-        )
+        tickets = cart.tickets.filter(holder=self.request.user, owner__isnull=True)
         if tickets.count() != cart.tickets.count():
             return Response(
                 {


### PR DESCRIPTION
Resolves edge case where the user initiates checkout, but waits 15 mins (i.e. longer than the hold, but shorter than the capture context expiration). 