### PR TITLE
Application submission management clarity

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -6619,17 +6619,17 @@ class ClubApplicationViewSet(viewsets.ModelViewSet):
                 invite.send_mail(self.request)
 
         dry_run_msg = "Would have sent" if dry_run else "Sent"
-        skip_msg = ""
+        skip_msg = []
         if skip["already_notified"]:
-            skip_msg += f" {skip['already_notified']} already notified"
+            skip_msg.append(f" {skip['already_notified']} already notified")
         if skip["pending"]:
-            skip_msg += f" {skip['pending']} still marked as pending"
+            skip_msg.append(f" {skip['pending']} still marked as pending")
         if skip["no_reason"]:
-            skip_msg += f" {skip['no_reason']} have no reason provided"
+            skip_msg.append(f" {skip['no_reason']} have no reason provided")
         return Response(
             {
-                "detail": f"{dry_run_msg} emails to {n} people, "
-                f"{skip_msg if skip_msg else ''}",
+                "detail": f"{dry_run_msg} emails to {n} people"
+                f"{(': ' + ', '.join(skip_msg)) if len(skip_msg) > 0 else ''}",
             }
         )
 

--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -261,7 +261,7 @@ const NotificationModal = (props: {
         {(props) => (
           <Form>
             <StyledHeader style={{ marginBottom: '2px' }}>
-              Send application update
+              Send application updates
             </StyledHeader>
             <Text>
               Send acceptance or rejection emails. This may take a while...
@@ -288,13 +288,14 @@ const NotificationModal = (props: {
               onClick={(e) => {
                 if (e.target.checked) {
                   toast.warning(
-                    'Resending emails will send emails to all applicants, even if they have already been notified.',
+                    'Resending emails will send emails to applicants who have already received update emails. Please proceed with caution.',
                   )
                 }
               }}
               helpText={
-                <strong>
-                  If selected, will resend notifications to all applicants
+                <strong className="has-text-danger">
+                  If selected, will resend notifications to all applicants,
+                  including those who have already been notified.
                 </strong>
               }
             />
@@ -441,9 +442,10 @@ export default function ApplicationsPage({
               return {
                 ...response,
                 committee: response.committee?.name ?? 'General Member',
-                status: APPLICATION_STATUS_TYPES.find(
-                  (status) => status.value === response.status,
-                )?.label,
+                status:
+                  APPLICATION_STATUS_TYPES.find(
+                    (status) => status.value === response.status,
+                  )?.label + (response.notified && ' (notified)'),
                 created_at: moment(response.created_at)
                   .tz('America/New_York')
                   .format('LLL'),
@@ -620,6 +622,11 @@ export default function ApplicationsPage({
                   <button
                     className="button is-link mr-3"
                     onClick={(event) => {
+                      if (selectedSubmissions.length > 0) {
+                        toast.warning(
+                          'This will send emails to all applicants, including those not selected!',
+                        )
+                      }
                       setShowNotifModal(true)
                     }}
                   >

--- a/frontend/pages/club/[club]/application/[application]/index.tsx
+++ b/frontend/pages/club/[club]/application/[application]/index.tsx
@@ -5,6 +5,7 @@ import { Container, Icon, Title } from 'components/common'
 import { Field, Form, Formik } from 'formik'
 import moment from 'moment'
 import { NextPageContext } from 'next'
+import Link from 'next/link'
 import { type JSX, ReactElement, useState } from 'react'
 import TimeAgo from 'react-timeago'
 import renderPage from 'renderPage'
@@ -116,6 +117,24 @@ const ApplicationPage = ({
 }): ReactElement<any> => {
   if (!userInfo) {
     return <AuthPrompt />
+  } else if (club.detail) {
+    return (
+      <Container paddingTop>
+        <Title>Club Not Found</Title>
+        <p>
+          Back to <Link href="/">Home</Link>.
+        </p>
+      </Container>
+    )
+  } else if (application.detail) {
+    return (
+      <Container paddingTop>
+        <Title>Application Not Found</Title>
+        <p>
+          Back to <Link href={`/club/${club.code}`}>{club.name}</Link>.
+        </p>
+      </Container>
+    )
   }
 
   // Second condition will be replaced with perms check or question nullity check once backend is updated


### PR DESCRIPTION
Some QoL improvements to the application submission management flow for club officers, aiming at reducing user error and increasing clarity for the application decision sending process:

* Add warning toast when sending decisions while having selected applications (route send decisions to all submissions regardless of selection on frontend, so can result in wrong user assumptions about who the updates are sent to)
* Wording changes to emphasize the above fact and warn users against the resend notifications feature
* Route to send application updates now has detail breaking down why certain users were not sent new emails
* (not that related) Putting in non-existent club/application ids into the `/application` route returns a proper X not found screen instead of an empty one