### PR TITLE
Increase authed/non-authed clarity for mobile view, change wording on "Add Club" button

### DIFF
--- a/frontend/components/DisplayButtons.tsx
+++ b/frontend/components/DisplayButtons.tsx
@@ -74,10 +74,10 @@ const DisplayButtons = ({
       <Link href="/create" className="button is-small is-primary">
         <Icon
           name="plus"
-          alt={`create ${OBJECT_NAME_SINGULAR}`}
+          alt={`register ${OBJECT_NAME_SINGULAR}`}
           style={iconStylesDark}
         />
-        Add {OBJECT_NAME_TITLE_SINGULAR}
+        Register {OBJECT_NAME_TITLE_SINGULAR}
       </Link>
     )}
   </DisplayButtonsTag>

--- a/frontend/components/Header/Burger.tsx
+++ b/frontend/components/Header/Burger.tsx
@@ -4,6 +4,9 @@ const Burger = ({ toggle }: BurgerProps): ReactElement => (
   <a
     role="button"
     className="navbar-burger burger"
+    style={{
+      marginLeft: '8px',
+    }}
     aria-label="menu"
     aria-expanded="false"
     data-target="navbarBasicExample"

--- a/frontend/components/Header/Links.tsx
+++ b/frontend/components/Header/Links.tsx
@@ -55,6 +55,20 @@ const LoginButton = styled.a`
   }
 `
 
+export const MobileLoginButton = styled(LoginButton)`
+  display: none;
+  margin-right: 0;
+  ${mediaMaxWidth(MD)} {
+    display: inline-flex;
+  }
+`
+const DesktopLoginButton = styled(LoginButton)`
+  margin-left: 20px;
+  ${mediaMaxWidth(MD)} {
+    display: none;
+  }
+`
+
 const StyledLinkAnchor = styled.a`
   padding: ${LINK_MARGIN} 20px;
   color: ${BANNER_TEXT} !important;
@@ -116,13 +130,13 @@ const Links = ({ userInfo, authenticated, show }: Props): ReactElement => {
           FAQ
         </StyledLink>
         {authenticated === false && (
-          <LoginButton
+          <DesktopLoginButton
             className="button"
             href={`${LOGIN_URL}?next=${router.asPath}`}
             onClick={() => logEvent('login', 'click')}
           >
             Login
-          </LoginButton>
+          </DesktopLoginButton>
         )}
         {authenticated && userInfo && (
           <StyledLink href={SETTINGS_ROUTE}>

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -191,7 +191,7 @@ const Header = ({ authenticated, userInfo }: HeaderProps): ReactElement => {
           </Link>
           {authenticated === false && (
             <MobileLoginButton
-              className="button is-mobile"
+              className="button"
               href={`${LOGIN_URL}?next=${router.asPath}`}
               onClick={() => logEvent('login', 'click')}
             >

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { ReactElement, useEffect, useState } from 'react'
 import styled from 'styled-components'
+
+import { LOGIN_URL } from '~/utils'
+import { logEvent } from '~/utils/analytics'
 
 import { BANNER_BG, BANNER_TEXT, BORDER } from '../../constants/colors'
 import {
@@ -31,7 +35,7 @@ import {
 import Burger from './Burger'
 import Feedback from './Feedback'
 import Heading from './Head'
-import Links from './Links'
+import Links, { MobileLoginButton } from './Links'
 
 const Nav = styled.nav`
   height: ${NAV_HEIGHT};
@@ -164,6 +168,7 @@ const isHub = SITE_ID === 'fyh'
 
 const Header = ({ authenticated, userInfo }: HeaderProps): ReactElement => {
   const [show, setShow] = useState(false)
+  const router = useRouter()
 
   const toggle = () => setShow(!show)
 
@@ -184,6 +189,15 @@ const Header = ({ authenticated, userInfo }: HeaderProps): ReactElement => {
               <Title>{SITE_NAME}</Title>
             </LogoItem>
           </Link>
+          {authenticated === false && (
+            <MobileLoginButton
+              className="button is-mobile"
+              href={`${LOGIN_URL}?next=${router.asPath}`}
+              onClick={() => logEvent('login', 'click')}
+            >
+              Login
+            </MobileLoginButton>
+          )}
           <Burger toggle={toggle} />
         </div>
         <Links userInfo={userInfo} authenticated={authenticated} show={show} />


### PR DESCRIPTION
This PR does a couple things to make the user flow a little clearer:

1. Shows the login button on the navbar for mobile users versus hidden in the menu, making it more obvious when users aren't signed in (we have received support requests where users were simply not signed in on mobile but were unaware)
2. Rename the "Add Club" button to "Register Club" to make its purpose more specific and signals the fact that Penn Clubs is the official OSA-sponsored platform for new clubs to register on
3. Makes the login button equally spaced with the other links in desktop view (this one is gratuitous)

Before/After (Desktop)

![desktop screenshot before changes](https://github.com/user-attachments/assets/56a994cb-4468-4624-a5e2-07943d52c086)

![desktop screenshot after changes](https://github.com/user-attachments/assets/1b3f97c2-a97a-4044-905e-3c67dcdd67c2)

Before/After (Mobile)

![mobile screenshot before changes](https://github.com/user-attachments/assets/032d2201-aa73-4508-bd32-548125d272e7)

![mobile screenshot after changes](https://github.com/user-attachments/assets/544dee8c-793d-4a68-acb7-14bed2fb7a00)
