### PR TITLE
Disable queue for summer

### DIFF
--- a/backend/clubs/management/commands/daily_notifications.py
+++ b/backend/clubs/management/commands/daily_notifications.py
@@ -96,7 +96,7 @@ class Command(BaseCommand):
         group_name = "Approvers"
 
         # only send notifications if it is currently a weekday
-        if now.isoweekday() not in range(1, 6):
+        if now.isoweekday() not in range(1, 6) or not settings.QUEUE_OPEN:
             return False
 
         # get users in group to send notification to

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1505,16 +1505,17 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
                     field
                 ] == getattr(self.instance, field, None):
                     needs_reapproval = True
-                    if not settings.QUEUE_OPEN:
-                        raise serializers.ValidationError(
-                            "The approval queue is not currently open."
-                        )
                     break
 
         # if the editing user has approval permissions, skip the approval process
         request = self.context.get("request", None)
         if request and request.user.has_perm("clubs.approve_club"):
             needs_reapproval = False
+
+        if needs_reapproval and not settings.QUEUE_OPEN:
+            raise serializers.ValidationError(
+                "The approval queue is not currently open."
+            )
 
         has_approved_version = (
             self.instance and self.instance.history.filter(approved=True).exists()

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1505,6 +1505,10 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
                     field
                 ] == getattr(self.instance, field, None):
                     needs_reapproval = True
+                    if not settings.QUEUE_OPEN:
+                        raise serializers.ValidationError(
+                            "The approval queue is not currently open."
+                        )
                     break
 
         # if the editing user has approval permissions, skip the approval process

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -203,6 +203,7 @@ RENEWAL_URL = "https://{domain}/club/{club}/renew"
 APPLY_URL = "https://{domain}/club/{club}/apply"
 
 OSA_EMAILS = ["vpul-orgs@pobox.upenn.edu"]
+QUEUE_OPEN = False
 
 # File upload settings
 

--- a/backend/tests/clubs/test_commands.py
+++ b/backend/tests/clubs/test_commands.py
@@ -373,8 +373,11 @@ class SendInvitesTestCase(TestCase):
             "django.utils.timezone.now",
             return_value=now,
         ):
-            call_command("daily_notifications", stderr=errors)
-
+            with mock.patch("django.conf.settings.QUEUE_OPEN", False):
+                call_command("daily_notifications", stderr=errors)
+            self.assertFalse(any(m.to == [self.user1.email] for m in mail.outbox))
+            with mock.patch("django.conf.settings.QUEUE_OPEN", True):
+                call_command("daily_notifications", stderr=errors)
         # ensure approval email was sent out
         self.assertTrue(any(m.to == [self.user1.email] for m in mail.outbox))
 

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -3,7 +3,6 @@ import io
 import json
 import os
 from collections import Counter
-from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
@@ -1365,7 +1364,7 @@ class ClubTestCase(TestCase):
 
         self.client.login(username=self.user1.username, password="test")
 
-        with mock.patch("django.conf.settings.QUEUE_OPEN", True):
+        with patch("django.conf.settings.QUEUE_OPEN", True):
             resp = self.client.patch(
                 reverse("clubs-detail", args=(self.club1.code,)),
                 {
@@ -1986,7 +1985,7 @@ class ClubTestCase(TestCase):
         # login to officer user
         self.client.login(username=self.user4.username, password="test")
 
-        with mock.patch("django.conf.settings.QUEUE_OPEN", False):
+        with patch("django.conf.settings.QUEUE_OPEN", False):
             for field in {"name", "description"}:
                 # edit sensitive field
                 resp = self.client.patch(
@@ -2000,7 +1999,7 @@ class ClubTestCase(TestCase):
                 club.refresh_from_db()
                 self.assertTrue(club.approved)
 
-        with mock.patch("django.conf.settings.QUEUE_OPEN", True):
+        with patch("django.conf.settings.QUEUE_OPEN", True):
             for field in {"name", "description"}:
                 # edit sensitive field
                 resp = self.client.patch(

--- a/frontend/components/ClubEditPage/ClubEditCard.tsx
+++ b/frontend/components/ClubEditPage/ClubEditCard.tsx
@@ -34,10 +34,12 @@ import {
   OBJECT_NAME_SINGULAR,
   OBJECT_NAME_TITLE_SINGULAR,
   OBJECT_TAB_ADMISSION_LABEL,
+  QUEUE_ENABLED,
   SHOW_RANK_ALGORITHM,
   SITE_ID,
   SITE_NAME,
 } from '../../utils/branding'
+import { LiveBanner, LiveSub, LiveTitle } from '../ClubPage/LiveEventsDialog'
 import { Checkbox, CheckboxLabel, Contact, Text } from '../common'
 import {
   CheckboxField,
@@ -400,6 +402,7 @@ export default function ClubEditCard({
           type: 'text',
           required: true,
           label: `${OBJECT_NAME_TITLE_SINGULAR} Name`,
+          disabled: !QUEUE_ENABLED,
           help: isEdit ? (
             <>
               If you would like to change your {OBJECT_NAME_SINGULAR} URL in
@@ -446,6 +449,7 @@ export default function ClubEditCard({
           help: `Changing this field will require reapproval from the ${APPROVAL_AUTHORITY}.`,
           placeholder: `Type your ${OBJECT_NAME_SINGULAR} description here!`,
           type: 'html',
+          hidden: !QUEUE_ENABLED,
         },
         {
           name: 'tags',
@@ -461,6 +465,7 @@ export default function ClubEditCard({
           accept: 'image/*',
           type: 'image',
           label: `${OBJECT_NAME_TITLE_SINGULAR} Logo`,
+          disabled: !QUEUE_ENABLED,
         },
         {
           name: 'size',
@@ -814,6 +819,15 @@ export default function ClubEditCard({
     <Formik initialValues={initialValues} onSubmit={submit} enableReinitialize>
       {({ dirty, isSubmitting }) => (
         <Form>
+          {!QUEUE_ENABLED && (
+            <LiveBanner>
+              <LiveTitle>Queue Closed for Summer Break</LiveTitle>
+              <LiveSub>
+                No new edits to club name, image, or description will be
+                submitted for review to OSA.
+              </LiveSub>
+            </LiveBanner>
+          )}
           <FormStyle isHorizontal>
             {fields.map(({ name, description, fields, hidden }, i) => {
               if (hidden) {

--- a/frontend/components/ClubPage/LiveEventsDialog.tsx
+++ b/frontend/components/ClubPage/LiveEventsDialog.tsx
@@ -13,7 +13,7 @@ import { ClubEventType, MembershipRank } from '../../types'
 import { doApiRequest, useSetting } from '../../utils'
 import { FAIR_NAME, MEMBERSHIP_ROLE_NAMES } from '../../utils/branding'
 
-const LiveBanner = styled.div`
+export const LiveBanner = styled.div`
   padding: 20px;
   border-radius: 5px;
   background-image: radial-gradient(
@@ -37,13 +37,13 @@ const LiveBanner = styled.div`
   margin-bottom: 10px;
 `
 
-const LiveTitle = styled.div`
+export const LiveTitle = styled.div`
   font-size: ${M4};
   font-weight: bold;
   color: white;
 `
 
-const LiveSub = styled.div`
+export const LiveSub = styled.div`
   margin-top: -3px;
   margin-bottom: 3px;
   font-size: ${M2};

--- a/frontend/components/FormComponents.tsx
+++ b/frontend/components/FormComponents.tsx
@@ -643,6 +643,7 @@ export const FileField = useFieldWrapper(
     value,
     isImage = false,
     canDelete = false,
+    disabled = false,
   }: BasicFormField & AnyHack): ReactElement => {
     const { setFieldValue } = useFormikContext()
 
@@ -681,7 +682,12 @@ export const FileField = useFieldWrapper(
             <img style={{ maxWidth: 300 }} src={imageUrl} />
           ))}
         <div className="file">
-          <label className="file-label">
+          <label
+            className="file-label"
+            style={{
+              cursor: disabled ? 'not-allowed' : 'pointer',
+            }}
+          >
             <input
               className="file-input"
               type="file"
@@ -693,11 +699,14 @@ export const FileField = useFieldWrapper(
               }}
               onBlur={onBlur}
               placeholder={placeholder}
+              onClick={(e) => {
+                if (disabled) {
+                  e.preventDefault()
+                }
+              }}
             />
             <span className="file-cta">
-              <span className="file-label">
-                Choose a {isImage ? 'image' : 'file'}...
-              </span>
+              Choose a {isImage ? 'image' : 'file'}...
             </span>
           </label>
           {imageUrl && (canDelete || isImage) && (

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -252,6 +252,7 @@ const sites = {
 }
 
 export const TICKETING_PAYMENT_ENABLED = false
+export const QUEUE_ENABLED = false
 export const SITE_ID = site
 export const SITE_NAME = sites[site].SITE_NAME
 export const SITE_SUBTITLE = sites[site].SITE_SUBTITLE


### PR DESCRIPTION
Per OSA request, disables editing of club fields that would necessitate queue approval as well as daily email notifications for queue approval.