### PR TITLE
Display apply button to unauthenticated users

### DIFF
--- a/frontend/components/ClubPage/Actions.tsx
+++ b/frontend/components/ClubPage/Actions.tsx
@@ -12,12 +12,7 @@ import { mediaMaxWidth, mediaMinWidth, SM } from '~/constants'
 
 import { BORDER, MEDIUM_GRAY, WHITE } from '../../constants/colors'
 import { CLUB_APPLY_ROUTE, CLUB_EDIT_ROUTE } from '../../constants/routes'
-import {
-  Club,
-  ClubApplicationRequired,
-  QuestionAnswer,
-  UserInfo,
-} from '../../types'
+import { Club, ClubApplicationRequired, QuestionAnswer } from '../../types'
 import { apiCheckPermission, apiSetLikeStatus, doApiRequest } from '../../utils'
 import {
   FIELD_PARTICIPATION_LABEL,
@@ -85,7 +80,7 @@ const ActionButton = styled.a`
 
 type ActionsProps = {
   club: Club
-  userInfo: UserInfo
+  authenticated: boolean
   style?: CSSProperties
   className?: string
   updateRequests: (code: string) => Promise<void>

--- a/frontend/pages/club/[club]/application/[application]/index.tsx
+++ b/frontend/pages/club/[club]/application/[application]/index.tsx
@@ -17,6 +17,7 @@ import {
 } from 'types'
 import { doApiRequest } from 'utils'
 
+import AuthPrompt from '~/components/common/AuthPrompt'
 import { SelectField, TextField } from '~/components/FormComponents'
 
 type ApplicationPageProps = {
@@ -107,11 +108,16 @@ export function formatQuestionType(
 }
 
 const ApplicationPage = ({
+  userInfo,
   club,
   application,
   questions,
   initialValues,
-}: ApplicationPageProps): ReactElement => {
+}): ReactElement => {
+  if (!userInfo) {
+    return <AuthPrompt />
+  }
+
   // Second condition will be replaced with perms check or question nullity check once backend is updated
   // eslint-disable-next-line no-constant-condition
   if (new Date() < new Date(application.application_start_time) && false) {

--- a/frontend/pages/club/[club]/index.tsx
+++ b/frontend/pages/club/[club]/index.tsx
@@ -225,14 +225,11 @@ const ClubPage = ({
               pending approval from the {APPROVAL_AUTHORITY}.
             </div>
           )}
-
-          {userInfo != null && (
-            <MobileActions
-              club={club}
-              userInfo={userInfo}
-              updateRequests={updateRequests}
-            />
-          )}
+          <MobileActions
+            club={club}
+            authenticated={userInfo !== undefined}
+            updateRequests={updateRequests}
+          />
           <StyledCard $bordered>
             <Description club={club} />
           </StyledCard>
@@ -278,13 +275,11 @@ const ClubPage = ({
           )}
         </div>
         <div className="column is-one-third">
-          {userInfo && (
-            <DesktopActions
-              club={club}
-              userInfo={userInfo}
-              updateRequests={updateRequests}
-            />
-          )}
+          <DesktopActions
+            club={club}
+            authenticated={userInfo !== undefined}
+            updateRequests={updateRequests}
+          />
           <QAButton onClick={scrollToQuestions}>
             {questions.length > 0
               ? `Click here to see the ${questions.length} question${


### PR DESCRIPTION
Currently, if a user is unauthenticated, the apply button does not display even if the club's application is open (leading to some confusion). Additionally, enforces auth for viewing club applications.