### PR TITLE
Partially open queue for Fall 2024

### DIFF
--- a/backend/clubs/management/commands/daily_notifications.py
+++ b/backend/clubs/management/commands/daily_notifications.py
@@ -96,7 +96,7 @@ class Command(BaseCommand):
         group_name = "Approvers"
 
         # only send notifications if it is currently a weekday
-        if now.isoweekday() not in range(1, 6) or not settings.QUEUE_OPEN:
+        if now.isoweekday() not in range(1, 6) or not settings.REAPPROVAL_QUEUE_OPEN:
             return False
 
         # get users in group to send notification to

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1285,6 +1285,14 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
         # New clubs created through the API must always be approved.
         validated_data["approved"] = None
 
+        request = self.context.get("request", None)
+        perms = request and request.user.has_perm("clubs.approve_club")
+
+        if not perms and (not settings.QUEUE_OPEN or not settings.NEW_QUEUE_OPEN):
+            raise serializers.ValidationError(
+                "The approval queue is not currently open."
+            )
+
         obj = super().create(validated_data)
 
         # assign user who created as owner
@@ -1500,7 +1508,7 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
         # if key fields were edited, require re-approval
         needs_reapproval = False
         if self.instance:
-            for field in {"name", "image", "description"}:
+            for field in {"name", "image"}:
                 if field in self.validated_data and not self.validated_data[
                     field
                 ] == getattr(self.instance, field, None):

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1288,7 +1288,9 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
         request = self.context.get("request", None)
         perms = request and request.user.has_perm("clubs.approve_club")
 
-        if not perms and (not settings.QUEUE_OPEN or not settings.NEW_QUEUE_OPEN):
+        if not perms and (
+            not settings.REAPPROVAL_QUEUE_OPEN or not settings.NEW_APPROVAL_QUEUE_OPEN
+        ):
             raise serializers.ValidationError(
                 "The approval queue is not currently open."
             )
@@ -1520,7 +1522,7 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
         if request and request.user.has_perm("clubs.approve_club"):
             needs_reapproval = False
 
-        if needs_reapproval and not settings.QUEUE_OPEN:
+        if needs_reapproval and not settings.REAPPROVAL_QUEUE_OPEN:
             raise serializers.ValidationError(
                 "The approval queue is not currently open."
             )

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -203,7 +203,8 @@ RENEWAL_URL = "https://{domain}/club/{club}/renew"
 APPLY_URL = "https://{domain}/club/{club}/apply"
 
 OSA_EMAILS = ["vpul-orgs@pobox.upenn.edu"]
-QUEUE_OPEN = False
+QUEUE_OPEN = True
+NEW_QUEUE_OPEN = False
 
 # File upload settings
 

--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -203,8 +203,12 @@ RENEWAL_URL = "https://{domain}/club/{club}/renew"
 APPLY_URL = "https://{domain}/club/{club}/apply"
 
 OSA_EMAILS = ["vpul-orgs@pobox.upenn.edu"]
-QUEUE_OPEN = True
-NEW_QUEUE_OPEN = False
+
+
+# Controls whether existing clubs can submit for reapproval
+REAPPROVAL_QUEUE_OPEN = True
+# Controls whether new clubs can submit for initial approval
+NEW_APPROVAL_QUEUE_OPEN = False
 
 # File upload settings
 

--- a/backend/tests/clubs/test_commands.py
+++ b/backend/tests/clubs/test_commands.py
@@ -373,10 +373,10 @@ class SendInvitesTestCase(TestCase):
             "django.utils.timezone.now",
             return_value=now,
         ):
-            with mock.patch("django.conf.settings.QUEUE_OPEN", False):
+            with mock.patch("django.conf.settings.REAPPROVAL_QUEUE_OPEN", False):
                 call_command("daily_notifications", stderr=errors)
             self.assertFalse(any(m.to == [self.user1.email] for m in mail.outbox))
-            with mock.patch("django.conf.settings.QUEUE_OPEN", True):
+            with mock.patch("django.conf.settings.REAPPROVAL_QUEUE_OPEN", True):
                 call_command("daily_notifications", stderr=errors)
         # ensure approval email was sent out
         self.assertTrue(any(m.to == [self.user1.email] for m in mail.outbox))

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -973,23 +973,25 @@ class ClubTestCase(TestCase):
         """
         self.client.login(username=self.user4.username, password="test")
 
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {
-                "code": "penn-labs",
-                "name": "Penn Labs",
-                "description": "This is an example description.",
-                "tags": [{"name": "Graduate"}],
-                "email": "example@example.com",
-                "facebook": "",
-                "twitter": "",
-                "instagram": "",
-                "website": "",
-                "linkedin": "",
-                "github": "",
-            },
-            content_type="application/json",
-        )
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {
+                        "code": "penn-labs",
+                        "name": "Penn Labs",
+                        "description": "This is an example description.",
+                        "tags": [{"name": "Graduate"}],
+                        "email": "example@example.com",
+                        "facebook": "",
+                        "twitter": "",
+                        "instagram": "",
+                        "website": "",
+                        "linkedin": "",
+                        "github": "",
+                    },
+                    content_type="application/json",
+                )
         self.assertIn(resp.status_code, [200, 201], resp.content)
 
         # continue these tests as not a superuser but still logged in
@@ -1044,20 +1046,22 @@ class ClubTestCase(TestCase):
 
         exploit_string = "javascript:alert(1)"
 
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {
-                "name": "Bad Club",
-                "tags": [],
-                "facebook": exploit_string,
-                "twitter": exploit_string,
-                "instagram": exploit_string,
-                "website": exploit_string,
-                "linkedin": exploit_string,
-                "github": exploit_string,
-            },
-            content_type="application/json",
-        )
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {
+                        "name": "Bad Club",
+                        "tags": [],
+                        "facebook": exploit_string,
+                        "twitter": exploit_string,
+                        "instagram": exploit_string,
+                        "website": exploit_string,
+                        "linkedin": exploit_string,
+                        "github": exploit_string,
+                    },
+                    content_type="application/json",
+                )
         self.assertIn(resp.status_code, [400, 403], resp.content)
 
     def test_club_create_description_sanitize_good(self):
@@ -1079,16 +1083,19 @@ class ClubTestCase(TestCase):
 <img src=\"/test.png\">"""
 
         self.client.login(username=self.user5.username, password="test")
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {
-                "name": "Penn Labs",
-                "tags": [{"name": "Undergraduate"}],
-                "description": test_good_string,
-                "email": "example@example.com",
-            },
-            content_type="application/json",
-        )
+
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {
+                        "name": "Penn Labs",
+                        "tags": [{"name": "Undergraduate"}],
+                        "description": test_good_string,
+                        "email": "example@example.com",
+                    },
+                    content_type="application/json",
+                )
         cache.clear()
         self.assertIn(resp.status_code, [200, 201], resp.content)
 
@@ -1105,16 +1112,19 @@ class ClubTestCase(TestCase):
         test_bad_string = '<script>alert(1);</script><img src="javascript:alert(1)">'
 
         self.client.login(username=self.user5.username, password="test")
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {
-                "name": "Penn Labs",
-                "tags": [{"name": "Graduate"}],
-                "description": test_bad_string,
-                "email": "example@example.com",
-            },
-            content_type="application/json",
-        )
+
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {
+                        "name": "Penn Labs",
+                        "tags": [{"name": "Graduate"}],
+                        "description": test_bad_string,
+                        "email": "example@example.com",
+                    },
+                    content_type="application/json",
+                )
         self.assertIn(resp.status_code, [200, 201], resp.content)
 
         resp = self.client.get(reverse("clubs-detail", args=("penn-labs",)))
@@ -1130,9 +1140,11 @@ class ClubTestCase(TestCase):
         """
         self.client.login(username=self.user5.username, password="test")
 
-        resp = self.client.post(
-            reverse("clubs-list"), {}, content_type="application/json"
-        )
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"), {}, content_type="application/json"
+                )
         self.assertIn(resp.status_code, [400, 403], resp.content)
 
     def test_club_create_nonexistent_tag(self):
@@ -1141,35 +1153,40 @@ class ClubTestCase(TestCase):
         """
         self.client.login(username=self.user5.username, password="test")
 
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {
-                "name": "Penn Labs",
-                "description": "We code stuff.",
-                "email": "contact@pennlabs.org",
-                "tags": [{"name": "totally definitely nonexistent tag"}],
-            },
-            content_type="application/json",
-        )
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {
+                        "name": "Penn Labs",
+                        "description": "We code stuff.",
+                        "email": "contact@pennlabs.org",
+                        "tags": [{"name": "totally definitely nonexistent tag"}],
+                    },
+                    content_type="application/json",
+                )
         self.assertIn(resp.status_code, [400, 404], resp.content)
 
     def test_club_create_no_auth(self):
         """
         Creating a club without authentication should result in an error.
         """
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {
-                "name": "Penn Labs",
-                "description": "We code stuff.",
-                "email": "contact@pennlabs.org",
-                "facebook": "966590693376781",
-                "twitter": "@Penn",
-                "instagram": "@uofpenn",
-                "tags": [],
-            },
-            content_type="application/json",
-        )
+
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {
+                        "name": "Penn Labs",
+                        "description": "We code stuff.",
+                        "email": "contact@pennlabs.org",
+                        "facebook": "966590693376781",
+                        "twitter": "@Penn",
+                        "instagram": "@uofpenn",
+                        "tags": [],
+                    },
+                    content_type="application/json",
+                )
         self.assertIn(resp.status_code, [400, 403], resp.content)
 
     def test_club_create(self):
@@ -1185,31 +1202,33 @@ class ClubTestCase(TestCase):
 
         self.client.login(username=self.user5.username, password="test")
 
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {
-                "name": "Penn Labs",
-                "description": "We code stuff.",
-                "badges": [{"label": "SAC Funded"}],
-                "tags": [
-                    {"name": tag1.name},
-                    {"name": tag2.name},
-                    {"name": "Graduate"},
-                ],
-                "target_schools": [{"id": school1.id}],
-                "email": "example@example.com",
-                "facebook": "https://www.facebook.com/groups/966590693376781/"
-                + "?ref=nf_target&fref=nf",
-                "twitter": "https://twitter.com/Penn",
-                "instagram": "https://www.instagram.com/uofpenn/?hl=en",
-                "website": "https://pennlabs.org",
-                "linkedin": "https://www.linkedin.com"
-                "/school/university-of-pennsylvania/",
-                "youtube": "https://youtu.be/dQw4w9WgXcQ",
-                "github": "https://github.com/pennlabs",
-            },
-            content_type="application/json",
-        )
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {
+                        "name": "Penn Labs",
+                        "description": "We code stuff.",
+                        "badges": [{"label": "SAC Funded"}],
+                        "tags": [
+                            {"name": tag1.name},
+                            {"name": tag2.name},
+                            {"name": "Graduate"},
+                        ],
+                        "target_schools": [{"id": school1.id}],
+                        "email": "example@example.com",
+                        "facebook": "https://www.facebook.com/groups/966590693376781/"
+                        + "?ref=nf_target&fref=nf",
+                        "twitter": "https://twitter.com/Penn",
+                        "instagram": "https://www.instagram.com/uofpenn/?hl=en",
+                        "website": "https://pennlabs.org",
+                        "linkedin": "https://www.linkedin.com"
+                        "/school/university-of-pennsylvania/",
+                        "youtube": "https://youtu.be/dQw4w9WgXcQ",
+                        "github": "https://github.com/pennlabs",
+                    },
+                    content_type="application/json",
+                )
         self.assertIn(resp.status_code, [200, 201], resp.content)
 
         # ensure club was actually created
@@ -1249,11 +1268,13 @@ class ClubTestCase(TestCase):
         """
         self.client.login(username=self.user5.username, password="test")
 
-        resp = self.client.post(
-            reverse("clubs-list"),
-            {"name": "Test Club", "tags": []},
-            content_type="application/json",
-        )
+        with patch("django.conf.settings.QUEUE_OPEN", True):
+            with patch("django.conf.settings.NEW_QUEUE_OPEN", True):
+                resp = self.client.post(
+                    reverse("clubs-list"),
+                    {"name": "Test Club", "tags": []},
+                    content_type="application/json",
+                )
         self.assertIn(resp.status_code, [400, 403], resp.content)
 
     def test_club_list_search(self):
@@ -1986,7 +2007,7 @@ class ClubTestCase(TestCase):
         self.client.login(username=self.user4.username, password="test")
 
         with patch("django.conf.settings.QUEUE_OPEN", False):
-            for field in {"name", "description"}:
+            for field in {"name"}:
                 # edit sensitive field
                 resp = self.client.patch(
                     reverse("clubs-detail", args=(club.code,)),
@@ -2000,7 +2021,7 @@ class ClubTestCase(TestCase):
                 self.assertTrue(club.approved)
 
         with patch("django.conf.settings.QUEUE_OPEN", True):
-            for field in {"name", "description"}:
+            for field in {"name"}:
                 # edit sensitive field
                 resp = self.client.patch(
                     reverse("clubs-detail", args=(club.code,)),

--- a/frontend/components/ClubEditPage/ClubEditCard.tsx
+++ b/frontend/components/ClubEditPage/ClubEditCard.tsx
@@ -31,11 +31,11 @@ import {
   FORM_TAG_DESCRIPTION,
   FORM_TARGET_DESCRIPTION,
   MEMBERSHIP_ROLE_NAMES,
-  NEW_QUEUE_ENABLED,
+  NEW_APPROVAL_QUEUE_ENABLED,
   OBJECT_NAME_SINGULAR,
   OBJECT_NAME_TITLE_SINGULAR,
   OBJECT_TAB_ADMISSION_LABEL,
-  QUEUE_ENABLED,
+  REAPPROVAL_QUEUE_ENABLED,
   SHOW_RANK_ALGORITHM,
   SITE_ID,
   SITE_NAME,
@@ -403,7 +403,7 @@ export default function ClubEditCard({
           type: 'text',
           required: true,
           label: `${OBJECT_NAME_TITLE_SINGULAR} Name`,
-          disabled: !QUEUE_ENABLED,
+          disabled: !REAPPROVAL_QUEUE_ENABLED,
           help: isEdit ? (
             <>
               If you would like to change your {OBJECT_NAME_SINGULAR} URL in
@@ -450,7 +450,7 @@ export default function ClubEditCard({
           help: `Changing this field will require reapproval from the ${APPROVAL_AUTHORITY}.`,
           placeholder: `Type your ${OBJECT_NAME_SINGULAR} description here!`,
           type: 'html',
-          hidden: !QUEUE_ENABLED,
+          hidden: !REAPPROVAL_QUEUE_ENABLED,
         },
         {
           name: 'tags',
@@ -466,7 +466,7 @@ export default function ClubEditCard({
           accept: 'image/*',
           type: 'image',
           label: `${OBJECT_NAME_TITLE_SINGULAR} Logo`,
-          disabled: !QUEUE_ENABLED,
+          disabled: !REAPPROVAL_QUEUE_ENABLED,
         },
         {
           name: 'size',
@@ -820,7 +820,7 @@ export default function ClubEditCard({
     <Formik initialValues={initialValues} onSubmit={submit} enableReinitialize>
       {({ dirty, isSubmitting }) => (
         <Form>
-          {!QUEUE_ENABLED && (
+          {!REAPPROVAL_QUEUE_ENABLED && (
             <LiveBanner>
               <LiveTitle>Queue Closed for Summer Break</LiveTitle>
               <LiveSub>
@@ -829,15 +829,17 @@ export default function ClubEditCard({
               </LiveSub>
             </LiveBanner>
           )}
-          {!NEW_QUEUE_ENABLED && QUEUE_ENABLED && !isEdit && (
-            <LiveBanner>
-              <LiveTitle>Queue Closed for New Clubs</LiveTitle>
-              <LiveSub>
-                Submissions for new clubs are closed until the school year
-                begins.
-              </LiveSub>
-            </LiveBanner>
-          )}
+          {!NEW_APPROVAL_QUEUE_ENABLED &&
+            REAPPROVAL_QUEUE_ENABLED &&
+            !isEdit && (
+              <LiveBanner>
+                <LiveTitle>Queue Closed for New Clubs</LiveTitle>
+                <LiveSub>
+                  Submissions for new clubs are closed until the school year
+                  begins.
+                </LiveSub>
+              </LiveBanner>
+            )}
           <FormStyle isHorizontal>
             {fields.map(({ name, description, fields, hidden }, i) => {
               if (hidden) {
@@ -896,7 +898,9 @@ export default function ClubEditCard({
             })}
             <button
               disabled={
-                !dirty || isSubmitting || (!NEW_QUEUE_ENABLED && !isEdit)
+                !dirty ||
+                isSubmitting ||
+                (!NEW_APPROVAL_QUEUE_ENABLED && !isEdit)
               }
               type="submit"
               className="button is-primary is-large"

--- a/frontend/components/ClubEditPage/ClubEditCard.tsx
+++ b/frontend/components/ClubEditPage/ClubEditCard.tsx
@@ -31,6 +31,7 @@ import {
   FORM_TAG_DESCRIPTION,
   FORM_TARGET_DESCRIPTION,
   MEMBERSHIP_ROLE_NAMES,
+  NEW_QUEUE_ENABLED,
   OBJECT_NAME_SINGULAR,
   OBJECT_NAME_TITLE_SINGULAR,
   OBJECT_TAB_ADMISSION_LABEL,
@@ -823,8 +824,17 @@ export default function ClubEditCard({
             <LiveBanner>
               <LiveTitle>Queue Closed for Summer Break</LiveTitle>
               <LiveSub>
-                No new edits to club name, image, or description will be
+                No edits to existing clubs or applications for new clubs will be
                 submitted for review to OSA.
+              </LiveSub>
+            </LiveBanner>
+          )}
+          {!NEW_QUEUE_ENABLED && QUEUE_ENABLED && !isEdit && (
+            <LiveBanner>
+              <LiveTitle>Queue Closed for New Clubs</LiveTitle>
+              <LiveSub>
+                Submissions for new clubs are closed until the school year
+                begins.
               </LiveSub>
             </LiveBanner>
           )}
@@ -885,7 +895,9 @@ export default function ClubEditCard({
               )
             })}
             <button
-              disabled={!dirty || isSubmitting}
+              disabled={
+                !dirty || isSubmitting || (!NEW_QUEUE_ENABLED && !isEdit)
+              }
               type="submit"
               className="button is-primary is-large"
             >

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -252,8 +252,8 @@ const sites = {
 }
 
 export const TICKETING_PAYMENT_ENABLED = false
-export const QUEUE_ENABLED = true
-export const NEW_QUEUE_ENABLED = false
+export const REAPPROVAL_QUEUE_ENABLED = true
+export const NEW_APPROVAL_QUEUE_ENABLED = false
 export const SITE_ID = site
 export const SITE_NAME = sites[site].SITE_NAME
 export const SITE_SUBTITLE = sites[site].SITE_SUBTITLE

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -252,7 +252,8 @@ const sites = {
 }
 
 export const TICKETING_PAYMENT_ENABLED = false
-export const QUEUE_ENABLED = false
+export const QUEUE_ENABLED = true
+export const NEW_QUEUE_ENABLED = false
 export const SITE_ID = site
 export const SITE_NAME = sites[site].SITE_NAME
 export const SITE_SUBTITLE = sites[site].SITE_SUBTITLE


### PR DESCRIPTION
Per OSA request:

* Opens approval queue solely for edits to existing clubs, keeping club creation closed
* Disables approval queue entrance on editing club description

Also:

* Fixes bug where creating new clubs on backend doesn't check for approval queue status