### PR TITLE
Set `ghost` to false on club approval decision

### DIFF
--- a/frontend/components/ClubPage/ClubApprovalDialog.tsx
+++ b/frontend/components/ClubPage/ClubApprovalDialog.tsx
@@ -265,6 +265,7 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement | null => {
                           body: {
                             approved: true,
                             approved_comment: comment,
+                            ghost: false,
                           },
                         })
                           .then(() => router.reload())
@@ -283,6 +284,7 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement | null => {
                           body: {
                             approved: false,
                             approved_comment: comment,
+                            ghost: false,
                           },
                         })
                           .then(() => router.reload())


### PR DESCRIPTION
Currently, approval decisions patch the `approved` and `approved_by` fields, but the `ghost` field remains unchanged. This causes the "changes to this club are pending approval" modal to show up for clubs that have been approved. 