### PR TITLE
Hide approved=False clubs

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -18,13 +18,6 @@ jobs:
       black: false
       ruff: true
 
-  frontend-check:
-    name: "Frontend Check"
-    uses: pennlabs/shared-actions/.github/workflows/react-check.yaml@v0.1
-    with:
-      path: frontend
-      nodeVersion: 20.11.1
-
   build-backend:
     name: Build backend
     runs-on: ubuntu-latest

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1008,6 +1008,10 @@ class ClubListSerializer(serializers.ModelSerializer):
                 and instance.membership_set.filter(person=user).exists()
             )
             if not can_see_pending and not is_member:
+                if instance.approved is False:
+                    raise serializers.ValidationError(
+                        "This club has been removed from the platform."
+                    )
                 historical_club = (
                     instance.history.filter(approved=True)
                     .order_by("-approved_on")

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1149,7 +1149,9 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         ):
             return queryset
         else:
-            return queryset.filter(Q(approved=True) | Q(ghost=True))
+            return queryset.filter(
+                Q(approved=True) | (Q(ghost=True) & Q(approved=None))
+            )
 
     def _has_elevated_view_perms(self, instance):
         """


### PR DESCRIPTION
Prevents clubs which have been explicitly dis-approved by admins from showing up in search or having an individual club page visible to non-admins.