### PR TITLE
Ticket drop time UI support, unapproved club event visibility changes

### DIFF
--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -355,6 +355,7 @@ class Club(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    # signifies the existence of a previous instance within history with approved=True
     ghost = models.BooleanField(default=False)
     history = HistoricalRecords(cascade_delete_history=True)
 

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -457,9 +457,17 @@ class ClubEventSerializer(serializers.ModelSerializer):
         end_time = data.get(
             "end_time", self.instance.end_time if self.instance is not None else None
         )
+        ticket_drop_time = data.get(
+            "ticket_drop_time",
+            self.instance.ticket_drop_time if self.instance is not None else None,
+        )
         if start_time is not None and end_time is not None and start_time > end_time:
             raise serializers.ValidationError(
                 "Your event start time must be less than the end time!"
+            )
+        if ticket_drop_time is not None and ticket_drop_time > end_time:
+            raise serializers.ValidationError(
+                "Your ticket drop time must be before the event ends!"
             )
         return data
 
@@ -507,6 +515,7 @@ class ClubEventSerializer(serializers.ModelSerializer):
             "location",
             "name",
             "start_time",
+            "ticket_drop_time",
             "ticketed",
             "type",
             "url",

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -465,7 +465,7 @@ class ClubEventSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "Your event start time must be less than the end time!"
             )
-        if ticket_drop_time is not None and ticket_drop_time > end_time:
+        if ticket_drop_time is not None and ticket_drop_time >= end_time:
             raise serializers.ValidationError(
                 "Your ticket drop time must be before the event ends!"
             )

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3216,7 +3216,10 @@ class ClubEventViewSet(viewsets.ModelViewSet):
         event = self.get_object()
         if (
             "ticket_drop_time" in request.data
-            and parse(request.data["ticket_drop_time"]) >= timezone.now()
+            and (
+                event.ticket_drop_time is None  # case where sales immediately start
+                or event.ticket_drop_time <= timezone.now()
+            )
             and Ticket.objects.filter(event=event, owner__isnull=False).exists()
         ):
             raise DRFValidationError(

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -3211,11 +3211,12 @@ class ClubEventViewSet(viewsets.ModelViewSet):
     def partial_update(self, request, *args, **kwargs):
         """
         Do not let club admins modify the ticket drop time
-        if tickets have already been sold.
+        if tickets have potentially been sold through the checkout process.
         """
         event = self.get_object()
         if (
             "ticket_drop_time" in request.data
+            and parse(request.data["ticket_drop_time"]) >= timezone.now()
             and Ticket.objects.filter(event=event, owner__isnull=False).exists()
         ):
             raise DRFValidationError(

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2788,7 +2788,7 @@ class ClubEventViewSet(viewsets.ModelViewSet):
         event = self.get_object()
 
         # Tickets can't be edited after they've dropped
-        if event.ticket_drop_time and timezone.now() > event.ticket_drop_time:
+        if event.ticket_drop_time and timezone.now() >= event.ticket_drop_time:
             return Response(
                 {"detail": "Tickets cannot be edited after they have dropped"},
                 status=status.HTTP_403_FORBIDDEN,
@@ -5297,7 +5297,7 @@ class TicketViewSet(viewsets.ModelViewSet):
                 continue
 
             available_tickets = Ticket.objects.filter(
-                Q(event__ticket_drop_time__lt=timezone.now())
+                Q(event__ticket_drop_time__lte=timezone.now())
                 | Q(event__ticket_drop_time__isnull=True),
                 event=ticket_class["event"],
                 type=ticket_class["type"],
@@ -5393,7 +5393,7 @@ class TicketViewSet(viewsets.ModelViewSet):
         # are locked, we shouldn't block.
         tickets = cart.tickets.select_for_update(skip_locked=True).filter(
             Q(holder__isnull=True) | Q(holder=self.request.user),
-            Q(event__ticket_drop_time__lt=timezone.now())
+            Q(event__ticket_drop_time__lte=timezone.now())
             | Q(event__ticket_drop_time__isnull=True),
             event__club__archived=False,
             owner__isnull=True,

--- a/backend/tests/clubs/test_ticketing.py
+++ b/backend/tests/clubs/test_ticketing.py
@@ -430,21 +430,6 @@ class TicketEventTestCase(TestCase):
             data["available"],
         )
 
-    def test_get_tickets_before_drop_time(self):
-        self.event1.ticket_drop_time = timezone.now() + timedelta(days=1)
-        self.event1.save()
-
-        self.client.login(username=self.user1.username, password="test")
-        resp = self.client.get(
-            reverse("club-events-tickets", args=(self.club1.code, self.event1.pk)),
-        )
-        self.assertEqual(resp.status_code, 200, resp.content)
-        data = resp.json()
-
-        # Tickets shouldn't be available before the drop time
-        self.assertEqual(data["totals"], [])
-        self.assertEqual(data["available"], [])
-
     def test_get_tickets_buyers(self):
         self.client.login(username=self.user1.username, password="test")
 

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -227,6 +227,14 @@ class ClubTestCase(TestCase):
             visibility=Advisor.ADVISOR_VISIBILITY_ALL,
         )
 
+    def test_directory(self):
+        """
+        Test retrieving the club directory.
+        """
+        resp = self.client.get(reverse("clubs-directory"))
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+        self.assertEqual(len(resp.data), 1)
+
     def test_advisor_visibility(self):
         """
         Tests each tier of advisor visibility.

--- a/frontend/components/ClubEditPage/EventsCard.tsx
+++ b/frontend/components/ClubEditPage/EventsCard.tsx
@@ -1,17 +1,19 @@
 import { Field } from 'formik'
 import moment from 'moment'
-import React, { ReactElement, useRef, useState } from 'react'
+import React, {
+  forwardRef,
+  ReactElement,
+  RefObject,
+  useRef,
+  useState,
+} from 'react'
 import TimeAgo from 'react-timeago'
 import styled from 'styled-components'
 
 import { LIGHT_GRAY } from '../../constants'
 import { Club, ClubEvent, ClubEventType } from '../../types'
 import { stripTags } from '../../utils'
-import {
-  FAIR_NAME,
-  OBJECT_EVENT_TYPES,
-  OBJECT_NAME_SINGULAR,
-} from '../../utils/branding'
+import { FAIR_NAME, OBJECT_EVENT_TYPES } from '../../utils/branding'
 import { Device, Icon, Line, Modal, Text } from '../common'
 import EventModal from '../EventPage/EventModal'
 import {
@@ -311,51 +313,6 @@ const eventTableFields = [
   },
 ]
 
-const eventFields = (
-  <>
-    <Field
-      name="name"
-      as={TextField}
-      required
-      helpText="Provide a descriptive name for the planned event."
-    />
-    <Field
-      name="url"
-      as={TextField}
-      type="url"
-      helpText="Provide a videoconference link to join the event (Zoom, Google Meet, etc)."
-      label="Meeting Link"
-    />
-    <Field name="image" as={FileField} isImage />
-    <Field
-      name="type"
-      as={SelectField}
-      required
-      choices={EVENT_TYPES}
-      serialize={({ value }) => value}
-      isMulti={false}
-      valueDeserialize={(val) => EVENT_TYPES.find((x) => x.value === val)}
-    />
-    <Field
-      name="start_time"
-      required
-      placeholder="Provide a start time for the event"
-      as={DateTimeField}
-    />
-    <Field
-      name="end_time"
-      required
-      placeholder="Provide a end time for the event"
-      as={DateTimeField}
-    />
-    <Field
-      name="description"
-      placeholder="Type your event description here!"
-      as={RichTextField}
-    />
-  </>
-)
-
 const EventPreviewContainer = styled.div`
   display: flex;
   justify-content: space-around;
@@ -401,50 +358,122 @@ const CreateContainer = styled.div`
   align-items: center;
 `
 
-const CreateTickets = ({ event, club }: { event: ClubEvent; club: Club }) => {
-  const [show, setShow] = useState(false)
-  const showModal = () => setShow(true)
-  const hideModal = () => setShow(false)
-
-  return (
-    <CreateContainer>
-      <div className="is-pulled-left">
-        <Text style={{ padding: 0, margin: 0 }}>
-          {event.ticketed ? 'Add' : 'Create'} ticket offerings for this event
-        </Text>
-      </div>
-      <div className="is-pulled-right">
-        <button
-          onClick={() => {
-            showModal()
-          }}
-          disabled={!event.name}
-          className="button is-primary"
-        >
-          Create
-        </button>
-      </div>
-      {show && (
-        <Modal
-          width="50vw"
-          show={show}
-          closeModal={hideModal}
-          marginBottom={false}
-        >
-          <TicketsModal
-            club={club}
-            event={event}
-            onSuccessfulSubmit={hideModal}
-          />
-        </Modal>
-      )}
-    </CreateContainer>
-  )
+interface CreateTicketsProps {
+  event: ClubEvent
+  club: Club
 }
+
+const CreateTickets = forwardRef<HTMLDivElement, CreateTicketsProps>(
+  ({ event, club }, ticketDroptimeRef) => {
+    const [show, setShow] = useState(false)
+
+    const showModal = () => setShow(true)
+    const hideModal = () => setShow(false)
+
+    return (
+      <CreateContainer>
+        <div className="is-pulled-left">
+          <Text style={{ padding: 0, margin: 0 }}>
+            {event.ticketed ? 'Add' : 'Create'} ticket offerings for this event
+          </Text>
+        </div>
+        <div className="is-pulled-right">
+          <button
+            onClick={showModal}
+            disabled={!event.name}
+            className="button is-primary"
+          >
+            Create
+          </button>
+        </div>
+        {show && (
+          <Modal
+            width="50vw"
+            show={show}
+            closeModal={hideModal}
+            marginBottom={false}
+          >
+            <TicketsModal
+              club={club}
+              event={event}
+              onSuccessfulSubmit={hideModal}
+              closeModal={() => {
+                hideModal()
+                if (ticketDroptimeRef && 'current' in ticketDroptimeRef) {
+                  const divRef = ticketDroptimeRef as RefObject<HTMLDivElement>
+                  ticketDroptimeRef.current?.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                  })
+                  divRef.current?.querySelector('input')?.focus()
+                }
+              }}
+            />
+          </Modal>
+        )}
+      </CreateContainer>
+    )
+  },
+)
 
 export default function EventsCard({ club }: EventsCardProps): ReactElement {
   const [deviceContents, setDeviceContents] = useState<any>({})
   const eventDetailsRef = useRef<HTMLDivElement>(null)
+  const ticketDroptimeRef = useRef<HTMLDivElement>(null)
+
+  const eventFields = (
+    <>
+      <Field
+        name="name"
+        as={TextField}
+        required
+        helpText="Provide a descriptive name for the planned event."
+      />
+      <Field
+        name="url"
+        as={TextField}
+        type="url"
+        helpText="Provide a videoconference link to join the event (Zoom, Google Meet, etc)."
+        label="Meeting Link"
+      />
+      <Field name="image" as={FileField} isImage />
+      <Field
+        name="type"
+        as={SelectField}
+        required
+        choices={EVENT_TYPES}
+        serialize={({ value }) => value}
+        isMulti={false}
+        valueDeserialize={(val) => EVENT_TYPES.find((x) => x.value === val)}
+      />
+      <Field
+        name="start_time"
+        required
+        placeholder="Provide a start time for the event"
+        as={DateTimeField}
+      />
+      <Field
+        name="end_time"
+        required
+        placeholder="Provide a end time for the event"
+        as={DateTimeField}
+      />
+      <div ref={ticketDroptimeRef} className="mb-3">
+        {/* TODO: modify field components to support ref props after forwardRef() is depreciated in React 19 */}
+        <Field
+          name="ticket_drop_time"
+          id="ticket_drop_time"
+          placeholder="Provide a time when event tickets will first be available (not changeable after first ticket sold)"
+          as={DateTimeField}
+        />
+      </div>
+      <Field
+        name="description"
+        placeholder="Type your event description here!"
+        as={RichTextField}
+      />
+    </>
+  )
 
   const event = {
     ...deviceContents,
@@ -458,8 +487,9 @@ export default function EventsCard({ club }: EventsCardProps): ReactElement {
   return (
     <BaseCard title="Events">
       <Text>
-        Manage events for this {OBJECT_NAME_SINGULAR}. Events that have already
-        passed are hidden by default.
+        {club.approved || club.is_ghost
+          ? 'Manage events for this club. Events that have already passed are hidden by default.'
+          : 'Note: you must be an approved club to create publicly-viewable events.'}
       </Text>
       <ModelForm
         baseUrl={`/clubs/${club.code}/events/`}
@@ -480,7 +510,7 @@ export default function EventsCard({ club }: EventsCardProps): ReactElement {
         }}
       />
       <Line />
-      <CreateTickets event={event} club={club} />
+      <CreateTickets event={event} club={club} ref={ticketDroptimeRef} />
       <Line />
       <div ref={eventDetailsRef}>
         <EventPreview event={event} />

--- a/frontend/components/ClubEditPage/EventsCard.tsx
+++ b/frontend/components/ClubEditPage/EventsCard.tsx
@@ -1,12 +1,7 @@
 import { Field } from 'formik'
 import moment from 'moment'
-import React, {
-  forwardRef,
-  ReactElement,
-  RefObject,
-  useRef,
-  useState,
-} from 'react'
+import Link from 'next/link'
+import { forwardRef, ReactElement, RefObject, useRef, useState } from 'react'
 import TimeAgo from 'react-timeago'
 import styled from 'styled-components'
 
@@ -492,6 +487,13 @@ export default function EventsCard({ club }: EventsCardProps): ReactElement {
           : 'Note: you must be an approved club to create publicly-viewable events.'}
       </Text>
       <ModelForm
+        actions={(object) => (
+          <Link legacyBehavior href={{ pathname: `/events/${object.id}` }}>
+            <button className="button is-info is-small">
+              <Icon name="eye" /> Page
+            </button>
+          </Link>
+        )}
         baseUrl={`/clubs/${club.code}/events/`}
         listParams={`&end_time__gte=${new Date().toISOString()}`}
         fields={eventFields}

--- a/frontend/components/ClubEditPage/QuestionsCard.tsx
+++ b/frontend/components/ClubEditPage/QuestionsCard.tsx
@@ -20,7 +20,7 @@ export default function QuestionsCard({
       <p className="mb-3">
         You can see a list of questions that prospective {OBJECT_NAME_SINGULAR}{' '}
         members have asked below. Answering any of these questions will make
-        them publically available and show your name as the person who answered
+        them publicly available and show your name as the person who answered
         the question.
       </p>
       <ModelForm

--- a/frontend/components/ClubEditPage/TicketsModal.tsx
+++ b/frontend/components/ClubEditPage/TicketsModal.tsx
@@ -362,15 +362,14 @@ const TicketsModal = ({
             <p className="help">
               You can optionally add a time in which after when tickets will be
               available{' '}
-              <label
-                htmlFor="ticket_drop_time"
+              <a
                 onClick={(e) => {
                   setSubmitting(false)
                   closeModal()
                 }}
               >
                 within the event's edit page
-              </label>
+              </a>
               . Please note that this cannot be changed once any tickets are
               sold.
             </p>

--- a/frontend/components/ClubEditPage/TicketsModal.tsx
+++ b/frontend/components/ClubEditPage/TicketsModal.tsx
@@ -224,10 +224,12 @@ type Ticket = {
 const TicketsModal = ({
   event,
   club,
+  closeModal,
   onSuccessfulSubmit,
 }: {
   event: ClubEvent
   club: Club
+  closeModal: () => void
   onSuccessfulSubmit: () => void
 }): ReactElement => {
   const { large_image_url, image_url, club_name, name, id } = event
@@ -325,7 +327,7 @@ const TicketsModal = ({
       <ModalBody>
         <Title>{name}</Title>
         <Text>
-          Create new tickets for this event. For our alpha, only free tickets
+          Create new tickets for this event. For our beta, only free tickets
           will be supported for now: stay tuned for payments integration!
         </Text>
         <Line />
@@ -355,6 +357,25 @@ const TicketsModal = ({
             New Ticket Class
           </button>
         </SectionContainer>
+        {!event.ticket_drop_time && (
+          <SectionContainer>
+            <p className="help">
+              You can optionally add a time in which after when tickets will be
+              available{' '}
+              <label
+                htmlFor="ticket_drop_time"
+                onClick={(e) => {
+                  setSubmitting(false)
+                  closeModal()
+                }}
+              >
+                within the event's edit page
+              </label>
+              . Please note that this cannot be changed once any tickets are
+              sold.
+            </p>
+          </SectionContainer>
+        )}
         <div>
           {submitting ? (
             <>

--- a/frontend/components/ClubPage/QuestionList.tsx
+++ b/frontend/components/ClubPage/QuestionList.tsx
@@ -94,8 +94,8 @@ const QuestionList = ({
         <div className="notification is-primary">
           <b>Your question has been submitted!</b>
           <p>
-            It will be posted publically once it has been approved and answered
-            by {OBJECT_NAME_SINGULAR} members.
+            It will be posted publicly once it has been approved and answered by{' '}
+            {OBJECT_NAME_SINGULAR} members.
           </p>
           <p className="mb-3">Thank you for contributing to {SITE_NAME}!</p>
           <button

--- a/frontend/components/EmbedOption.tsx
+++ b/frontend/components/EmbedOption.tsx
@@ -202,11 +202,11 @@ const EmbedOption = (props: Props): ReactElement => {
                 Google Drive PDF Files
                 <br />
                 <small>
-                  You can upload a PDF file on Google Drive, share it
-                  publically, and then go to right click &gt; Preview &gt; More
-                  actions (three dots) &gt; Open in a new window. After that,
-                  you can click on More actions (three dots) &gt; Embed item.
-                  Example link format:
+                  You can upload a PDF file on Google Drive, share it and then
+                  go to right click &gt; Preview &gt; More actions actions
+                  (three dots) &gt; Open in a new window. After that, you can
+                  click on More actions (three dots) &gt; Embed item. Example
+                  link format:
                   https://drive.google.com/file/d/1hfN3dWDIE4cTApJ-XPgLx_3eIta_IihV/preview
                 </small>
               </li>

--- a/frontend/components/EventPage/EventCard.tsx
+++ b/frontend/components/EventPage/EventCard.tsx
@@ -40,7 +40,7 @@ const TicketsPill = styled.div`
 const clipLink = (s: string) => (s.length > 32 ? `${s.slice(0, 35)}...` : s)
 
 const EventCard = (props: {
-  event: ClubEvent & { clubPublic: boolean }
+  event: ClubEvent & { clubPublic?: boolean }
 }): ReactElement => {
   const {
     image_url: imageUrl,
@@ -80,7 +80,7 @@ const EventCard = (props: {
       )}
       <ClubName>{clubName}</ClubName>
       <EventName>{name}</EventName>
-      {!clubPublic && <p>This event is not shown to the public.</p>}
+      {clubPublic === false && <p>This event is not shown to the public.</p>}
       {ticketed && (
         <TicketsPill
           style={{

--- a/frontend/components/EventPage/EventCard.tsx
+++ b/frontend/components/EventPage/EventCard.tsx
@@ -39,10 +39,13 @@ const TicketsPill = styled.div`
 
 const clipLink = (s: string) => (s.length > 32 ? `${s.slice(0, 35)}...` : s)
 
-const EventCard = (props: { event: ClubEvent }): ReactElement => {
+const EventCard = (props: {
+  event: ClubEvent & { clubPublic: boolean }
+}): ReactElement => {
   const {
     image_url: imageUrl,
     club_name: clubName,
+    clubPublic,
     start_time,
     end_time,
     name,
@@ -77,6 +80,7 @@ const EventCard = (props: { event: ClubEvent }): ReactElement => {
       )}
       <ClubName>{clubName}</ClubName>
       <EventName>{name}</EventName>
+      {!clubPublic && <p>This event is not shown to the public.</p>}
       {ticketed && (
         <TicketsPill
           style={{

--- a/frontend/pages/events/[id].tsx
+++ b/frontend/pages/events/[id].tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { BaseLayout } from '~/components/BaseLayout'
 import {
+  Icon,
   Metadata,
   Modal,
   StrongText,
@@ -32,6 +33,7 @@ import {
 } from '~/constants'
 import { Club, ClubEvent, TicketAvailability } from '~/types'
 import { doApiRequest, EMPTY_DESCRIPTION } from '~/utils'
+import { APPROVAL_AUTHORITY } from '~/utils/branding'
 import { createBasePropFetcher } from '~/utils/getBaseProps'
 
 Settings.defaultZone = 'America/New_York'
@@ -195,6 +197,7 @@ const GetTicketItem: React.FC<TicketItemProps> = ({
         borderBottom: '1px solid #e0e0e0',
         borderTop: '1px solid #e0e0e0',
       }}
+      id={ticket.type}
     >
       <div
         style={{
@@ -332,6 +335,14 @@ const EventPage: React.FC<EventPageProps> = ({
       <BaseLayout {...baseProps}>
         <Metadata title="Events" />
         <MainWrapper>
+          {!club.active && !club.is_ghost && (
+            <div className="notification is-info is-light">
+              <Icon name="alert-circle" style={{ marginTop: '-3px' }} />
+              This event is hosted by a club that has not been approved by the{' '}
+              {APPROVAL_AUTHORITY} and is therefore not visible to the public
+              yet.
+            </div>
+          )}
           <GridWrapper>
             <div>
               <Title>{event.name}</Title>

--- a/frontend/pages/events/[id].tsx
+++ b/frontend/pages/events/[id].tsx
@@ -269,6 +269,8 @@ const EventPage: React.FC<EventPageProps> = ({
     event.ticket_drop_time !== null &&
     new Date(event.ticket_drop_time) > new Date()
 
+  const historicallyApproved = club.approved !== true && !club.is_ghost
+
   return (
     <>
       <Modal
@@ -390,17 +392,20 @@ const EventPage: React.FC<EventPageProps> = ({
                     disabled={
                       totalAvailableTickets === 0 ||
                       endTime < DateTime.now() ||
-                      notDroppedYet
+                      notDroppedYet ||
+                      historicallyApproved
                     }
                     onClick={() => setShowTicketModal(true)}
                   >
-                    {endTime < DateTime.now()
-                      ? 'Event Ended'
-                      : notDroppedYet
-                        ? 'Tickets Not Available Yet'
-                        : totalAvailableTickets === 0
-                          ? 'Sold Out'
-                          : 'Get Tickets'}
+                    {historicallyApproved
+                      ? 'Club Not Approved'
+                      : endTime < DateTime.now()
+                        ? 'Event Ended'
+                        : notDroppedYet
+                          ? 'Tickets Not Available Yet'
+                          : totalAvailableTickets === 0
+                            ? 'Sold Out'
+                            : 'Get Tickets'}
                   </button>
                 </Card>
               )}

--- a/frontend/pages/events/index.tsx
+++ b/frontend/pages/events/index.tsx
@@ -47,7 +47,8 @@ export const getServerSideProps = (async (ctx) => {
   const clubMap = new Map(clubs.map((club) => [club.code, club]))
   const eventsWithClubs = events.map((event) => ({
     ...event,
-    club: event.club ? clubMap.get(event.club) : null,
+    club: event.club ? clubMap.get(event.club) ?? null : null,
+    clubPublic: event.club == null || clubMap.get(event.club) !== undefined,
   }))
   return {
     props: {

--- a/frontend/pages/events/index.tsx
+++ b/frontend/pages/events/index.tsx
@@ -37,9 +37,9 @@ export const getServerSideProps = (async (ctx) => {
   // TODO: Add caching
   const [baseProps, clubs, events] = await Promise.all([
     getBaseProps(ctx),
-    doApiRequest('/clubs/directory/?format=json', data)
-      .then((resp) => resp.json() as Promise<Club[]>)
-      .then((resp) => resp.filter(({ approved }) => approved)),
+    doApiRequest('/clubs/directory/?format=json', data).then(
+      (resp) => resp.json() as Promise<Club[]>,
+    ),
     doApiRequest(`/events/?${params.toString()}`, data).then(
       (resp) => resp.json() as Promise<ClubEvent[]>,
     ),

--- a/frontend/pages/tickets/[[...slug]].tsx
+++ b/frontend/pages/tickets/[[...slug]].tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react'
 import { Center, Container, Icon, Metadata } from 'components/common'
 import { Form, Formik } from 'formik'
+import moment from 'moment-timezone'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import Link from 'next/link'
 import React, { ReactElement, useState } from 'react'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
@@ -160,6 +162,18 @@ const Ticket: React.FC<TicketProps> = ({
           <BetaTag>
             <Title>All Tickets for {event.name}</Title>
           </BetaTag>
+          {event.ticket_drop_time &&
+            new Date(event.ticket_drop_time) > new Date() && (
+              <Text>
+                Tickets have not dropped yet. Visit the{' '}
+                <Link href={`/club/${event.club}/edit/events`}>event page</Link>{' '}
+                to change the current drop time of{' '}
+                {moment(event.ticket_drop_time)
+                  .tz('America/New_York')
+                  .format('MMMM Do YYYY')}
+                .
+              </Text>
+            )}
           {Object.values(tickTypes).map((ticket, i) => (
             <TicketCard
               key={i}

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -62,6 +62,7 @@ export interface ClubEvent {
   location: string | null
   name: string
   ticketed: boolean
+  ticket_drop_time: string | null
   pinned: boolean
   start_time: string
   type: ClubEventType

--- a/frontend/utils.tsx
+++ b/frontend/utils.tsx
@@ -24,7 +24,7 @@ const internalCache = new LRUCache({ max: 500 })
 
 /**
  * Cache the return value of a function.
- * This should only be used with publically available information.
+ * This should only be used with publicly available information.
  * The time should be specified in milliseconds.
  */
 export async function cache<T>(


### PR DESCRIPTION
* Add UI support for ticket drop times
* Add `ticket_drop_time` validation in event serializer based on event end time
* Prevent retroactive editing of ticket drop time after tickets have been sold (plus handling of edge case where ticket has been added to cart but not bought before ticket drop time is pushed back)
* Prevent unapproved clubs from selling tickets (add_to_cart)
* Prevent clubs which have been archived from selling existing tickets
* Allow leaders of unapproved clubs to create and view events (with the warning that such events are not visible to the public until the club is approved), allowing for "draft" functionality (also currently, the event just disappears after submission on the frontend for unapproved clubs...)
* Standardize spelling of "publicly" in the codebase (alternative being "publically")
* Add button to view public event page within event editing page
* Show all clubs in `/directory` which have been approved at some point

![Event page with unreleased tickets](https://github.com/user-attachments/assets/36d37f46-dee1-4de6-be1a-7cc76d10d4c1)

![Unapproved club event (displayed to officers only)](https://github.com/user-attachments/assets/c6144cd6-5ec3-460e-bc9a-900279bd71dd)

![Note for events without a ticket_drop_time](https://github.com/user-attachments/assets/e7c40a9e-011f-4198-baed-5d93910f73be)

![User viewport after clicking on link to ticket_drop_time field within note](https://github.com/user-attachments/assets/98da2bad-ebb6-4516-bb70-f782ddf96045)