### PR TITLE
Admin note frontend

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -2974,8 +2974,7 @@ class ClubFairSerializer(serializers.ModelSerializer):
         )
 
 
-class AdminNoteSerializer(serializers.ModelSerializer):
-    club = serializers.SlugRelatedField(queryset=Club.objects.all(), slug_field="code")
+class AdminNoteSerializer(ClubRouteMixin, serializers.ModelSerializer):
     creator = serializers.SerializerMethodField("get_creator")
     title = serializers.CharField(max_length=255, default="Note")
     content = serializers.CharField(required=False)
@@ -2984,16 +2983,16 @@ class AdminNoteSerializer(serializers.ModelSerializer):
         return obj.creator.get_full_name()
 
     def create(self, validated_data):
-        return AdminNote.objects.create(
-            creator=self.context["request"].user,
-            club=validated_data["club"],
-            title=validated_data["title"],
-            content=validated_data["content"],
-        )
+        validated_data["creator"] = self.context["request"].user
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        validated_data.pop("creator", "")
+        return super().update(instance, validated_data)
 
     class Meta:
         model = AdminNote
-        fields = ("id", "creator", "club", "title", "content", "created_at")
+        fields = ("id", "creator", "title", "content", "created_at")
 
 
 class WritableClubFairSerializer(ClubFairSerializer):

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -7382,7 +7382,9 @@ class AdminNoteViewSet(viewsets.ModelViewSet):
     http_method_names = ["get", "post", "put", "patch", "delete"]
 
     def get_queryset(self):
-        return AdminNote.objects.filter(club__code=self.kwargs.get("club_code"))
+        return AdminNote.objects.filter(
+            club__code=self.kwargs.get("club_code")
+        ).order_by("-created_at")
 
 
 class ScriptExecutionView(APIView):

--- a/frontend/components/ClubEditPage.tsx
+++ b/frontend/components/ClubEditPage.tsx
@@ -42,6 +42,7 @@ import {
   SHOW_ORG_MANAGEMENT,
   SITE_NAME,
 } from '../utils/branding'
+import AdminNoteCard from './ClubEditPage/AdminNoteCard'
 import AdvisorCard from './ClubEditPage/AdvisorCard'
 import AnalyticsCard from './ClubEditPage/AnalyticsCard'
 import ApplicationsCard from './ClubEditPage/ApplicationsCard'
@@ -236,6 +237,11 @@ const ClubForm = ({
             onSubmit={submit}
           />
         ),
+      },
+      {
+        name: 'notes',
+        label: 'Administrator Notes',
+        content: <AdminNoteCard club={club} />,
       },
       {
         name: 'member',

--- a/frontend/components/ClubEditPage.tsx
+++ b/frontend/components/ClubEditPage.tsx
@@ -26,6 +26,7 @@ import {
   School,
   StudentType,
   Tag,
+  UserInfo,
   VisitType,
   Year,
 } from '../types'
@@ -75,6 +76,7 @@ type ClubFormProps = {
   tags: Tag[]
   studentTypes: StudentType[]
   tab?: string | null
+  userInfo?: UserInfo
 }
 
 const ClubForm = ({
@@ -86,6 +88,7 @@ const ClubForm = ({
   studentTypes,
   clubId,
   tab,
+  userInfo,
 }: ClubFormProps): ReactElement => {
   const [club, setClub] = useState<Club | null>(null)
   const [isEdit, setIsEdit] = useState<boolean>(typeof clubId !== 'undefined')
@@ -238,11 +241,15 @@ const ClubForm = ({
           />
         ),
       },
-      {
-        name: 'notes',
-        label: 'Administrator Notes',
-        content: <AdminNoteCard club={club} />,
-      },
+      ...(userInfo !== undefined && userInfo.is_superuser
+        ? [
+            {
+              name: 'notes',
+              label: 'Administrator Notes',
+              content: <AdminNoteCard club={club} />,
+            },
+          ]
+        : []),
       {
         name: 'member',
         label: OBJECT_TAB_MEMBERSHIP_LABEL,

--- a/frontend/components/ClubEditPage/AdminNoteCard.tsx
+++ b/frontend/components/ClubEditPage/AdminNoteCard.tsx
@@ -1,0 +1,48 @@
+import { Field } from 'formik'
+import moment from 'moment-timezone'
+import { ReactElement } from 'react'
+
+import { Club } from '../../types'
+import { TextField } from '../FormComponents'
+import { ModelForm } from '../ModelForm'
+import BaseCard from './BaseCard'
+
+type AdminNoteCardProps = {
+  club: Club
+}
+
+export default function AdminNoteCard({
+  club,
+}: AdminNoteCardProps): ReactElement {
+  const noteTableFields = [
+    { label: 'Author', name: 'creator' },
+    { label: 'Title', name: 'title' },
+    { label: 'Content', name: 'content' },
+    {
+      label: 'Created On',
+      name: 'created_at',
+      converter: (field) => moment(field).format('MMMM Do, YYYY'),
+    },
+  ]
+
+  return (
+    <BaseCard title="Notes">
+      <p className="mb-3">
+        Below is a list of notes about {club.name}. These notes are only visible
+        to site administrators.
+      </p>
+      <ModelForm
+        baseUrl={`/clubs/${club.code}/adminnotes/`}
+        fields={
+          <>
+            <Field name="title" as={TextField} required />
+            <Field name="content" as={TextField} type="textarea" />
+          </>
+        }
+        tableFields={noteTableFields}
+        searchableColumns={['title', 'content']}
+        noun="Note"
+      />
+    </BaseCard>
+  )
+}

--- a/frontend/components/ClubEditPage/AdminNoteCard.tsx
+++ b/frontend/components/ClubEditPage/AdminNoteCard.tsx
@@ -16,8 +16,7 @@ export default function AdminNoteCard({
 }: AdminNoteCardProps): ReactElement {
   const noteTableFields = [
     { label: 'Author', name: 'creator' },
-    { label: 'Title', name: 'title' },
-    { label: 'Content', name: 'content' },
+    { label: 'Note', name: 'content' },
     {
       label: 'Created On',
       name: 'created_at',
@@ -35,12 +34,11 @@ export default function AdminNoteCard({
         baseUrl={`/clubs/${club.code}/adminnotes/`}
         fields={
           <>
-            <Field name="title" as={TextField} required />
-            <Field name="content" as={TextField} type="textarea" />
+            <Field name="content" as={TextField} type="textarea" required />
           </>
         }
         tableFields={noteTableFields}
-        searchableColumns={['title', 'content']}
+        searchableColumns={['content']}
         noun="Note"
       />
     </BaseCard>


### PR DESCRIPTION
Adds a tab under the club management page for site admins to add notes about clubs as per OSA's request. Previously, site admins could only use interact with notes via the backend.

![image](https://github.com/user-attachments/assets/634649c0-135c-4101-a88e-ab64d593ca5b)
