### PR TITLE
Add retry logic for SMTP errors

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -54,7 +54,7 @@ def get_mail_type_annotation(name):
 
 
 def send_mail_helper(
-    name, subject, emails, context, attachment=None, reply_to=None, num_retries=3
+    name, subject, emails, context, attachment=None, reply_to=None, num_retries=2
 ):
     """
     A helper to send out an email given the template name, subject, to emails,
@@ -127,14 +127,13 @@ def send_mail_helper(
     msg.attach_alternative(html_content, "text/html")
 
     # Retry to avoid one-off SMTP errors
-    for attempt in range(num_retries):
+    for attempt in range(num_retries + 1):
         try:
             msg.send(fail_silently=False)
             return True
         except (SMTPServerDisconnected, SMTPAuthenticationError) as e:
-            if attempt == num_retries - 1:
+            if attempt == num_retries:
                 raise e
-    return False
 
 
 def get_asset_file_name(instance, fname):

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -5,6 +5,7 @@ import uuid
 import warnings
 from email.mime.image import MIMEImage
 from io import BytesIO
+from smtplib import SMTPAuthenticationError, SMTPServerDisconnected
 from urllib.parse import urlparse
 
 import pytz
@@ -52,7 +53,9 @@ def get_mail_type_annotation(name):
     return None
 
 
-def send_mail_helper(name, subject, emails, context, attachment=None, reply_to=None):
+def send_mail_helper(
+    name, subject, emails, context, attachment=None, reply_to=None, num_retries=3
+):
     """
     A helper to send out an email given the template name, subject, to emails,
     and context. Returns true if an email was sent out, or false if no emails
@@ -122,7 +125,15 @@ def send_mail_helper(name, subject, emails, context, attachment=None, reply_to=N
             msg.mixed_subtype = "related"
 
     msg.attach_alternative(html_content, "text/html")
-    msg.send(fail_silently=False)
+
+    # Retry to avoid one-off SMTP errors
+    for attempt in range(num_retries):
+        try:
+            msg.send(fail_silently=False)
+        except (SMTPServerDisconnected, SMTPAuthenticationError) as e:
+            if attempt == num_retries - 1:
+                raise e
+
     return True
 
 

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -130,11 +130,11 @@ def send_mail_helper(
     for attempt in range(num_retries):
         try:
             msg.send(fail_silently=False)
+            return True
         except (SMTPServerDisconnected, SMTPAuthenticationError) as e:
             if attempt == num_retries - 1:
                 raise e
-
-    return True
+    return False
 
 
 def get_asset_file_name(instance, fname):


### PR DESCRIPTION
Adds retry logic to handle one-off SMTP errors. Seems to primarily affect membership requests. [[1](https://penn-labs.sentry.io/issues/5414670480/?end=2024-05-27T23%3A59%3A59&project=6171867&query=&referrer=issue-stream&start=2024-02-29T00%3A00%3A00&stream_index=3&utc=true), [2](https://penn-labs.sentry.io/issues/4820156177/?end=2024-05-27T23%3A59%3A59&project=6171867&query=&referrer=issue-stream&start=2024-02-29T00%3A00%3A00&stream_index=5&utc=true)]