### PR TITLE
Group badges by color in club page

### DIFF
--- a/frontend/components/common/TagGroup.tsx
+++ b/frontend/components/common/TagGroup.tsx
@@ -34,6 +34,10 @@ export const TagGroup = ({ tags = [] }: TagGroupProps): ReactElement | null => {
         .sort((a, b) => {
           if (isBadge(a) && !isBadge(b)) return 1
           if (!isBadge(a) && isBadge(b)) return -1
+          if (isBadge(a) && isBadge(b)) {
+            // badges should be sorted by color
+            return a.color.localeCompare(b.color)
+          }
           return 0
         })
         .map((tag) =>


### PR DESCRIPTION
Should fix badges of different colors being scattered throughout a club's page. 
![Screenshot 2024-09-01 at 5 51 57 PM](https://github.com/user-attachments/assets/d67ba99a-4ded-4649-9fa2-515881a26cdc)
