### PR TITLE
Don't display duplicate badges and tags

### DIFF
--- a/frontend/components/common/TagGroup.tsx
+++ b/frontend/components/common/TagGroup.tsx
@@ -14,9 +14,23 @@ function isBadge(tag): tag is Badge {
 export const TagGroup = ({ tags = [] }: TagGroupProps): ReactElement | null => {
   if (!tags || !tags.length) return null
 
+  // sometimes there will be duplicate badges, or a badge will end up with the same content as a tag
+  // when there are duplicate badges, choose one arbitrarily
+  // when there's a tag and a badge with the same content, render the badge
+
+  const uniqueTags = tags.reduce((acc, tag) => {
+    const key = isBadge(tag) ? tag.label : tag.name
+    if (!acc.has(key)) {
+      acc.set(key, tag)
+    } else if (isBadge(tag)) {
+      acc.set(key, tag)
+    }
+    return acc
+  }, new Map())
+
   return (
     <>
-      {tags.map((tag) =>
+      {Array.from(uniqueTags.values()).map((tag) =>
         isBadge(tag) ? (
           <DefaultTag
             key={`${tag.id}-badge`}


### PR DESCRIPTION
There are sometimes collisions between tags and badges on a club's main page. (See the attached file for an example.) This PR adds filtering logic on the frontend to 1) only display one badge per unique label 2)  in the event of a conflict between a badge and a tag, display the badge. 

Credit to @jamesdoh0109 for spotting this. 
![Screenshot 2024-08-28 at 6 15 32 PM](https://github.com/user-attachments/assets/2040c831-813a-46b7-9ab4-257b15444428)
