### PR TITLE
Club diff for merge

### DIFF
--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -1228,6 +1228,10 @@ class StudentTypeSerializer(serializers.ModelSerializer):
         fields = ("id", "name")
 
 def description_diff_helper(latest_approved_description, latest_description):
+
+    if (latest_approved_description == latest_description):
+        return latest_description
+    
     # Get the diff between old and new HTML
     html_text = diff(latest_approved_description, latest_description)
     soup = BeautifulSoup(html_text, "html.parser")

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from urllib.parse import parse_qs, urlparse
 
 import bleach
+from bs4 import BeautifulSoup
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -13,10 +14,9 @@ from django.db import models
 from django.db.models import Prefetch
 from django.template.defaultfilters import slugify
 from django.utils import timezone
+from html_diff import diff
 from rest_framework import serializers, validators
 from simple_history.utils import update_change_reason
-from html_diff import diff
-from bs4 import BeautifulSoup
 
 from clubs.mixins import ManyToManySaveMixin
 from clubs.models import (

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -990,8 +990,13 @@ class ClubDiffSerializer(serializers.ModelSerializer):
 
         latest_approved_description = diff["description"]["old"] or ""
         latest_description = diff["description"]["new"] or ""
-        diff["description"]["diff"] = description_diff_helper(
+        latest_approved_title = diff["name"]["old"] or ""
+        latest_title = diff["name"]["new"] or ""
+        diff["description"]["diff"] = diff_calculator(
             latest_approved_description, latest_description
+        )
+        diff["name"]["diff"] = diff_calculator(
+            latest_approved_title, latest_title
         )
 
         if is_same:
@@ -1230,7 +1235,7 @@ class StudentTypeSerializer(serializers.ModelSerializer):
         fields = ("id", "name")
 
 
-def description_diff_helper(latest_approved_description, latest_description):
+def diff_calculator(latest_approved_description, latest_description):
     if latest_approved_description == latest_description:
         return latest_description
     # Get the diff between old and new HTML

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -968,6 +968,7 @@ class ClubConstitutionSerializer(ClubMinimalSerializer):
     class Meta(ClubMinimalSerializer.Meta):
         fields = ClubMinimalSerializer.Meta.fields + ["files"]
 
+
 class ClubDiffSerializer(serializers.ModelSerializer):
     diff = serializers.SerializerMethodField()
 
@@ -1000,6 +1001,7 @@ class ClubDiffSerializer(serializers.ModelSerializer):
             }
 
         return {instance.code: diff}
+
 
 class ClubListSerializer(serializers.ModelSerializer):
     """
@@ -1227,11 +1229,10 @@ class StudentTypeSerializer(serializers.ModelSerializer):
         model = StudentType
         fields = ("id", "name")
 
-def description_diff_helper(latest_approved_description, latest_description):
 
-    if (latest_approved_description == latest_description):
+def description_diff_helper(latest_approved_description, latest_description):
+    if latest_approved_description == latest_description:
         return latest_description
-    
     # Get the diff between old and new HTML
     html_text = diff(latest_approved_description, latest_description)
     soup = BeautifulSoup(html_text, "html.parser")

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2097,6 +2097,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         if (
             cached_object
             and not self.request.user.groups.filter(name="Approvers").exists()
+            and not self.request.user.has_perm("clubs.approve_club")
         ):
             return Response(cached_object)
 
@@ -2201,8 +2202,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             ),
             latest_approved_image=Subquery(
                 latest_approved_version_qs.values("image")[:1]
-            ),
-            description_difference=Subquery(latest_version_qs.values("name")[:1]),
+            )
         )
 
         return qs
@@ -2235,6 +2235,10 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
                                                     type: string
                                                     description: >
                                                         New name of the club
+                                                diff:
+                                                    type: string
+                                                    description: >
+                                                        Diffed name of the club
                                         description:
                                             type: object
                                             description: >

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "pyasyncore>=1.0.4",
     "standard-smtpd>=3.13.0",
     "pip>=25.0.1",
+    "html-diff>=0.4.1",
 ]
 
 [dependency-groups]

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1663,12 +1663,12 @@ class ClubTestCase(TestCase):
 
         self.assertEqual(
             data["new-club"]["description"]["diff"],
-            """We are <ins style="text-decoration: none; background-color: #dafdd5;
-            opacity: 1;">not </ins>open<ins style=" text-decoration: none;
-            background-color: #dafdd5; opacity: 1;">,</ins> <del style="text-decoration:
-            none; background-color: #ffbdbd; opacity: 0.3;">source,</del><ins
-            style="text-decoration: none; background-color: #dafdd5; opacity: 1;">
-            do not</ins> expect us.""",
+            """We are <ins style="text-decoration: none; background-color: #dafdd5;"""
+            """ opacity: 1;">not </ins>open<ins style="text-decoration: none; backg"""
+            """round-color: #dafdd5; opacity: 1;">,</ins> <del style="text-decorati"""
+            """on: none; background-color: #ffbdbd; opacity: 0.3;">source,</del><in"""
+            """s style="text-decoration: none; background-color: #dafdd5; opacity: """
+            """1;">do not</ins> expect us.""",
         )
 
         # attempt to get diff of approved club

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1516,6 +1516,150 @@ class ClubTestCase(TestCase):
             codes = [club["code"] for club in data]
             self.assertEqual(set(codes), set(query["results"]), (query, resp.content))
 
+
+    def test_club_detail_diff(self):
+        """
+        Test that diff returns the correct old and new club for a club in approval queue
+        """
+
+        # create club that requires approval
+        new_club = Club.objects.create(
+            code="new-club",
+            name="New Club",
+            description="We're the spirits of open source.",
+            approved=None,
+            active=True,
+            email="example@example.com",
+        )
+
+        # add officer to club
+        Membership.objects.create(
+            person=self.user4, club=new_club, role=Membership.ROLE_OFFICER
+        )
+
+        # login to officer user
+        self.client.login(username=self.user4.username, password="test")
+
+        # New club should not have any old data
+        resp = self.client.get(reverse("clubs-club-detail-diff", args=(new_club.code,)))
+        data = json.loads(resp.content.decode("utf-8"))
+
+        self.assertEqual(data["new-club"]["name"]["new"], "New Club")
+        self.assertEqual(data["new-club"]["name"]["old"], None)
+
+        self.assertEqual(
+            data["new-club"]["description"]["new"], "We're the spirits of open source."
+        )
+        self.assertEqual(data["new-club"]["description"]["old"], None)
+
+        self.assertEqual(data["new-club"]["image"]["new"], "")
+        self.assertEqual(data["new-club"]["image"]["old"], None)
+
+        # approve club
+        new_club.approved = True
+        new_club.save(update_fields=["approved"])
+        new_club.refresh_from_db()
+        self.assertTrue(new_club.approved)
+
+        # trigger reapproval by changing name
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(new_club.code,)),
+            {"name": "New Club 2"},
+            content_type="application/json",
+        )
+
+        # Ensure change successful
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+
+        resp = self.client.get(reverse("clubs-club-detail-diff", args=(new_club.code,)))
+        data = json.loads(resp.content.decode("utf-8"))
+
+        new_club.refresh_from_db()
+        self.assertFalse(new_club.approved)
+        self.assertEqual(data["new-club"]["name"]["new"], "New Club 2")
+
+        # approve club
+        new_club.approved = True
+        new_club.save(update_fields=["approved"])
+        new_club.refresh_from_db()
+        self.assertTrue(new_club.approved)
+
+        # changing description should not trigger reapproval.
+        # Might later be changed back to trigger reapproval
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(new_club.code,)),
+            {"description": "We are open source, expect us."},
+            content_type="application/json",
+        )
+
+        # Ensure change successful
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+        new_club.refresh_from_db()
+        self.assertTrue(new_club.approved)
+
+        resp = self.client.get(reverse("clubs-club-detail-diff", args=(new_club.code,)))
+        data = json.loads(resp.content.decode("utf-8"))
+        self.assertEqual(
+            data["new-club"],
+            "No changes that require approval made since last approval",
+        )
+
+        # change club name twice before approval
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(new_club.code,)),
+            {"name": "New Club 3"},
+            content_type="application/json",
+        )
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(new_club.code,)),
+            {"name": "New Club 4"},
+            content_type="application/json",
+        )
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+
+        # Ensure club is marked as not approved
+        new_club.refresh_from_db()
+        self.assertFalse(new_club.approved)
+
+        resp = self.client.get(reverse("clubs-club-detail-diff", args=(new_club.code,)))
+        data = json.loads(resp.content.decode("utf-8"))
+
+        # should have latest unapproved name
+        self.assertEqual(
+            data["new-club"]["name"]["new"],
+            "New Club 4",
+        )
+        # should have latest approved name
+        self.assertEqual(
+            data["new-club"]["name"]["old"],
+            "New Club 2",
+        )
+        # should have latest description, since description doesn't require reapproval
+        self.assertEqual(
+            data["new-club"]["description"]["new"],
+            "We are open source, expect us.",
+        )
+        # should have latest description
+        self.assertEqual(
+            data["new-club"]["description"]["old"],
+            "We are open source, expect us.",
+        )
+
+        # attempt to get diff of approved club
+        new_club.approved = True
+        new_club.save(update_fields=["approved"])
+        new_club.refresh_from_db()
+        self.assertTrue(new_club.approved)
+        resp3 = self.client.get(
+            reverse("clubs-club-detail-diff", args=(new_club.code,))
+        )
+        new_data1 = json.loads(resp3.content.decode("utf-8"))
+        self.assertEqual(
+            new_data1["new-club"],
+            "No changes that require approval made since last approval",
+        )
+
     def test_club_modify_wrong_auth(self):
         """
         Outsiders should not be able to modify a club.

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1516,7 +1516,6 @@ class ClubTestCase(TestCase):
             codes = [club["code"] for club in data]
             self.assertEqual(set(codes), set(query["results"]), (query, resp.content))
 
-
     def test_club_detail_diff(self):
         """
         Test that diff returns the correct old and new club for a club in approval queue
@@ -1664,7 +1663,12 @@ class ClubTestCase(TestCase):
 
         self.assertEqual(
             data["new-club"]["description"]["diff"],
-            """We are <ins style="text-decoration: none; background-color: #dafdd5; opacity: 1;">not </ins>open<ins style="text-decoration: none; background-color: #dafdd5; opacity: 1;">,</ins> <del style="text-decoration: none; background-color: #ffbdbd; opacity: 0.3;">source,</del><ins style="text-decoration: none; background-color: #dafdd5; opacity: 1;">do not</ins> expect us."""
+            """We are <ins style="text-decoration: none; background-color: #dafdd5;
+            opacity: 1;">not </ins>open<ins style=" text-decoration: none;
+            background-color: #dafdd5; opacity: 1;">,</ins> <del style="text-decoration:
+            none; background-color: #ffbdbd; opacity: 0.3;">source,</del><ins
+            style="text-decoration: none; background-color: #dafdd5; opacity: 1;">
+            do not</ins> expect us.""",
         )
 
         # attempt to get diff of approved club

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1645,6 +1645,27 @@ class ClubTestCase(TestCase):
             data["new-club"]["description"]["old"],
             "We are open source, expect us.",
         )
+        # difference will just return current description
+        self.assertEqual(
+            data["new-club"]["description"]["diff"],
+            "We are open source, expect us.",
+        )
+
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(new_club.code,)),
+            {"description": "We are not open, do not expect us."},
+            content_type="application/json",
+        )
+
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+
+        resp = self.client.get(reverse("clubs-club-detail-diff", args=(new_club.code,)))
+        data = json.loads(resp.content.decode("utf-8"))
+
+        self.assertEqual(
+            data["new-club"]["description"]["diff"],
+            """We are <ins style="text-decoration: none; background-color: #dafdd5; opacity: 1;">not </ins>open<ins style="text-decoration: none; background-color: #dafdd5; opacity: 1;">,</ins> <del style="text-decoration: none; background-color: #ffbdbd; opacity: 0.3;">source,</del><ins style="text-decoration: none; background-color: #dafdd5; opacity: 1;">do not</ins> expect us."""
+        )
 
         # attempt to get diff of approved club
         new_club.approved = True

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -644,6 +644,18 @@ wheels = [
 ]
 
 [[package]]
+name = "html-diff"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/b2/53c5b08a6af8b90213f45aad08ef6dc02a50bffc30f27b6093fb9d4f1bb9/html-diff-0.4.1.tar.gz", hash = "sha256:4260ad08d80a043f34a45721d429d3462ec2738b9002c7e5bd75040bdcd40528", size = 24461 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/ea/2306cede5715f6203515f595b7c251c1a5ea083e5139be70c503962edff8/html_diff-0.4.1-py3-none-any.whl", hash = "sha256:b64d90514abecd13702b936ec4221aa103f4f0df96427bf8387bb18ca6c0ab74", size = 24174 },
+]
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -961,6 +973,7 @@ dependencies = [
     { name = "drf-nested-routers" },
     { name = "freezegun" },
     { name = "gunicorn" },
+    { name = "html-diff" },
     { name = "httptools" },
     { name = "ics" },
     { name = "inflection" },
@@ -1023,6 +1036,7 @@ requires-dist = [
     { name = "drf-nested-routers" },
     { name = "freezegun" },
     { name = "gunicorn" },
+    { name = "html-diff", specifier = ">=0.4.1" },
     { name = "httptools" },
     { name = "ics" },
     { name = "inflection" },

--- a/frontend/components/ClubPage/Description.tsx
+++ b/frontend/components/ClubPage/Description.tsx
@@ -1,8 +1,11 @@
-import { ReactElement } from 'react'
+import { ReactElement, useState, useEffect } from 'react'
 import styled from 'styled-components'
 
 import { Club } from '../../types'
-import { EMPTY_DESCRIPTION } from '../../utils'
+import { 
+  EMPTY_DESCRIPTION,
+  doApiRequest
+} from '../../utils'
 import { StrongText } from '../common'
 
 const Wrapper = styled.div`
@@ -13,14 +16,61 @@ const Wrapper = styled.div`
   flex: 1;
 `
 
-type Props = {
+type DescProps = {
   club: Club
 }
 
-const Description = ({ club }: Props): ReactElement<any> => (
+
+const Description = ({ club }: DescProps): ReactElement => {
+
+
+  const { active, name, tags, badges } = club
+
+  const [diffs, setDiffs] = useState(null);
+  
+  const retrieveDiffs = async () => {
+    const resp = await doApiRequest(`/clubs/${club.code}/club_detail_diff/?format=json`, {
+      method: 'GET'
+    })
+    const json = await resp.json()
+    return json[club.code]
+  }
+
+  if (club.approved == null) {
+    useEffect(() => {
+      const fetchDiffs = async () => {
+        if (club.approved == null) {
+          const resp = await retrieveDiffs();
+          setDiffs(resp);
+        }
+      };
+      fetchDiffs();
+    }, [club.code]);
+
+    if (diffs != null) {
+      console.log(diffs)
+      let display = diffs["description"]["diff"]
+      return (
+        <Wrapper>
+          <div style={{ width: '100%' }}>
+            <StrongText>Description</StrongText>
+            <div
+              className="content"
+              dangerouslySetInnerHTML={{
+                __html: display || EMPTY_DESCRIPTION,
+              }}
+            />
+          </div>
+        </Wrapper>
+      )
+    }
+  }
+
+  return (
   <Wrapper>
     <div style={{ width: '100%' }}>
       <StrongText>Club Mission</StrongText>
+      <div></div>
       <div
         className="content"
         dangerouslySetInnerHTML={{
@@ -29,6 +79,7 @@ const Description = ({ club }: Props): ReactElement<any> => (
       />
     </div>
   </Wrapper>
-)
+  );
+}
 
-export default Description
+export default Description;

--- a/frontend/components/ClubPage/Description.tsx
+++ b/frontend/components/ClubPage/Description.tsx
@@ -39,8 +39,10 @@ type ClubDiff = {
 }
 
 const Description = ({ club }: DescProps): ReactElement => {
+
   const [diffs, setDiffs] = useState<ClubDiff | null>(null)
   const canApprove = apiCheckPermission('clubs.approve_club')
+  const canDeleteClub = apiCheckPermission('clubs.delete_club')
 
   const NewDescription = () => {
     return (
@@ -59,7 +61,8 @@ const Description = ({ club }: DescProps): ReactElement => {
     )
   }
 
-  if (!canApprove) {
+
+  if (!canApprove || club.approved == false) {
     return <NewDescription />
   }
 

--- a/frontend/components/ClubPage/Description.tsx
+++ b/frontend/components/ClubPage/Description.tsx
@@ -48,7 +48,6 @@ const Description = ({ club }: DescProps): ReactElement => {
     }, [club.code]);
 
     if (diffs != null) {
-      console.log(diffs)
       let display = diffs["description"]["diff"]
       return (
         <Wrapper>

--- a/frontend/components/ClubPage/Description.tsx
+++ b/frontend/components/ClubPage/Description.tsx
@@ -39,7 +39,6 @@ type ClubDiff = {
 }
 
 const Description = ({ club }: DescProps): ReactElement => {
-
   const [diffs, setDiffs] = useState<ClubDiff | null>(null)
   const canApprove = apiCheckPermission('clubs.approve_club')
   const canDeleteClub = apiCheckPermission('clubs.delete_club')
@@ -61,8 +60,7 @@ const Description = ({ club }: DescProps): ReactElement => {
     )
   }
 
-
-  if (!canApprove || club.approved == false) {
+  if (!canApprove || club.approved === false) {
     return <NewDescription />
   }
 

--- a/frontend/components/ClubPage/Description.tsx
+++ b/frontend/components/ClubPage/Description.tsx
@@ -1,11 +1,8 @@
-import { ReactElement, useState, useEffect } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { Club } from '../../types'
-import { 
-  EMPTY_DESCRIPTION,
-  doApiRequest
-} from '../../utils'
+import { doApiRequest, EMPTY_DESCRIPTION } from '../../utils'
 import { StrongText } from '../common'
 
 const Wrapper = styled.div`
@@ -20,18 +17,34 @@ type DescProps = {
   club: Club
 }
 
+type ClubDiff = {
+  description: {
+    old: string
+    new: string
+    diff: string
+  }
+  name: {
+    old: string
+    new: string
+  }
+  image: {
+    old: string
+    new: string
+  }
+}
 
 const Description = ({ club }: DescProps): ReactElement => {
-
-
   const { active, name, tags, badges } = club
 
-  const [diffs, setDiffs] = useState(null);
-  
+  const [diffs, setDiffs] = useState<ClubDiff | null>(null)
+
   const retrieveDiffs = async () => {
-    const resp = await doApiRequest(`/clubs/${club.code}/club_detail_diff/?format=json`, {
-      method: 'GET'
-    })
+    const resp = await doApiRequest(
+      `/clubs/${club.code}/club_detail_diff/?format=json`,
+      {
+        method: 'GET',
+      },
+    )
     const json = await resp.json()
     return json[club.code]
   }
@@ -40,15 +53,15 @@ const Description = ({ club }: DescProps): ReactElement => {
     useEffect(() => {
       const fetchDiffs = async () => {
         if (club.approved == null) {
-          const resp = await retrieveDiffs();
-          setDiffs(resp);
+          const resp = await retrieveDiffs()
+          setDiffs(resp)
         }
-      };
-      fetchDiffs();
-    }, [club.code]);
+      }
+      fetchDiffs()
+    }, [club.code])
 
     if (diffs != null) {
-      let display = diffs["description"]["diff"]
+      const display = diffs.description.diff
       return (
         <Wrapper>
           <div style={{ width: '100%' }}>
@@ -66,19 +79,19 @@ const Description = ({ club }: DescProps): ReactElement => {
   }
 
   return (
-  <Wrapper>
-    <div style={{ width: '100%' }}>
-      <StrongText>Club Mission</StrongText>
-      <div></div>
-      <div
-        className="content"
-        dangerouslySetInnerHTML={{
-          __html: club.description || EMPTY_DESCRIPTION,
-        }}
-      />
-    </div>
-  </Wrapper>
-  );
+    <Wrapper>
+      <div style={{ width: '100%' }}>
+        <StrongText>Club Mission</StrongText>
+        <div></div>
+        <div
+          className="content"
+          dangerouslySetInnerHTML={{
+            __html: club.description || EMPTY_DESCRIPTION,
+          }}
+        />
+      </div>
+    </Wrapper>
+  )
 }
 
-export default Description;
+export default Description

--- a/frontend/components/ClubPage/Header.tsx
+++ b/frontend/components/ClubPage/Header.tsx
@@ -54,7 +54,7 @@ const Header = ({ club, style }: HeaderProps): ReactElement => {
     )
   }
 
-  if (!canApprove) {
+  if (!canApprove || club.approved == false) {
     return <NewHeader />
   }
 

--- a/frontend/components/ClubPage/Header.tsx
+++ b/frontend/components/ClubPage/Header.tsx
@@ -1,7 +1,8 @@
-import { CSSProperties, ReactElement } from 'react'
+import { CSSProperties, ReactElement, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { Club } from '../../types'
+import { apiCheckPermission, doApiRequest } from '../../utils'
 import { InactiveTag, TagGroup, Title } from '../common'
 
 const Wrapper = styled.div`
@@ -16,21 +17,100 @@ type HeaderProps = {
   style?: CSSProperties
 }
 
-const Header = ({ club, style }: HeaderProps): ReactElement<any> => {
+type ClubDiff = {
+  description: {
+    old: string
+    new: string
+    diff: string
+  }
+  name: {
+    old: string
+    new: string
+    diff: string
+  }
+  image: {
+    old: string
+    new: string
+  }
+}
+
+const Header = ({ club, style }: HeaderProps): ReactElement => {
   const { active, name, tags, badges } = club
-  return (
-    <div style={style}>
-      <Wrapper>
-        <Title style={{ marginBottom: '0.25rem' }}>
-          {name}
-          {!active && <InactiveTag />}
-        </Title>
-      </Wrapper>
-      <div style={{ marginBottom: '1rem' }}>
-        <TagGroup tags={[...tags, ...badges]} />
+  const canApprove = apiCheckPermission('clubs.approve_club')
+
+  const NewHeader = () => {
+    return (
+      <div style={style}>
+        <Wrapper>
+          <Title style={{ marginBottom: '0.25rem' }}>
+            {name}
+            {!active && <InactiveTag />}
+          </Title>
+        </Wrapper>
+        <div style={{ marginBottom: '1rem' }}>
+          <TagGroup tags={[...tags, ...badges]} />
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
+
+  if (!canApprove) {
+    return <NewHeader />
+  }
+
+  const [diffs, setDiffs] = useState<ClubDiff | null>(null)
+
+  const retrieveDiffs = async () => {
+    const resp = await doApiRequest(
+      `/clubs/${club.code}/club_detail_diff/?format=json`,
+      {
+        method: 'GET',
+      },
+    )
+    const json = await resp.json()
+    return json[club.code]
+  }
+
+  if (club.approved == null) {
+    useEffect(() => {
+      const fetchDiffs = async () => {
+        if (club.approved == null) {
+          const resp = await retrieveDiffs()
+          if (
+            resp === 'No changes that require approval made since last approval'
+          ) {
+            setDiffs(null)
+          } else {
+            setDiffs(resp)
+          }
+        }
+      }
+      fetchDiffs()
+    }, [club.code])
+  }
+
+  if (diffs != null && canApprove) {
+    const display = diffs.name.diff
+    return (
+      <div style={style}>
+        <Wrapper>
+          <Title style={{ marginBottom: '0.25rem' }}>
+            <div
+              className="content"
+              dangerouslySetInnerHTML={{
+                __html: display || name,
+              }}
+            />
+            {!active && <InactiveTag />}
+          </Title>
+        </Wrapper>
+        <div style={{ marginBottom: '1rem' }}>
+          <TagGroup tags={[...tags, ...badges]} />
+        </div>
+      </div>
+    )
+  }
+  return <NewHeader />
 }
 
 export default Header

--- a/frontend/components/ClubPage/Header.tsx
+++ b/frontend/components/ClubPage/Header.tsx
@@ -54,7 +54,7 @@ const Header = ({ club, style }: HeaderProps): ReactElement => {
     )
   }
 
-  if (!canApprove || club.approved == false) {
+  if (!canApprove || club.approved === false) {
     return <NewHeader />
   }
 

--- a/frontend/components/Settings/QueueTab.tsx
+++ b/frontend/components/Settings/QueueTab.tsx
@@ -213,17 +213,6 @@ const QueueTable = ({ clubs }: QueueTableProps): ReactElement => {
   )
 }
 
-const retrieveDiffs = async (club) => {
-  const resp = await doApiRequest(
-    `/clubs/${club.code}/club_detail_diff/?format=json`,
-    {
-      method: 'GET',
-    },
-  )
-  const json = await resp.json()
-  return json[club.code]
-}
-
 const ClubLink = ({ code, name }: Club) => (
   <Link
     href={CLUB_ROUTE()}
@@ -254,7 +243,13 @@ const ClubTags = ({ code, name }: Club): ReactElement => {
   useEffect(() => {
     const fetchDiffs = async () => {
       const resp = await retrieveDiffs()
-      setDiffs(resp)
+      if (
+        resp === 'No changes that require approval made since last approval'
+      ) {
+        setDiffs(null)
+      } else {
+        setDiffs(resp)
+      }
     }
     fetchDiffs()
   }, [code])

--- a/frontend/components/Settings/QueueTab.tsx
+++ b/frontend/components/Settings/QueueTab.tsx
@@ -1,12 +1,10 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ReactElement, useEffect, useState } from 'react'
-import Select from 'react-select'
-import { toast } from 'react-toastify'
 import styled from 'styled-components'
 
 import { CLUB_ROUTE } from '../../constants'
-import { Club, RegistrationQueueSettings, Template } from '../../types'
+import { Club } from '../../types'
 import { apiCheckPermission, doApiRequest } from '../../utils'
 import {
   OBJECT_NAME_PLURAL,
@@ -23,7 +21,6 @@ type QueueTableModalProps = {
   closeModal: () => void
   bulkAction: (comment: string) => void
   isApproving: boolean
-  templates: Template[]
 }
 
 const QueueTableModal = ({
@@ -31,23 +28,13 @@ const QueueTableModal = ({
   closeModal,
   bulkAction,
   isApproving,
-  templates,
-}: QueueTableModalProps): ReactElement<any> => {
+}: QueueTableModalProps): ReactElement => {
   const [comment, setComment] = useState<string>('')
-  const [selectedTemplates, setSelectedTemplates] = useState<Template[]>([])
-
-  useEffect(() => {
-    setComment(
-      selectedTemplates.map((template) => template.content).join('\n\n'),
-    )
-  }, [selectedTemplates])
-
   return (
     <Modal
       show={show}
       closeModal={() => {
         setComment('')
-        setSelectedTemplates([])
         closeModal()
       }}
       marginBottom={false}
@@ -58,36 +45,6 @@ const QueueTableModal = ({
           notes will be emailed to the requesters when you{' '}
           {isApproving ? 'approve' : 'reject'} these requests.
         </div>
-        <Select
-          isMulti
-          isClearable
-          placeholder="Select templates"
-          value={selectedTemplates.map((template) => ({
-            value: template.id,
-            label: template.title,
-            content: template.content,
-            author: template.author,
-          }))}
-          options={templates.map((template) => ({
-            value: template.id,
-            label: template.title,
-            content: template.content,
-            author: template.author,
-          }))}
-          onChange={(selectedOptions) => {
-            if (selectedOptions) {
-              const selected = selectedOptions.map((option) => ({
-                id: option.value,
-                title: option.label,
-                content: option.content,
-                author: option.author,
-              }))
-              setSelectedTemplates(selected)
-            } else {
-              setSelectedTemplates([])
-            }
-          }}
-        />
         <textarea
           value={comment}
           onChange={(e) => setComment(e.target.value)}
@@ -95,7 +52,7 @@ const QueueTableModal = ({
           placeholder={`${isApproving ? 'approval' : 'rejection'} notes`}
         ></textarea>
         <button
-          className={`mt-2 button ${isApproving ? 'is-success' : 'is-danger'}`}
+          className={`mb-2 button ${isApproving ? 'is-success' : 'is-danger'}`}
           onClick={() => {
             closeModal()
             bulkAction(comment)
@@ -111,14 +68,10 @@ const QueueTableModal = ({
 
 type QueueTableProps = {
   clubs: Club[] | null
-  templates: Template[]
 }
 /* TODO: refactor with Table component when render and search
 functionality are disconnected */
-const QueueTable = ({
-  clubs,
-  templates,
-}: QueueTableProps): ReactElement<any> => {
+const QueueTable = ({ clubs }: QueueTableProps): ReactElement => {
   const router = useRouter()
   const [selectedCodes, setSelectedCodes] = useState<string[]>([])
   const [showModal, setShowModal] = useState<boolean>(false)
@@ -153,10 +106,9 @@ const QueueTable = ({
         closeModal={() => setShowModal(false)}
         bulkAction={bulkAction}
         isApproving={approve}
-        templates={templates}
       />
-      <QueueSectionHeader>
-        <div>
+      <QueueTableHeader>
+        <QueueTableHeaderText>
           <SmallTitle>Pending Clubs</SmallTitle>
           <div className="mt-3 mb-3">
             As an administrator of {SITE_NAME}, you can approve and reject{' '}
@@ -164,8 +116,8 @@ const QueueTable = ({
             list of {OBJECT_NAME_PLURAL} pending your approval. Click on the{' '}
             {OBJECT_NAME_SINGULAR} name to view the {OBJECT_NAME_SINGULAR}.
           </div>
-        </div>
-        <QueueSettingsButtonStack direction="row">
+        </QueueTableHeaderText>
+        <div className="buttons">
           <button
             className="button is-success"
             disabled={!selectedCodes.length || loading}
@@ -186,8 +138,8 @@ const QueueTable = ({
           >
             <Icon name="x" /> Reject
           </button>
-        </QueueSettingsButtonStack>
-      </QueueSectionHeader>
+        </div>
+      </QueueTableHeader>
       {(() => {
         if (clubs === null)
           return <div className="has-text-info">Loading table...</div>
@@ -218,7 +170,7 @@ const QueueTable = ({
             <tbody>
               {clubs.map((club) => (
                 <tr key={club.code}>
-                  <td>
+                  <TableRow>
                     <Checkbox
                       className="mr-3"
                       checked={selectedCodes.includes(club.code)}
@@ -230,8 +182,11 @@ const QueueTable = ({
                         )
                       }
                     />
-                    <ClubLink {...club} />
-                  </td>
+                    <QueueRowContent>
+                      <ClubLink {...club} />
+                      <ClubTags {...club} />
+                    </QueueRowContent>
+                  </TableRow>
                 </tr>
               ))}
             </tbody>
@@ -242,17 +197,107 @@ const QueueTable = ({
   )
 }
 
+const retrieveDiffs = async (club) => {
+  const resp = await doApiRequest(`/clubs/${club.code}/club_detail_diff/?format=json`, {
+    method: 'GET'
+  })
+  const json = await resp.json()
+  return json[club.code]
+}
+
 const ClubLink = ({ code, name }: Club) => (
-  <Link href={CLUB_ROUTE()} as={CLUB_ROUTE(code)} target="_blank">
+  <Link href={CLUB_ROUTE()} as={CLUB_ROUTE(code)} target="_blank" style={{marginRight: "1rem"}}>
     {name}
   </Link>
 )
-const QueueSectionHeader = styled.div`
+
+const ClubTags = ({ code, name, }: Club) : ReactElement => {
+  
+  const tagList : string[][] = []
+  
+  const [diffs, setDiffs] = useState(null);
+    
+  const retrieveDiffs = async () => {
+    const resp = await doApiRequest(`/clubs/${code}/club_detail_diff/?format=json`, {
+      method: 'GET'
+    })
+    const json = await resp.json()
+    return json[code]
+  }
+
+  useEffect(() => {
+    const fetchDiffs = async () => {
+      const resp = await retrieveDiffs();
+      setDiffs(resp);
+    };
+    fetchDiffs();
+  }, [code]);
+
+  if (diffs != null) {
+    const oldDescription : String = diffs["description"]["old"] ?? ""
+    const newDescription : String = diffs["description"]["new"] ?? ""
+    const oldTitle : String = diffs["name"]["old"]
+    const newTitle : String = diffs["name"]["new"] ?? ""
+    const oldImage : String = diffs["image"]["old"] ?? ""
+    const newImage : String = diffs["image"]["new"] ?? ""
+  
+    if (oldTitle == null) {
+      tagList.push(["New Club", "#8467c2"])
+    } 
+    else {
+      if (oldTitle.valueOf() != (newTitle.valueOf())){     
+        tagList.push(["Title", "#4198db"])
+      }
+      if (oldDescription.valueOf() != newDescription.valueOf()){
+        tagList.push(["Desc", "#ee4768"])
+      }
+      if (oldImage != newImage){
+        tagList.push(["Image", "#4cc776"])
+      }
+    }
+  }
+  
+  return (
+    <>
+      {tagList.map(([text, color]) => {
+        return (
+          <TableTag style={{backgroundColor: color}}>
+            {text}
+          </TableTag>
+        )
+      })}
+    </>
+  )
+}
+
+
+const TableRow = styled.td`
+  display: flex;  
+`
+
+const TableTag = styled.div`
+  height: 1.3125rem;
+  margin-top: 0.0625rem;
+  margin-left: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-radius: 0.65625rem;
+  color: white;
+  font-size: 0.875rem;
+`
+
+const QueueTableHeader = styled.div`
   margin-top: 2rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+`
+const QueueRowContent = styled.div`
+  display: flex;
+`
+
+const QueueTableHeaderText = styled.div`
+  flex-basis: 75%;
 `
 
 const MultiProgressBar = styled.div`
@@ -278,63 +323,12 @@ const SmallTitle = styled.div`
   }
 `
 
-const QueueSettingsButtonStack = styled.div<{ direction: 'column' | 'row' }>`
-  display: flex;
-  flex-direction: ${({ direction }) => direction};
-  align-items: flex-end;
-  flex-shrink: 0;
-  gap: 0.5rem;
-`
-
-const QueueSettingsButton = ({
-  open,
-  for: queueType,
-  setOpen: setQueueOpen,
-}: {
-  open: boolean
-  for: 'reapproval_queue_open' | 'new_approval_queue_open'
-  setOpen: (open: boolean) => void
-}): ReactElement<any> => {
-  const onClick = () => {
-    doApiRequest('/settings/queue/', {
-      method: 'PATCH',
-      body: {
-        [queueType]: !open,
-      },
-    }).then((resp) => {
-      if (resp.ok) {
-        setQueueOpen(!open)
-      } else {
-        toast.error('Failed to update queue settings.')
-      }
-    })
-  }
-  const name =
-    queueType === 'reapproval_queue_open' ? 'Reapprovals' : 'New Approvals'
-  if (open) {
-    return (
-      <button className="button is-small is-danger is-block" onClick={onClick}>
-        Close {name}
-      </button>
-    )
-  } else {
-    return (
-      <button className="button is-small is-success is-block" onClick={onClick}>
-        Open {name}
-      </button>
-    )
-  }
-}
-
-const QueueTab = (): ReactElement<any> => {
+const QueueTab = (): ReactElement => {
   const [pendingClubs, setPendingClubs] = useState<Club[] | null>(null)
   const [approvedClubs, setApprovedClubs] = useState<Club[] | null>(null)
   const [rejectedClubs, setRejectedClubs] = useState<Club[] | null>(null)
   const [inactiveClubs, setInactiveClubs] = useState<Club[] | null>(null)
   const [allClubs, setAllClubs] = useState<boolean[] | null>(null)
-  const [templates, setTemplates] = useState<Template[]>([])
-  const [registrationQueueSettings, setRegistrationQueueSettings] =
-    useState<RegistrationQueueSettings | null>(null)
   const canApprove = apiCheckPermission('clubs.approve_club')
 
   useEffect(() => {
@@ -358,14 +352,6 @@ const QueueTab = (): ReactElement<any> => {
       doApiRequest('/clubs/directory/?format=json')
         .then((resp) => resp.json())
         .then((data) => setAllClubs(data.map((club: Club) => club.approved)))
-
-      doApiRequest('/templates/?format=json')
-        .then((resp) => resp.json())
-        .then(setTemplates)
-
-      doApiRequest('/settings/queue/?format=json')
-        .then((resp) => resp.json())
-        .then(setRegistrationQueueSettings)
     }
   }, [])
 
@@ -391,15 +377,11 @@ const QueueTab = (): ReactElement<any> => {
     approvedClubs.concat(rejectedClubs, inactiveClubs)
   return (
     <>
-      <QueueSectionHeader>
-        <div>
-          <SmallTitle>Overview</SmallTitle>
-          <div className="mb-3">
-            From the progress bar below, you can see the current approval status
-            of all {OBJECT_NAME_PLURAL} across {SITE_NAME}.{' '}
-          </div>
-        </div>
-      </QueueSectionHeader>
+      <SmallTitle>Overview</SmallTitle>
+      <div className="mb-3">
+        From the progress bar below, you can see the current approval status of
+        all {OBJECT_NAME_PLURAL} across {SITE_NAME}.
+      </div>
       <MultiProgressBar className="has-background-light mb-3 is-clearfix">
         {totalClubsCount > 0 && (
           <>
@@ -436,70 +418,7 @@ const QueueTab = (): ReactElement<any> => {
           {approvedClubsCount} Approved {OBJECT_NAME_TITLE}
         </li>
       </ul>
-      {registrationQueueSettings && (
-        <>
-          <QueueSectionHeader>
-            <div>
-              <SmallTitle>Status</SmallTitle>
-              <div className="mb-3">
-                The approval queue is currently
-                <b
-                  className={
-                    registrationQueueSettings.reapproval_queue_open
-                      ? 'has-text-success'
-                      : 'has-text-danger'
-                  }
-                >
-                  {registrationQueueSettings.reapproval_queue_open
-                    ? ' open'
-                    : ' closed'}
-                </b>{' '}
-                for reapproval requests and
-                <b
-                  className={
-                    registrationQueueSettings.new_approval_queue_open
-                      ? 'has-text-success'
-                      : 'has-text-danger'
-                  }
-                >
-                  {registrationQueueSettings.new_approval_queue_open
-                    ? ' open'
-                    : ' closed'}
-                </b>{' '}
-                for new requests.
-                <span
-                  title={`Queue settings last updated at ${new Date(registrationQueueSettings.updated_at).toLocaleString()} by ${registrationQueueSettings.updated_by}`}
-                >
-                  <Icon name="clock" className="ml-1" />
-                </span>
-              </div>
-            </div>
-          </QueueSectionHeader>
-          <QueueSettingsButtonStack direction="row">
-            <QueueSettingsButton
-              open={registrationQueueSettings.reapproval_queue_open}
-              for="reapproval_queue_open"
-              setOpen={(open) =>
-                setRegistrationQueueSettings({
-                  ...registrationQueueSettings,
-                  reapproval_queue_open: open,
-                })
-              }
-            />
-            <QueueSettingsButton
-              open={registrationQueueSettings.new_approval_queue_open}
-              for="new_approval_queue_open"
-              setOpen={(open) =>
-                setRegistrationQueueSettings({
-                  ...registrationQueueSettings,
-                  new_approval_queue_open: open,
-                })
-              }
-            />
-          </QueueSettingsButtonStack>
-        </>
-      )}
-      <QueueTable clubs={pendingClubs} templates={templates} />
+      <QueueTable clubs={pendingClubs} />
       <SmallTitle>Other Clubs</SmallTitle>
       <div className="mt-3 mb-3">
         The table below shows a list of {OBJECT_NAME_PLURAL} that have been

--- a/frontend/components/Settings/QueueTab.tsx
+++ b/frontend/components/Settings/QueueTab.tsx
@@ -16,6 +16,22 @@ import {
 import { ModalContent } from '../ClubPage/Actions'
 import { Checkbox, Icon, Modal } from '../common'
 
+type ClubDiff = {
+  description: {
+    old: string
+    new: string
+    diff: string
+  }
+  name: {
+    old: string
+    new: string
+  }
+  image: {
+    old: string
+    new: string
+  }
+}
+
 type QueueTableModalProps = {
   show: boolean
   closeModal: () => void
@@ -198,81 +214,85 @@ const QueueTable = ({ clubs }: QueueTableProps): ReactElement => {
 }
 
 const retrieveDiffs = async (club) => {
-  const resp = await doApiRequest(`/clubs/${club.code}/club_detail_diff/?format=json`, {
-    method: 'GET'
-  })
+  const resp = await doApiRequest(
+    `/clubs/${club.code}/club_detail_diff/?format=json`,
+    {
+      method: 'GET',
+    },
+  )
   const json = await resp.json()
   return json[club.code]
 }
 
 const ClubLink = ({ code, name }: Club) => (
-  <Link href={CLUB_ROUTE()} as={CLUB_ROUTE(code)} target="_blank" style={{marginRight: "1rem"}}>
+  <Link
+    href={CLUB_ROUTE()}
+    as={CLUB_ROUTE(code)}
+    target="_blank"
+    style={{ marginRight: '1rem' }}
+  >
     {name}
   </Link>
 )
 
-const ClubTags = ({ code, name, }: Club) : ReactElement => {
-  
-  const tagList : string[][] = []
-  
-  const [diffs, setDiffs] = useState(null);
-    
+const ClubTags = ({ code, name }: Club): ReactElement => {
+  const tagList: string[][] = []
+
+  const [diffs, setDiffs] = useState<ClubDiff | null>(null)
+
   const retrieveDiffs = async () => {
-    const resp = await doApiRequest(`/clubs/${code}/club_detail_diff/?format=json`, {
-      method: 'GET'
-    })
+    const resp = await doApiRequest(
+      `/clubs/${code}/club_detail_diff/?format=json`,
+      {
+        method: 'GET',
+      },
+    )
     const json = await resp.json()
     return json[code]
   }
 
   useEffect(() => {
     const fetchDiffs = async () => {
-      const resp = await retrieveDiffs();
-      setDiffs(resp);
-    };
-    fetchDiffs();
-  }, [code]);
+      const resp = await retrieveDiffs()
+      setDiffs(resp)
+    }
+    fetchDiffs()
+  }, [code])
 
-  if (diffs != null) {
-    const oldDescription : String = diffs["description"]["old"] ?? ""
-    const newDescription : String = diffs["description"]["new"] ?? ""
-    const oldTitle : String = diffs["name"]["old"]
-    const newTitle : String = diffs["name"]["new"] ?? ""
-    const oldImage : String = diffs["image"]["old"] ?? ""
-    const newImage : String = diffs["image"]["new"] ?? ""
-  
+  if (diffs !== null) {
+    const oldDescription: string = diffs.description.old ?? ''
+    const newDescription: string = diffs.description.new ?? ''
+    const oldTitle: string = diffs.name.old
+    const newTitle: string = diffs.name.new ?? ''
+    const oldImage: string = diffs.image.old ?? ''
+    const newImage: string = diffs.image.new ?? ''
+
     if (oldTitle == null) {
-      tagList.push(["New Club", "#8467c2"])
-    } 
-    else {
-      if (oldTitle.valueOf() != (newTitle.valueOf())){     
-        tagList.push(["Title", "#4198db"])
+      tagList.push(['New Club', '#8467c2'])
+    } else {
+      if (oldTitle.valueOf() !== newTitle.valueOf()) {
+        tagList.push(['Title', '#4198db'])
       }
-      if (oldDescription.valueOf() != newDescription.valueOf()){
-        tagList.push(["Desc", "#ee4768"])
+      if (oldDescription.valueOf() !== newDescription.valueOf()) {
+        tagList.push(['Desc', '#ee4768'])
       }
-      if (oldImage != newImage){
-        tagList.push(["Image", "#4cc776"])
+      if (oldImage !== newImage) {
+        tagList.push(['Image', '#4cc776'])
       }
     }
   }
-  
+
   return (
     <>
       {tagList.map(([text, color]) => {
-        return (
-          <TableTag style={{backgroundColor: color}}>
-            {text}
-          </TableTag>
-        )
+        return <TableTag style={{ backgroundColor: color }}>{text}</TableTag>
       })}
     </>
   )
 }
 
-
 const TableRow = styled.td`
-  display: flex;  
+  display: flex;
 `
 
 const TableTag = styled.div`


### PR DESCRIPTION
Main features:

- In the admin queue there are now tags denoting whether a club is new or has an updated name/title/description
- If a club is pending approval, administrators now see the difference between the old and new versions. Red highlighting denotes text being removed. Green denotes text being added, and yellow denotes style changes that did not involve the actual content (e.g. changing the font size of text).

Flow:

1. Engineering Student creates a club

<img width="1274" alt="newClubQueue" src="https://github.com/user-attachments/assets/981304a1-7a5c-4d8f-afcf-2ca1abc279f4" />
<img width="1280" alt="newClubDiff" src="https://github.com/user-attachments/assets/f68f2582-3043-446f-8e61-edb2c5bd919d" />

2. Engineering student updates description

Admin perspective:

<img width="1277" alt="DIff" src="https://github.com/user-attachments/assets/85217c99-b924-4f56-b36f-5aab3cdd4d15" />

Student perpspective:

<img width="1280" alt="julaieng" src="https://github.com/user-attachments/assets/7c734b36-eb27-4c6b-bc4c-59f0630b20c1" />

Main modifications:

Serializers.py
(1238-1308) - Function for calculating difference between HTML files and visually constructing them
(972 - 1010) - Created a serializer for club-detail-diff function that uses above diff function to add fields for header and description

Views.py
(2175 - 2274) - Modified queryset and club detail diff to integrate with serializer

Description.tsx + Header.tsx: Updated to render diffs when admin is viewing the file and the club is pending

Current issues:

- Noticed on 4/18 that React sometimes crashes upon the moment you reject a club. This isn't related to this PR, as it happened when I tested on master as well. 
- The admin queue does not update in real time, will look into. 