### PR TITLE
Restrict event creation to approved clubs

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3120,6 +3120,14 @@ class ClubEventViewSet(viewsets.ModelViewSet):
 
         ---
         """
+        # only approved clubs can create events
+        club = Club.objects.get(code=kwargs["club_code"])
+        if not club.approved:
+            return Response(
+                {"detail": "Only approved clubs can create events"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         # get event type
         type = request.data.get("type", 0)
         if type == Event.FAIR and not self.request.user.is_superuser:

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -766,6 +766,33 @@ class ClubTestCase(TestCase):
         )
         self.assertIn(resp.status_code, [200, 204], resp.content)
 
+    def test_event_create_unapproved_club(self):
+        self.club1.approved = False
+        self.club1.save()
+
+        start_date = datetime.datetime.now() - datetime.timedelta(days=3)
+        end_date = start_date + datetime.timedelta(hours=2)
+
+        # add user as officer
+        Membership.objects.create(
+            person=self.user1, club=self.club1, role=Membership.ROLE_OFFICER
+        )
+
+        self.client.login(username=self.user1.username, password="test")
+        resp = self.client.post(
+            reverse("club-events-list", args=(self.club1.code,)),
+            {
+                "name": "Interest Meeting",
+                "description": "Interest Meeting on Friday!",
+                "location": "JMHH G06",
+                "type": Event.RECRUITMENT,
+                "start_time": start_date.isoformat(),
+                "end_time": end_date.isoformat(),
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+
     def test_recurring_event_create(self):
         self.client.login(username=self.user4.username, password="test")
         self.assertFalse(self.user4.is_superuser)


### PR DESCRIPTION
Prevents clubs that aren't approved from creating events. This shouldn't change any existing behavior: events by non-approved clubs currently 404. (Should also resolve OSA's concerns about only approved clubs being able to use ticketing.)