### PR TITLE
Show newest application cycle first in edit club view

### DIFF
--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -418,8 +418,8 @@ export default function ApplicationsPage({
         if (applications.length !== 0) {
           setApplications(applications)
           setCurrentApplication({
-            ...applications[0],
-            name: format_app_name(applications[0]),
+            ...applications[applications.length - 1],
+            name: format_app_name(applications[applications.length - 1]),
           })
         }
       })
@@ -532,7 +532,7 @@ export default function ApplicationsPage({
         CSV.
       </Text>
       <Select
-        options={applications.map((application) => {
+        options={applications.toReversed().map((application) => {
           return {
             ...application,
             value: application.id,


### PR DESCRIPTION
## Context
Currently, the Manage Clubs > Applications Page view defaults to the first application cycle created for each club (see below). This is not ideal because when club leaders wish to see their applications page, it is almost always in order to view the most recent application, and creates a slower user flow because we first load all of the applications from the oldest application cycle.

<img width="1015" alt="Screenshot 2024-09-09 at 11 31 12 PM" src="https://github.com/user-attachments/assets/254cd322-e077-4592-9555-ad258046c2bd">

## Changes
This PR reverses the order of applications shown on the Applications Page tab and sets the default application to be the most recent cycle.

<img width="968" alt="Screenshot 2024-09-09 at 11 41 59 PM" src="https://github.com/user-attachments/assets/620dfcb8-3c45-4af9-8516-903987df05c6">