### PR TITLE
Fix empty fields in generated admin reports

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -2316,6 +2316,8 @@ class ReportClubSerializer(AuthenticatedClubSerializer):
                     label = json.loads(fair.questions)[index]["label"]
                     return f"[{fair.name}] {label}"
                 return f"Registered for {fair.name}"
+        else:
+            return key
 
     class Meta(AuthenticatedClubSerializer.Meta):
         pass


### PR DESCRIPTION
We've gotten complaints from OSA that admin reports are missing certain fields (e.g. `created_at`, `target_majors`, `accepting_members`, etc.). This PR should solve.

[without fix](https://github.com/pennlabs/penn-clubs/files/15103894/unfixed_w_all_fields.xlsx) vs [with fix](https://github.com/pennlabs/penn-clubs/files/15103896/fixed_w_all_fields.xlsx)