### PR TITLE
Change email templates

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -677,6 +677,7 @@ class Club(models.Model):
             "view_url": settings.VIEW_URL.format(domain=domain, club=self.code),
             "edit_url": settings.EDIT_URL.format(domain=domain, club=self.code),
             "change": change,
+            "reply_emails": settings.OSA_EMAILS + [settings.BRANDING_SITE_EMAIL],
         }
 
         emails = self.get_officer_emails()

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -685,10 +685,8 @@ class Club(models.Model):
         if emails:
             send_mail_helper(
                 name="approval_status",
-                subject="{}{} {} on {}".format(
-                    "Changes to " if change else "",
+                subject="{} status update on {}".format(
                     self.name,
-                    "accepted" if self.approved else "not approved",
                     settings.BRANDING_SITE_NAME,
                 ),
                 emails=emails,

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2068,9 +2068,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             "name": club.name,
             "reply_emails": settings.OSA_EMAILS + [settings.BRANDING_SITE_EMAIL],
         }
-        emails = (
-            club.get_officer_emails() + [self.request.user.email] + settings.OSA_EMAILS
-        )
+        emails = club.get_officer_emails() + [self.request.user.email]
         send_mail_helper(
             name="club_deletion",
             subject="Removal of {} from {}".format(
@@ -2078,6 +2076,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             ),
             emails=emails,
             context=context,
+            reply_to=settings.OSA_EMAILS + [settings.BRANDING_SITE_EMAIL],
         )
 
     @action(detail=False, methods=["GET"])

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2071,7 +2071,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         emails = club.get_officer_emails() + [self.request.user.email]
         send_mail_helper(
             name="club_deletion",
-            subject="Removal of {} from {}".format(
+            subject="{} status update on {}".format(
                 club.name, settings.BRANDING_SITE_NAME
             ),
             emails=emails,

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2066,9 +2066,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         # Send notice to club officers and executor
         context = {
             "name": club.name,
-            "branding_site_name": settings.BRANDING_SITE_NAME,
-            "branding_site_email": settings.BRANDING_SITE_EMAIL,
-            "osa_email": settings.OSA_EMAILS[0],
+            "reply_emails": settings.OSA_EMAILS + [settings.BRANDING_SITE_EMAIL],
         }
         emails = (
             club.get_officer_emails() + [self.request.user.email] + settings.OSA_EMAILS

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2068,8 +2068,11 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             "name": club.name,
             "branding_site_name": settings.BRANDING_SITE_NAME,
             "branding_site_email": settings.BRANDING_SITE_EMAIL,
+            "osa_email": settings.OSA_EMAILS[0],
         }
-        emails = club.get_officer_emails() + [self.request.user.email]
+        emails = (
+            club.get_officer_emails() + [self.request.user.email] + settings.OSA_EMAILS
+        )
         send_mail_helper(
             name="club_deletion",
             subject="Removal of {} from {}".format(

--- a/backend/templates/emails/approval_status.html
+++ b/backend/templates/emails/approval_status.html
@@ -35,7 +35,7 @@ reply_emails:
     </p>
     <p style="font-size: 1.2em">
         You can view your club <a href="{{ view_url }}">here</a> and make further edits <a href="{{ edit_url }}">here</a>.
-        If you have any feedback about the club renewal process, you can respond to this email.
+        If you have any feedback about the club renewal process, please respond to this email or <a href="mailto:{% for email in reply_emails %}{% if not forloop.first %},{% endif %}{{ email }}{% endfor %}">contact the Office of Student Affairs</a>.
     </p>
     <p style="font-size: 1.2em">
         Thank you for using Penn Clubs.
@@ -48,8 +48,7 @@ reply_emails:
     <p style="font-size: 1.2em; padding: 8px; border-left: 5px solid #ccc;">{{ approved_comment }}</p>
     <p style="font-size: 1.2em">Please <a href="{{ edit_url }}">make the necessary edits</a> to your club information and use the button <a href="{{ view_url }}">here</a> to resubmit for approval.</p>
     <p style="font-size: 1.2em">
-        If you have any questions or concerns, please contact 
-        <a href="mailto:{% for email in reply_emails %}{{ email }}{% if not forloop.last %},{% endif %}{% endfor %}">the Office of Student Affairs</a>.
+        If you have any questions about the approval process, please feel free to respond to this email or <a href="mailto:{% for email in reply_emails %}{% if not forloop.first %},{% endif %}{{ email }}{% endfor %}">contact the Office of Student Affairs</a>.
     </p>
     <p style="font-size: 1.2em">
     <a

--- a/backend/templates/emails/approval_status.html
+++ b/backend/templates/emails/approval_status.html
@@ -13,6 +13,10 @@ view_url:
     type: string
 year:
     type: number
+reply_emails:
+    type: array
+    items:
+        type: string
 -->
 {% extends 'emails/base.html' %}
 
@@ -31,7 +35,7 @@ year:
     </p>
     <p style="font-size: 1.2em">
         You can view your club <a href="{{ view_url }}">here</a> and make further edits <a href="{{ edit_url }}">here</a>.
-        If you have any feedback about the club renewal process, you can respond to this email or fill out <a href="https://airtable.com/shrCsYFWxCwfwE7cf">this form</a>.
+        If you have any feedback about the club renewal process, you can respond to this email.
     </p>
     <p style="font-size: 1.2em">
         Thank you for using Penn Clubs.
@@ -43,7 +47,10 @@ year:
     <p style="font-size: 1.2em">The feedback regarding your club's status is as follows:</p>
     <p style="font-size: 1.2em; padding: 8px; border-left: 5px solid #ccc;">{{ approved_comment }}</p>
     <p style="font-size: 1.2em">Please <a href="{{ edit_url }}">make the necessary edits</a> to your club information and use the button <a href="{{ view_url }}">here</a> to resubmit for approval.</p>
-    <p style="font-size: 1.2em">If you have any questions about the approval process, please feel free to respond to this email.</p>
+    <p style="font-size: 1.2em">
+        If you have any questions or concerns, please contact 
+        <a href="mailto:{% for email in reply_emails %}{{ email }}{% if not forloop.last %},{% endif %}{% endfor %}">the Office of Student Affairs</a>.
+    </p>
     <p style="font-size: 1.2em">
     <a
        style="text-decoration: none; padding: 5px 20px; font-size: 1.5em; margin-top: 20px; color: white; background-color: green; border-radius: 3px; font-weight: bold"

--- a/backend/templates/emails/approval_status.html
+++ b/backend/templates/emails/approval_status.html
@@ -17,33 +17,33 @@ year:
 {% extends 'emails/base.html' %}
 
 {% block content %}
-    <h2><b>{{ name }}</b> {% if change %}changes{% else %}renewal{% endif %} marked as {% if approved %}approved{% else %}not approved{% endif %} on Penn Clubs</h2>
+    <h2><b>{{ name }}</b> status update on Penn Clubs</h2>
     {% if approved %}
-    <p style="font-size: 1.2em; color: #228B22">
-        <b>🎉 Congratulations!</b> Your club {% if change %}changes have{% else %}has{% endif %} been approved by the <b>Office of Student Affairs</b> for the {{ year }} school year! 
-        Your {% if change %}updated{% else %}new{% endif %} club information is now open to the public on Penn Clubs.
+    <p style="font-size: 1.2em;">
+        Your club {% if change %}changes have{% else %}has{% endif %} been approved by the <b>Office of Student Affairs</b> for the {{ year }} school year. 
+        Your {% if change %}updated{% else %}new{% endif %} club information is now visible to the public on Penn Clubs.
     </p>
     {% if approved_comment %}
         <p style="font-size: 1.2em; padding: 8px; border-left: 5px solid #ccc; white-space: pre-wrap;">{{ approved_comment }}</p>
     {% endif %}
     <p style="font-size: 1.2em">
-        You do not need to perform any further actions.
+        No further action is required at this time.
     </p>
     <p style="font-size: 1.2em">
-        You can view your club <a href="{{ view_url }}">here</a> and make further edits <a href="{{ view_url }}">here</a>.
+        You can view your club <a href="{{ view_url }}">here</a> and make further edits <a href="{{ edit_url }}">here</a>.
         If you have any feedback about the club renewal process, you can respond to this email or fill out <a href="https://airtable.com/shrCsYFWxCwfwE7cf">this form</a>.
     </p>
     <p style="font-size: 1.2em">
-        Thank you for using Penn Clubs!
+        Thank you for using Penn Clubs.
     </p>
     {% else %}
-    <p style="font-size: 1.2em; color: #8B2222">
-        <b>Oh no!</b> Your club {% if change %}updates have{% else %}renewal has{% endif %} <b>not been approved</b> by the <b>Office of Student Affairs</b>. You will need to make changes to your club information before gaining approval.
+    <p style="font-size: 1.2em;">
+        Your club {% if change %}updates have{% else %}renewal has{% endif %} not been approved by the <b>Office of Student Affairs</b>. Some changes to your club information are required before approval can be granted.
     </p>
-    <p style="font-size: 1.2em">The reason your club was not approved is shown below:</p>
+    <p style="font-size: 1.2em">The feedback regarding your club's status is as follows:</p>
     <p style="font-size: 1.2em; padding: 8px; border-left: 5px solid #ccc;">{{ approved_comment }}</p>
-    <p style="font-size: 1.2em">You will need to <a href="{{ edit_url }}">make edits</a> to your club and press the button found <a href="{{ view_url }}">here</a> to apply again for approval.</p>
-    <p style="font-size: 1.2em">If you run into any issues with the approval process, you can respond to this email.</p>
+    <p style="font-size: 1.2em">Please <a href="{{ edit_url }}">make the necessary edits</a> to your club information and use the button <a href="{{ view_url }}">here</a> to resubmit for approval.</p>
+    <p style="font-size: 1.2em">If you have any questions about the approval process, please feel free to respond to this email.</p>
     <p style="font-size: 1.2em">
     <a
        style="text-decoration: none; padding: 5px 20px; font-size: 1.5em; margin-top: 20px; color: white; background-color: green; border-radius: 3px; font-weight: bold"

--- a/backend/templates/emails/club_deletion.html
+++ b/backend/templates/emails/club_deletion.html
@@ -14,7 +14,7 @@ reply_emails:
         Your club has been removed from Penn Clubs by the Office of Student Affairs.
     </p>
     <p style="font-size: 1.2em">
-        If you have any questions or concerns, please contact 
-        <a href="mailto:{% for email in reply_emails %}{{ email }}{% if not forloop.last %},{% endif %}{% endfor %}">the Office of Student Affairs</a>.
+        If you have any questions or concerns, please
+        respond to this email or <a href="mailto:{% for email in reply_emails %}{% if not forloop.first %},{% endif %}{{ email }}{% endfor %}">contact the Office of Student Affairs</a>.
     </p>
 {% endblock %}

--- a/backend/templates/emails/club_deletion.html
+++ b/backend/templates/emails/club_deletion.html
@@ -1,22 +1,20 @@
 <!-- TYPES:
 name:
     type: string
-branding_site_name: 
-    type: string
-branding_site_email: 
-    type: string
-osa_email:
-    type: string
+reply_emails:
+    type: array
+    items:
+        type: string
 -->
 {% extends 'emails/base.html' %}
 
 {% block content %}
     <h2><b>{{ name }}</b> status update on Penn Clubs</h2>
     <p style="font-size: 1.2em;">
-        Your club has been removed from {{ branding_site_name }} by the Office of Student Affairs.
+        Your club has been removed from Penn Clubs by the Office of Student Affairs.
     </p>
     <p style="font-size: 1.2em">
         If you have any questions or concerns, please contact 
-        <a href="mailto:{{ branding_site_email }},{{ osa_email }}">the Office of Student Affairs</a>.
+        <a href="mailto:{% for email in reply_emails %}{{ email }}{% if not forloop.last %},{% endif %}{% endfor %}">the Office of Student Affairs</a>.
     </p>
 {% endblock %}

--- a/backend/templates/emails/club_deletion.html
+++ b/backend/templates/emails/club_deletion.html
@@ -5,13 +5,18 @@ branding_site_name:
     type: string
 branding_site_email: 
     type: string
+osa_email:
+    type: string
 -->
 {% extends 'emails/base.html' %}
 
 {% block content %}
-    <h2><b>{{ name }}</b> has been marked as deleted on {{ branding_site_name }}</h2>
-    <p style="font-size: 1.2em; color: #8B2222">
-        <b>Oh no!</b> Your club has <b>been removed</b> from {{ branding_site_name }} by the <b>Office of Student Affairs</b>.
+    <h2><b>{{ name }}</b> status update on Penn Clubs</h2>
+    <p style="font-size: 1.2em;">
+        Your club has been removed from {{ branding_site_name }} by the Office of Student Affairs.
     </p>
-    <p style="font-size: 1.2em">If you believe this is an error, please contact <a href="mailto:{{ branding_site_email }}">{{ branding_site_email }}</a>.</p>
+    <p style="font-size: 1.2em">
+        If you have any questions or concerns, please contact 
+        <a href="mailto:{{ branding_site_email }},{{ osa_email }}">the Office of Student Affairs</a>.
+    </p>
 {% endblock %}


### PR DESCRIPTION
Modifies email templates to remove unnecessary language. Adds language telling clubs to contact OSA. Modifies sent message to direct replies to OSA. 

Screenshots below (left is before, right is after):

<img width="1440" alt="Screenshot 2024-10-11 at 7 52 08 PM" src="https://github.com/user-attachments/assets/bfb15bf2-b682-45b3-aab4-9216f9843840">
<img width="1440" alt="Screenshot 2024-10-11 at 7 52 11 PM" src="https://github.com/user-attachments/assets/31d30233-7252-4837-8ae1-87bb91e0e580">
<img width="1440" alt="Screenshot 2024-10-11 at 7 52 13 PM" src="https://github.com/user-attachments/assets/09e5262d-7491-44d8-b216-02eacd91f4c0">



