### PR TITLE
Disable cache for application submission exports

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -6935,7 +6935,6 @@ class ApplicationSubmissionViewSet(viewsets.ModelViewSet):
 
         return Response(data)
 
-    @method_decorator(cache_page(60 * 60 * 2))
     @action(detail=False, methods=["get"])
     def export(self, *args, **kwargs):
         """


### PR DESCRIPTION
As mentioned in #722, the CSV export for application submissions is currently cached, which leads to unintended staleness issues particularly when club leaders download a "final" list of following a period of many submissions (e.g. WC deadline), which may not be included in the cached copy. As speedup from caching is likely minimal (only one or two people are exporting any given application's submissions anyways and they implicitly expect an up-to-date copy regardless), we can just remove the caching for now.