### PR TITLE
Fix permission-related display issues after club deactivation

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -992,33 +992,6 @@ class ClubListSerializer(serializers.ModelSerializer):
 
         return fields_subset if len(fields_subset) > 0 else all_fields
 
-    def to_representation(self, instance):
-        """
-        Return the previous approved version of a club for users
-        that should not see unapproved content.
-        """
-        if instance.ghost and not instance.approved:
-            user = self.context["request"].user
-
-            can_see_pending = user.has_perm("clubs.see_pending_clubs") or user.has_perm(
-                "clubs.manage_club"
-            )
-            is_member = (
-                user.is_authenticated
-                and instance.membership_set.filter(person=user).exists()
-            )
-            if not can_see_pending and not is_member:
-                historical_club = (
-                    instance.history.filter(approved=True)
-                    .order_by("-approved_on")
-                    .first()
-                )
-                if historical_club is not None:
-                    approved_instance = historical_club.instance
-                    approved_instance._is_historical = True
-                    return super().to_representation(approved_instance)
-        return super().to_representation(instance)
-
     class Meta:
         model = Club
         fields = [

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2168,8 +2168,15 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
                     return ClubSerializer
             return ClubListSerializer
         if self.request is not None and self.request.user.is_authenticated:
-            club = self.get_object() if "code" in self.kwargs else None
-            if club and self._has_elevated_view_perms(club):
+            see_pending = self.request.user.has_perm("clubs.see_pending_clubs")
+            manage_club = self.request.user.has_perm("clubs.manage_club")
+            is_member = (
+                "code" in self.kwargs
+                and Membership.objects.filter(
+                    person=self.request.user, club__code=self.kwargs["code"]
+                ).exists()
+            )
+            if see_pending or manage_club or is_member:
                 return AuthenticatedClubSerializer
         return ClubSerializer
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2015,8 +2015,8 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def retrieve(self, *args, **kwargs):
         """
         Retrieve data about a specific club. Responses cached for 1 hour. Caching is
-        disabled for users with elevated view perms so that changes made before approval
-        don't spill over.
+        disabled for users with elevated view perms so that changes without approval
+        granted don't spill over to public.
         """
         club = self.get_object()
 

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2031,7 +2031,6 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
         resp = super().retrieve(*args, **kwargs)
         cache.set(key, resp.data, 60 * 60)
-
         return resp
 
     def update(self, request, *args, **kwargs):

--- a/backend/pennclubs/settings/ci.py
+++ b/backend/pennclubs/settings/ci.py
@@ -11,7 +11,7 @@ TEST_OUTPUT_VERBOSE = 2
 TEST_OUTPUT_DIR = "test-results"
 
 # Use dummy cache for testing
-CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
 
 del PLATFORM_ACCOUNTS["REDIRECT_URI"]
 

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -167,6 +167,8 @@ class ClubTestCase(TestCase):
         Tag.objects.create(name="Undergraduate")
 
     def setUp(self):
+        cache.clear()  # clear the cache between tests
+
         self.client = Client()
 
         self.club1 = Club.objects.create(


### PR DESCRIPTION
Deactivated clubs are displayed differently to permissioned vs non-permissioned users. Users without permissions are expected to see the last approved version; users with permissions see the most up-to-date version. Currently, caching in the viewset incorrect caches the non-permissioned state and displays it to permissioned users. This leads to approval messages showing up in the club management dashboard, despite the club not being approved. 

This PR adds a test to check this case (should fail with current code), and adds a fix. It also turns on caching in CI.