### PR TITLE
Move graduate_users script to cronjob

### DIFF
--- a/backend/clubs/management/commands/graduate_users.py
+++ b/backend/clubs/management/commands/graduate_users.py
@@ -9,7 +9,6 @@ class Command(BaseCommand):
         "Mark all memberships where the student has graduated as inactive. "
         "This script should be run at the beginning of each year."
     )
-    web_execute = True
 
     def handle(self, *args, **kwargs):
         now = timezone.now()

--- a/backend/tests/clubs/test_commands.py
+++ b/backend/tests/clubs/test_commands.py
@@ -733,3 +733,47 @@ class ExpireMembershipInvitesTest(TestCase):
 
         self.assertFalse(self.expired_invite.active)
         self.assertTrue(self.active_invite.active)
+
+
+class GraduateUsersTestCase(TestCase):
+    def setUp(self):
+        self.club = Club.objects.create(code="test", name="Test Club", active=True)
+        self.user1 = get_user_model().objects.create_user(
+            "bfranklin", "bfranklin@seas.upenn.edu", "test"
+        )
+        self.user2 = get_user_model().objects.create_user(
+            "tjefferson", "tjefferson@seas.upenn.edu", "test"
+        )
+
+        # Set graduation years
+        self.user1.profile.graduation_year = timezone.now().year - 1
+        self.user1.profile.save()
+        self.user2.profile.graduation_year = timezone.now().year + 1
+        self.user2.profile.save()
+
+        # Create active memberships
+        Membership.objects.create(person=self.user1, club=self.club, active=True)
+        Membership.objects.create(person=self.user2, club=self.club, active=True)
+
+    def test_graduate_users(self):
+        # Ensure both memberships are active initially
+        self.assertEqual(Membership.objects.filter(active=True).count(), 2)
+
+        # Run the command
+        call_command("graduate_users")
+
+        # Check that only the graduated user's membership is inactive
+        self.assertEqual(Membership.objects.filter(active=True).count(), 1)
+        self.assertFalse(Membership.objects.get(person=self.user1).active)
+        self.assertTrue(Membership.objects.get(person=self.user2).active)
+
+    def test_graduate_users_output(self):
+        # Capture command output
+        out = io.StringIO()
+        call_command("graduate_users", stdout=out)
+
+        # Check the output
+        self.assertIn(
+            "Updated the membership status of 1 student club relationships!",
+            out.getvalue(),
+        )

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -2600,7 +2600,7 @@ class ClubTestCase(TestCase):
         self.assertIn(resp.status_code, [200], resp.content)
         self.assertIsInstance(resp.data, list, resp.content)
 
-        resp = self.client.post(reverse("scripts"), {"action": "graduate_users"})
+        resp = self.client.post(reverse("scripts"), {"action": "find_broken_images"})
         self.assertIn(resp.status_code, [200], resp.content)
         self.assertIn("output", resp.data, resp.content)
 

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -97,7 +97,7 @@ export class MyChart extends PennLabsChart {
     });
 
     new CronJob(this, 'graduate-users', {
-      schedule: cronTime.everyYearIn(1, 1, 12, 0),
+      schedule: cronTime.everyYearIn(5, 31, 12, 0),
       image: backendImage,
       secret: clubsSecret,
       cmd: ["python", "manage.py", "graduate_users"],

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -95,6 +95,13 @@ export class MyChart extends PennLabsChart {
       secret: clubsSecret,
       cmd: ["python", "manage.py", "expire_membership_invites"],
     });
+
+    new CronJob(this, 'graduate-users', {
+      schedule: cronTime.everyYearIn(1, 1, 12, 0),
+      image: backendImage,
+      secret: clubsSecret,
+      cmd: ["python", "manage.py", "graduate_users"],
+    });
   }
 }
 

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -97,7 +97,7 @@ export class MyChart extends PennLabsChart {
     });
 
     new CronJob(this, 'graduate-users', {
-      schedule: cronTime.everyYearIn(5, 31, 12, 0),
+      schedule: cronTime.everyYearIn(1, 1, 12, 0),
       image: backendImage,
       secret: clubsSecret,
       cmd: ["python", "manage.py", "graduate_users"],


### PR DESCRIPTION
The `graduate_users` script, which deactivates memberships for users who graduated before the current year, was originally intended to be executed manually via the admin console. Since this task should occur automatically at the beginning of each year, it makes more sense to have the script as a cronjob.

