### PR TITLE
Check for empty responses before application submission

### DIFF
--- a/frontend/pages/club/[club]/application/[application]/index.tsx
+++ b/frontend/pages/club/[club]/application/[application]/index.tsx
@@ -203,6 +203,18 @@ const ApplicationPage = ({
           onSubmit={(values: { [id: number]: any }, actions) => {
             let submitErrors: string | null = null
 
+            // check for unanswered questions
+            const unansweredQuestions = questions.filter(
+              (question) =>
+                question.question_type !== ApplicationQuestionType.InfoText &&
+                (!values[question.id] || values[question.id].trim() === ''),
+            )
+
+            if (unansweredQuestions.length > 0) {
+              setErrors('Please answer all questions before submitting.')
+              return
+            }
+
             // word count error check
             for (const [questionId, text] of Object.entries(values)) {
               const question = questions.find(


### PR DESCRIPTION
Currently, users can hit the submit button with questions that don't have an answer. This PR adds a check over all questions in an application before calling the submit route.