### PR TITLE
Remove error details for hidden user profiles

### DIFF
--- a/frontend/pages/user/[user]/index.tsx
+++ b/frontend/pages/user/[user]/index.tsx
@@ -82,8 +82,7 @@ const UserProfilePage = ({
         <Metadata title="User Profile" />
         <AuthPrompt title="Oh no!" hasLogin={!authenticated}>
           You cannot view the profile for this user. This user might not exist
-          or have set their profile to private.{' '}
-          <span className="has-text-grey">{profile.detail}</span>
+          or have set their profile to private.
         </AuthPrompt>
       </>
     )


### PR DESCRIPTION
Currently, for signed in users, visiting a user profile set to private yields a slightly different page compared to profiles that don't exist, which implicates the existence or nonexistence of any given Pennkey and associated email at `/user/{pennkey}`. This would theoretically let someone scrape the vast majority of Penn emails in existence through brute force, including those hidden from the Penn directory and email autocompletes.

I'm not sure if this is necessary or outweighs the marginal benefit of the error detail, and we should discuss separately, but am opening a PR since it's a one line change.