### PR TITLE
Add support for (ticket) email blasts

### DIFF
--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -225,7 +225,12 @@ class EventPermission(permissions.BasePermission):
 
             if not old_type == FAIR_TYPE and new_type == FAIR_TYPE:
                 return False
-        elif view.action in ["buyers", "create_tickets", "issue_tickets"]:
+        elif view.action in [
+            "buyers",
+            "create_tickets",
+            "issue_tickets",
+            "email_blast",
+        ]:
             if not request.user.is_authenticated:
                 return False
             membership = find_membership_helper(request.user, obj.club)

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3067,6 +3067,17 @@ class ClubEventViewSet(viewsets.ModelViewSet):
                                     type: string
                                     description: A message indicating how many
                                         recipients received the blast
+            "400":
+                description: Content field was empty or missing
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+                                    description: Error message indicating content
+                                        was not provided
             "404":
                 description: Event not found
                 content:
@@ -3087,6 +3098,13 @@ class ClubEventViewSet(viewsets.ModelViewSet):
         ).values_list("owner__email", flat=True)
         officer_emails = event.club.get_officer_emails()
         emails = list(holder_emails) + list(officer_emails)
+
+        content = request.data.get("content").strip()
+        if not content:
+            return Response(
+                {"detail": "Content must be specified"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         send_mail_helper(
             name="blast",

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3099,7 +3099,7 @@ class ClubEventViewSet(viewsets.ModelViewSet):
         officer_emails = event.club.get_officer_emails()
         emails = list(holder_emails) + list(officer_emails)
 
-        content = request.data.get("content").strip()
+        content = request.data.get("content", "").strip()
         if not content:
             return Response(
                 {"detail": "Content must be specified"},

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3040,6 +3040,75 @@ class ClubEventViewSet(viewsets.ModelViewSet):
         )
 
     @action(detail=True, methods=["post"])
+    def email_blast(self, request, *args, **kwargs):
+        """
+        Send an email blast to all users holding tickets.
+        ---
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        properties:
+                            content:
+                                type: string
+                                description: The content of the email blast to send
+                        required:
+                            - content
+        responses:
+            "200":
+                description: Email blast was sent successfully
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+                                    description: A message indicating how many
+                                        recipients received the blast
+            "404":
+                description: Event not found
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+                                    description: Error message indicating event was
+                                        not found
+        ---
+        """
+        event = self.get_object()
+
+        holder_emails = Ticket.objects.filter(
+            event=event, owner__isnull=False
+        ).values_list("owner__email", flat=True)
+        officer_emails = event.club.get_officer_emails()
+        emails = list(holder_emails) + list(officer_emails)
+
+        send_mail_helper(
+            name="blast",
+            subject=f"Update on {event.name} from {event.club.name}",
+            emails=emails,
+            context={
+                "sender": event.club.name,
+                "content": request.data.get("content"),
+                "reply_emails": event.club.get_officer_emails(),
+            },
+        )
+
+        return Response(
+            {
+                "detail": (
+                    f"Blast sent to {len(holder_emails)} ticket holders "
+                    f"and {len(officer_emails)} officers"
+                )
+            }
+        )
+
+    @action(detail=True, methods=["post"])
     def upload(self, request, *args, **kwargs):
         """
         Upload a picture for the event.

--- a/backend/templates/emails/blast.html
+++ b/backend/templates/emails/blast.html
@@ -1,0 +1,25 @@
+<!-- TYPES:
+sender:
+    type: string
+content:
+    type: string
+reply_emails:
+    type: array
+    items:
+        type: string
+-->
+{% extends 'emails/base.html' %}
+
+{% block content %}
+    <h2>Message from {{ sender }}</h2>
+    
+    <p style="font-size: 1.2em">
+        The following message was sent by <b>{{ sender }}</b>:
+    </p>
+
+    <p style="font-size: 1.2em; padding: 8px; border-left: 5px solid #ccc; white-space: pre-wrap;">{{ content }}</p>
+
+    <p style="font-size: 1.2em">
+        If you have any questions, please respond to this email or <a href="mailto:{% for email in reply_emails %}{% if not forloop.first %},{% endif %}{{ email }}{% endfor %}">contact the sender</a>.
+    </p>
+{% endblock %}

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -428,6 +428,15 @@ class TicketEventTestCase(TestCase):
         )
         self.assertIn("Test email blast content", email.body)
 
+    def test_email_blast_empty_content(self):
+        self.client.login(username=self.user1.username, password="test")
+        resp = self.client.post(
+            reverse("club-events-email-blast", args=(self.club1.code, self.event1.pk)),
+            {"content": ""},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
     def test_get_tickets_information_no_tickets(self):
         # Delete all the tickets
         Ticket.objects.all().delete()


### PR DESCRIPTION
Adds support for email blasts from event owners to ticket holders. I'm envisioning using this for an admin feature as well (ex: OSA wants to send a message to all club leaders, like they did at the start of this semester). 

Here's what an event-related email might look like:
<img width="776" alt="Screenshot 2024-11-23 at 12 42 07 AM" src="https://github.com/user-attachments/assets/10b7bf99-0022-42cd-aac3-83e16e54c80b">
