### PR TITLE
Add email blast feature to admin dashboard

### DIFF
--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -171,6 +171,11 @@ class ClubPermission(permissions.BasePermission):
             return membership.role <= Membership.ROLE_OFFICER
 
     def has_permission(self, request, view):
+        if view.action in {"email_blast"}:
+            return request.user.is_authenticated and (
+                request.user.is_staff or request.user.has_perm("clubs.manage_club")
+            )
+
         if view.action in {
             "children",
             "create",

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2243,8 +2243,13 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             )
 
         target = request.data.get("target").lower().strip()
+        roles = {
+            "leaders": Membership.ROLE_OWNER,
+            "officers": Membership.ROLE_OFFICER,
+            "all": Membership.ROLE_MEMBER,
+        }
 
-        if target not in ["leaders", "officers", "all"]:
+        if target not in roles:
             return Response(
                 {"detail": "Target must be one of: leaders, officers, all"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -2257,11 +2262,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        target_role = {
-            "leaders": Membership.ROLE_OWNER,
-            "officers": Membership.ROLE_OFFICER,
-            "all": Membership.ROLE_MEMBER,
-        }[target]
+        target_role = roles[target]
 
         emails = list(
             Membership.objects.filter(role__lte=target_role, active=True)

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2191,6 +2191,98 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
         return Response(fields)
 
+    @action(detail=False, methods=["post"])
+    def email_blast(self, request, *args, **kwargs):
+        """
+        Send email blast to targeted (active) club members.
+        ---
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        properties:
+                            content:
+                                type: string
+                                description: The content of the email blast to send
+                            target:
+                                type: string
+                                description: Must be one of leaders, officers, or all
+                        required:
+                            - content
+                            - target
+        responses:
+            "200":
+                description: Email blast was sent successfully
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+                                    description: A message indicating how many
+                                        recipients received the blast
+            "400":
+                description: Content or target field was empty or missing
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+                                    description: Error message indicating content
+                                        or target was not provided correctly
+        ---
+        """
+        if "target" not in request.data:
+            return Response(
+                {"detail": "Target must be specified"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        target = request.data.get("target").lower().strip()
+
+        if target not in ["leaders", "officers", "all"]:
+            return Response(
+                {"detail": "Target must be one of: leaders, officers, all"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        content = request.data.get("content", "").strip()
+        if not content:
+            return Response(
+                {"detail": "Content must be specified"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        target_role = {
+            "leaders": Membership.ROLE_OWNER,
+            "officers": Membership.ROLE_OFFICER,
+            "all": Membership.ROLE_MEMBER,
+        }[target]
+
+        emails = list(
+            Membership.objects.filter(role__lte=target_role, active=True)
+            .values_list("person__email", flat=True)
+            .distinct()
+        )
+
+        send_mail_helper(
+            name="blast",
+            subject=f"Update from {settings.BRANDING_SITE_NAME}",
+            emails=emails,
+            context={
+                "sender": settings.BRANDING_SITE_NAME,
+                "content": content,
+                "reply_emails": settings.OSA_EMAILS + [settings.BRANDING_SITE_EMAIL],
+            },
+            reply_to=settings.OSA_EMAILS + [settings.BRANDING_SITE_EMAIL],
+        )
+
+        return Response({"detail": (f"Blast sent to {len(emails)} recipients")})
+
     def get_serializer_class(self):
         """
         Return a serializer class that is appropriate for the action being performed.
@@ -3125,15 +3217,18 @@ class ClubEventViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        reply_emails = event.club.get_officer_emails()
+
         send_mail_helper(
             name="blast",
             subject=f"Update on {event.name} from {event.club.name}",
             emails=emails,
             context={
                 "sender": event.club.name,
-                "content": request.data.get("content"),
-                "reply_emails": event.club.get_officer_emails(),
+                "content": content,
+                "reply_emails": reply_emails,
             },
+            reply_to=reply_emails,
         )
 
         return Response(

--- a/frontend/components/Settings/BulkEditTab.tsx
+++ b/frontend/components/Settings/BulkEditTab.tsx
@@ -97,7 +97,9 @@ const BulkEditTab = ({ tags, clubfairs, badges }: BulkEditTabProps) => {
         <Text>
           Sends an email blast to the selected group of users. Select a target
           group and provide the message content. All active users with roles
-          equivalent to or higher than the selected group will be notified.
+          equivalent to or higher than the selected group will be notified. The
+          subject line is nondescriptive, so it is recommended to explicitly
+          state the sender within the email body.
         </Text>
         <Formik
           initialValues={{

--- a/frontend/components/Settings/BulkEditTab.tsx
+++ b/frontend/components/Settings/BulkEditTab.tsx
@@ -100,21 +100,27 @@ const BulkEditTab = ({ tags, clubfairs, badges }: BulkEditTabProps) => {
           equivalent to or higher than the selected group will be notified.
         </Text>
         <Formik
-          initialValues={{ target: '', content: '' }}
+          initialValues={{
+            target: { id: 'leaders', name: 'Leaders' },
+            content: '',
+          }}
           onSubmit={async (values, { setSubmitting, resetForm }) => {
             try {
               const resp = await doApiRequest(
-                '/clubs/email-blast/?format=json',
+                '/clubs/email_blast/?format=json',
                 {
                   method: 'POST',
-                  body: values,
+                  body: {
+                    target: values.target.id,
+                    content: values.content,
+                  },
                 },
               )
               const data = await resp.json()
-              if (data.detail) {
-                toast.success(data.detail, { hideProgressBar: true })
-              } else if (data.error) {
+              if (data.error) {
                 toast.error(data.error, { hideProgressBar: true })
+              } else if (data.detail) {
+                toast.success(data.detail, { hideProgressBar: true })
               }
             } finally {
               setSubmitting(false)

--- a/frontend/components/Settings/BulkEditTab.tsx
+++ b/frontend/components/Settings/BulkEditTab.tsx
@@ -93,6 +93,65 @@ const BulkEditTab = ({ tags, clubfairs, badges }: BulkEditTabProps) => {
   return (
     <>
       <div className="box">
+        <div className="is-size-4">Email Blast</div>
+        <Text>
+          Sends an email blast to the selected group of users. Select a target
+          group and provide the message content. All active users with roles
+          equivalent to or higher than the selected group will be notified.
+        </Text>
+        <Formik
+          initialValues={{ target: '', content: '' }}
+          onSubmit={async (values, { setSubmitting, resetForm }) => {
+            try {
+              const resp = await doApiRequest(
+                '/clubs/email-blast/?format=json',
+                {
+                  method: 'POST',
+                  body: values,
+                },
+              )
+              const data = await resp.json()
+              if (data.detail) {
+                toast.success(data.detail, { hideProgressBar: true })
+              } else if (data.error) {
+                toast.error(data.error, { hideProgressBar: true })
+              }
+            } finally {
+              setSubmitting(false)
+              resetForm()
+            }
+          }}
+        >
+          {({ isSubmitting }) => (
+            <Form>
+              <Field
+                name="target"
+                as={SelectField}
+                choices={[
+                  { value: 'leaders', label: 'Leaders' },
+                  { value: 'officers', label: 'Officers' },
+                  { value: 'all', label: 'All' },
+                ]}
+                label="Target Group"
+              />
+              <Field
+                name="content"
+                as={TextField}
+                type="textarea"
+                label="Message Content"
+              />
+              <button
+                type="submit"
+                className="button is-primary"
+                disabled={isSubmitting}
+              >
+                <Icon name="mail" /> Send Email Blast
+              </button>
+            </Form>
+          )}
+        </Formik>
+      </div>
+      <div className="box">
         <div className="is-size-4">{OBJECT_NAME_TITLE_SINGULAR} Editing</div>
         <Text>
           You can use the form below to perform bulk editing on{' '}

--- a/frontend/pages/admin/[[...slug]].tsx
+++ b/frontend/pages/admin/[[...slug]].tsx
@@ -45,7 +45,7 @@ function AdminPage({
   const tabs = [
     {
       name: 'bulk',
-      label: 'Bulk Editing',
+      label: 'Club Management',
       content: () => (
         <BulkEditTab badges={badges} clubfairs={clubfairs} tags={tags} />
       ),


### PR DESCRIPTION
Adds backend route to email selected populations (e.g. club leaders, officers, or all members). This route's only usable by admins. Also adds frontend UI to admin dashboard.

Closes #783.