### PR TITLE
Make multiple owned tickets UI more intuitive

### DIFF
--- a/frontend/components/Settings/TicketsTab/index.tsx
+++ b/frontend/components/Settings/TicketsTab/index.tsx
@@ -200,7 +200,7 @@ const TicketsTab = ({ className, userInfo }: TicketsTabProps): ReactElement => {
       </TitleWrapper>
       {Object.entries(groupedTickets).map((group: [string, any[]], i) => (
         <div key={i}>
-          {expandedEvents.has(group[0] || group[1].length === 1) && (
+          {group[1].length !== 1 && (
             <a
               style={{
                 display: 'flex',
@@ -208,7 +208,7 @@ const TicketsTab = ({ className, userInfo }: TicketsTabProps): ReactElement => {
               }}
               onClick={() => toggleGroup(group[0])}
             >
-              Uncollapse
+              {expandedEvents.has(group[0]) ? 'Collapse' : 'Expand'}
             </a>
           )}
           {expandedEvents.has(group[0]) || group[1].length === 1 ? (

--- a/frontend/components/Settings/TicketsTab/index.tsx
+++ b/frontend/components/Settings/TicketsTab/index.tsx
@@ -222,10 +222,14 @@ const TicketsTab = ({ className, userInfo }: TicketsTabProps): ReactElement => {
                   }
                 }}
                 viewModal={(type) => viewModal(ticket.id, type)}
-                indexProps={{
-                  index: i,
-                  length: group[1].length,
-                }}
+                indexProps={
+                  group[1].length !== 1
+                    ? {
+                        index: i,
+                        length: group[1].length,
+                      }
+                    : undefined
+                }
               />
             ))
           ) : (
@@ -238,7 +242,12 @@ const TicketsTab = ({ className, userInfo }: TicketsTabProps): ReactElement => {
                   toggleGroup(group[0])
                 }
               }}
+              indexProps={{
+                index: 0,
+                length: group[1].length,
+              }}
               viewModal={(type) => viewModal(group[1][0].id, type)}
+              hideActions
             />
           )}
         </div>

--- a/frontend/components/Tickets/TicketCard.tsx
+++ b/frontend/components/Tickets/TicketCard.tsx
@@ -155,7 +155,7 @@ export const TicketCard = ({
         display: 'flex',
         cursor: typeof onClick === 'function' ? 'pointer' : 'default',
         boxShadow: generateBoxShadow(Math.min(3, collapsed)),
-        margin: collapsed !== 0 ? '4rem 0' : '1rem 0',
+        margin: collapsed !== 0 ? '2rem 0' : '1rem 0',
       }}
       onClick={onClick}
     >


### PR DESCRIPTION
![image](https://github.com/pennlabs/penn-clubs/assets/10285518/ad90f973-7ead-479d-8fa7-7595797b1b88)

- Removes action buttons when ticket stack for given event is collapsed.
- Adds numbering to ticket when stack is collapsed and has multiple tickets in it
- Removes numbering for "stacks" with only one ticket in it

Attempts to make it clearer when multiple tickets are owned that the stack is expandable, differentiating it visually from single owned tickets.