### PR TITLE
Fix backend tests for group discounts, new cart API, and more

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4831,21 +4831,10 @@ class TicketViewSet(viewsets.ModelViewSet):
                                     items:
                                         type: object
                                         properties:
-                                            id:
-                                                type: integer
                                             event:
-                                                type: object
-                                                properties:
-                                                    id:
-                                                        type: integer
-                                                    name:
-                                                        type: string
+                                                type: integer
                                             type:
                                                 type: string
-                                            owner:
-                                                type: string
-                                            price:
-                                                type: number
                                             count:
                                                 type: integer
         ---

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4832,7 +4832,12 @@ class TicketViewSet(viewsets.ModelViewSet):
                                         type: object
                                         properties:
                                             event:
-                                                type: integer
+                                                type: object
+                                                properties:
+                                                    id:
+                                                        type: integer
+                                                    name:
+                                                        type: string
                                             type:
                                                 type: string
                                             count:
@@ -4873,10 +4878,10 @@ class TicketViewSet(viewsets.ModelViewSet):
                 holder__isnull=True,
             ).exclude(id__in=tickets_in_cart)[: ticket_class["count"]]
 
-            if tickets.count() < ticket_class["count"]: 
+            if tickets.count() < ticket_class["count"]:
                 sold_out_tickets.append(
                     {
-                        **ticket_class, 
+                        **ticket_class,
                         "event": {
                             "id": ticket_class["event"],
                             "name": Event.objects.get(id=ticket_class["event"]).name,

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4783,7 +4783,8 @@ class TicketViewSet(viewsets.ModelViewSet):
     http_method_names = ["get", "post"]
     lookup_field = "id"
 
-    def _calculate_cart_total(self, cart) -> float:
+    @staticmethod
+    def _calculate_cart_total(cart) -> float:
         """
         Calculate the total price of all tickets in a cart, applying discounts
         where appropriate. Does not validate that the cart is valid.

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -4826,7 +4826,7 @@ class TicketViewSet(viewsets.ModelViewSet):
                                     allOf:
                                         - $ref: "#/components/schemas/Ticket"
                                 sold_out:
-                                    type: list
+                                    type: array
                                     items:
                                         type: object
                                         properties:

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -554,8 +554,7 @@ class TicketTestCase(TestCase):
         self.assertEqual(len(data["tickets"]), 5, data)
         for t1, t2 in zip(data["tickets"], tickets_to_add):
             self.assertEqual(t1["id"], str(t2.id))
-        num_sold_out = sum(item["count"] for item in data["sold_out"])
-        self.assertEqual(num_sold_out, 0, data)
+        self.assertEqual(len(data["sold_out"]), 0, data)
 
     def test_calculate_cart_total(self):
         # Add a few tickets to cart
@@ -624,8 +623,7 @@ class TicketTestCase(TestCase):
 
         # The cart still has 5 tickets: just replaced with available ones
         self.assertEqual(len(data["tickets"]), 5, data)
-        num_sold_out = sum(item["count"] for item in data["sold_out"])
-        self.assertEqual(num_sold_out, 0, data)
+        self.assertEqual(len(data["sold_out"]), 0, data)
 
         in_cart = set(map(lambda t: t["id"], data["tickets"]))
         to_add = set(map(lambda t: str(t.id), tickets_to_add))
@@ -656,14 +654,21 @@ class TicketTestCase(TestCase):
         # The cart now has 3 tickets
         self.assertEqual(len(data["tickets"]), 3, data)
 
-        # 2 tickets have been sold out
-        num_sold_out = sum(item["count"] for item in data["sold_out"])
-        self.assertEqual(num_sold_out, 2, data)
+        # Only 1 type of ticket should be sold out
+        self.assertEqual(len(data["sold_out"]), 1, data)
 
-        in_cart = set(map(lambda t: t["id"], data["tickets"]))
-        to_add = set(map(lambda t: str(t.id), tickets_to_add))
+        # 2 normal tickets should be sold out
+        expected_sold_out = {
+            "type": self.tickets1[0].type,
+            "event": self.tickets1[0].event.id,
+            "count": 2,
+        }
+        for key, val in expected_sold_out.items():
+            self.assertEqual(data["sold_out"][0][key], val, data)
 
         # 0 tickets are the same (we sell all but last 3)
+        in_cart = set(map(lambda t: t["id"], data["tickets"]))
+        to_add = set(map(lambda t: str(t.id), tickets_to_add))
         self.assertEqual(len(in_cart & to_add), 0, in_cart | to_add)
 
     def test_initiate_checkout(self):

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -600,6 +600,8 @@ class TicketTestCase(TestCase):
             cart.tickets.add(ticket)
         cart.save()
 
+        self.assertEqual(cart.tickets.count(), 5)
+
         total = TicketViewSet._calculate_cart_total(cart)
         self.assertEqual(total, 40.0)  # 5 * price=10 * (1 - group_discount=0.2) = 40
 

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -662,7 +662,10 @@ class TicketTestCase(TestCase):
         # 2 normal tickets should be sold out
         expected_sold_out = {
             "type": self.tickets1[0].type,
-            "event": self.tickets1[0].event.id,
+            "event": {
+                "id": self.tickets1[0].event.id,
+                "name": self.tickets1[0].event.name,
+            },
             "count": 2,
         }
         for key, val in expected_sold_out.items():

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -569,7 +569,7 @@ class TicketTestCase(TestCase):
 
         from clubs.views import TicketViewSet
 
-        actual_total = TicketViewSet()._calculate_cart_total(cart)
+        actual_total = TicketViewSet._calculate_cart_total(cart)
         self.assertEqual(actual_total, expected_total)
 
     def test_calculate_cart_total_with_group_discount(self):
@@ -594,7 +594,7 @@ class TicketTestCase(TestCase):
 
         from clubs.views import TicketViewSet
 
-        total = TicketViewSet()._calculate_cart_total(cart)
+        total = TicketViewSet._calculate_cart_total(cart)
         self.assertEqual(total, 40.0)  # 5 * price=10 * (1 - group_discount=0.2) = 40
 
     def test_get_cart_replacement_required(self):

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -554,7 +554,8 @@ class TicketTestCase(TestCase):
         self.assertEqual(len(data["tickets"]), 5, data)
         for t1, t2 in zip(data["tickets"], tickets_to_add):
             self.assertEqual(t1["id"], str(t2.id))
-        self.assertEqual(data["sold_out"], 0, data)
+        num_sold_out = sum(item["count"] for item in data["sold_out"])
+        self.assertEqual(num_sold_out, 0, data)
 
     def test_calculate_cart_total(self):
         # Add a few tickets to cart
@@ -616,7 +617,8 @@ class TicketTestCase(TestCase):
 
         # The cart still has 5 tickets: just replaced with available ones
         self.assertEqual(len(data["tickets"]), 5, data)
-        self.assertEqual(data["sold_out"], 0, data)
+        num_sold_out = sum(item["count"] for item in data["sold_out"])
+        self.assertEqual(num_sold_out, 0, data)
 
         in_cart = set(map(lambda t: t["id"], data["tickets"]))
         to_add = set(map(lambda t: str(t.id), tickets_to_add))
@@ -648,7 +650,8 @@ class TicketTestCase(TestCase):
         self.assertEqual(len(data["tickets"]), 3, data)
 
         # 2 tickets have been sold out
-        self.assertEqual(data["sold_out"], 2, data)
+        num_sold_out = sum(item["count"] for item in data["sold_out"])
+        self.assertEqual(num_sold_out, 2, data)
 
         in_cart = set(map(lambda t: t["id"], data["tickets"]))
         to_add = set(map(lambda t: str(t.id), tickets_to_add))

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -585,14 +585,21 @@ class TicketTestCase(TestCase):
             for _ in range(10)
         ]
 
-        # Add enough to activate group discount
         cart, _ = Cart.objects.get_or_create(owner=self.user1)
-        tickets_to_add = tickets[:5]
+        from clubs.views import TicketViewSet
+
+        # Add 1 ticket, shouldn't activate group discount
+        cart.tickets.add(tickets[0])
+        cart.save()
+
+        total = TicketViewSet._calculate_cart_total(cart)
+        self.assertEqual(total, 10.0)  # 1 * price=10 = 10
+
+        # Add 4 more tickets, enough to activate group discount
+        tickets_to_add = tickets[1:5]
         for ticket in tickets_to_add:
             cart.tickets.add(ticket)
         cart.save()
-
-        from clubs.views import TicketViewSet
 
         total = TicketViewSet._calculate_cart_total(cart)
         self.assertEqual(total, 40.0)  # 5 * price=10 * (1 - group_discount=0.2) = 40

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -594,9 +594,7 @@ class TicketTestCase(TestCase):
         from clubs.views import TicketViewSet
 
         total = TicketViewSet()._calculate_cart_total(cart)
-
-        # Total price should be 5 * price=10 * (1 - group_discount=0.2) = 40
-        self.assertEqual(total, 40.0)
+        self.assertEqual(total, 40.0)  # 5 * price=10 * (1 - group_discount=0.2) = 40
 
     def test_get_cart_replacement_required(self):
         self.client.login(username=self.user1.username, password="test")


### PR DESCRIPTION
Changelog: 
1. Refactors total price summation to an internal helper function. Adds tests for it. (Previous code was failing but wasn't caught, since we mock `initiate_checkout` and `complete_checkout`. Breaking this logic into its own, testable function will hopefully catch future mistakes.)
2. Adds tests for creating tickets with group discounts.
3. Adds tests for summing a cart total with group discounts applied. 
4. Only populates `sold_out` if there are tickets that were not replaced.
5. Aligns tests with changes introduced in ^ and #670.