### PR TITLE
Fix QR code not showing up in Gmail

### DIFF
--- a/backend/templates/emails/ticket_confirmation.html
+++ b/backend/templates/emails/ticket_confirmation.html
@@ -9,7 +9,7 @@ start_time:
     type: string
 end_time:
     type: string
-qr:
+cid:
     type: string
 -->
 
@@ -19,7 +19,7 @@ qr:
 <h2>Thanks for using Penn Clubs!</h2>
 
 <p style="font-size: 1.2em">
-    {{ first_name }}, thank you for your recent purchase of a ticket to {{ name }} with ticket type {{type }}.
+    {{ first_name }}, thank you for your recent acquisition of a ticket to {{ name }} with ticket type {{type }}.
 </p>
 
 <p style="font-size: 1.2em">
@@ -28,16 +28,12 @@ qr:
 
 </p>
 
-<p style="font-size: 1.2em">
-    Please be 10 minutes early for a smooth seating experience.
-</p>
-
 <p style="font-size: 1.2em"> Below is a
     QR code for
     your confirmation. </p>
 
 
-<img id="now" style="max-width: 60%; width: auto;" alt="" src="data:image/png;base64,{{ qr}}" />
+<img id="now" style="max-width: 60%; width: auto;" alt="Ticket QR code" src="cid:{{ cid }}" />
 
 <p style="font-size: 1.2em"> Note: all tickets issued by us are <b>non-refundable</b>. </p>
 


### PR DESCRIPTION
Adds QR code image as an attachment to the ticket confirmation email. Gmail does not display embedded base64 images, which is why the QR code was not previously showing up.

![Screenshot 2024-04-30 at 12 19 28 AM](https://github.com/pennlabs/penn-clubs/assets/60864468/86b7d93f-7339-463e-b53f-bdc80c9115ac)