### PR TITLE
Add note to ticket transfer flow

### DIFF
--- a/frontend/components/Settings/TicketTransferModal.tsx
+++ b/frontend/components/Settings/TicketTransferModal.tsx
@@ -41,7 +41,7 @@ const TicketTransferModal = ({
   return (
     <BaseCard title="Ticket Transfer">
       <p className="has-text-info" style={{ marginBottom: '10px' }}>
-        Recipient must have a PennClubs account.
+        Recipient must have a Penn Clubs account.
       </p>
       <input
         className="input"

--- a/frontend/components/Settings/TicketTransferModal.tsx
+++ b/frontend/components/Settings/TicketTransferModal.tsx
@@ -40,6 +40,9 @@ const TicketTransferModal = ({
 
   return (
     <BaseCard title="Ticket Transfer">
+      <p className="has-text-info" style={{ marginBottom: '10px' }}>
+        Recipient must have a PennClubs account.
+      </p>
       <input
         className="input"
         value={recipient}


### PR DESCRIPTION
Reminds users that transfer recipients must have a valid PennClubs account.
![Screenshot 2024-04-30 at 1 19 58 PM](https://github.com/pennlabs/penn-clubs/assets/69180850/56597569-4c3b-4286-b06d-7ec892bd509a)
