### PR TITLE
Fix QR codes in confirmation email

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -5569,6 +5569,8 @@ class TicketViewSet(viewsets.ModelViewSet):
             return Ticket.objects.filter(
                 Q(owner=self.request.user.id) | Q(event__club__in=officer_clubs)
             ).select_related("event__club")
+        elif self.action == "qr":
+            return Ticket.objects()
         return Ticket.objects.filter(owner=self.request.user.id)
 
     def _give_tickets(self, user, order_info, cart, reconciliation_id):

--- a/backend/templates/emails/ticket_confirmation.html
+++ b/backend/templates/emails/ticket_confirmation.html
@@ -37,7 +37,7 @@ qr:
     your confirmation. </p>
 
 
-<img id="now" style="max-width: 60%; width: auto;" alt="" src="data:image/png;base64,{{ qr}}" />
+<img id="now" style="max-width: 60%; width: auto;" alt="Ticket QR code" src="{{qr}}" />
 
 <p style="font-size: 1.2em"> Note: all tickets issued by us are <b>non-refundable</b>. </p>
 

--- a/backend/templates/emails/ticket_confirmation.html
+++ b/backend/templates/emails/ticket_confirmation.html
@@ -19,17 +19,13 @@ qr:
 <h2>Thanks for using Penn Clubs!</h2>
 
 <p style="font-size: 1.2em">
-    {{ first_name }}, thank you for your recent purchase of a ticket to {{ name }} with ticket type {{type }}.
+    {{ first_name }}, thank you for your recent acquisition of a ticket to {{ name }} with ticket type {{type }}.
 </p>
 
 <p style="font-size: 1.2em">
     As a reminder, the event starts at {{ start_time }} and ends at {{ end_time }}.
 
 
-</p>
-
-<p style="font-size: 1.2em">
-    Please be 10 minutes early for a smooth seating experience.
 </p>
 
 <p style="font-size: 1.2em"> Below is a


### PR DESCRIPTION
Adds qr code image as attachment in confirmation email.

Embeds image using now-public (temporary, since ticket ids are insecure currently regardless) `/tickets/{ticketid}/qr` route, as current method of embedding (data uris) does not work with Gmail clients.
