### PR TITLE
Reenable Sentry monitoring with lower sample rate

### DIFF
--- a/backend/pennclubs/settings/production.py
+++ b/backend/pennclubs/settings/production.py
@@ -25,8 +25,8 @@ if SENTRY_URL:
         dsn=SENTRY_URL,
         integrations=[DjangoIntegration(cache_spans=True)],
         send_default_pii=False,
-        enable_tracing=False,
-        traces_sample_rate=1.0,
+        enable_tracing=True,
+        traces_sample_rate=0.1,
         profiles_sample_rate=1.0,
     )
 


### PR DESCRIPTION
Sample 10% of transactions [as discussed](https://penn-labs.slack.com/archives/C05UD8MF894/p1716834205819349).