### PR TITLE
Move from badges -> affiliations on frontend only

### DIFF
--- a/frontend/components/ClubEditPage/ClubManagementCard.tsx
+++ b/frontend/components/ClubEditPage/ClubManagementCard.tsx
@@ -13,7 +13,7 @@ import {
   Text,
 } from '~/components/common'
 import { CLUB_ROUTE } from '~/constants'
-import { Badge, Club } from '~/types'
+import { Affiliation, Club } from '~/types'
 import { doApiRequest } from '~/utils'
 import {
   OBJECT_NAME_PLURAL,
@@ -60,87 +60,90 @@ type ClubManagementCardProps = {
 const ClubManagementCard = ({
   club,
 }: ClubManagementCardProps): ReactElement<any> => {
-  const [badges, setBadges] = useState<Badge[] | null>(null)
-  const [activeBadge, setActiveBadge] = useState<Badge | null>(null)
+  const [affiliations, setAffiliations] = useState<Affiliation[] | null>(null)
+  const [activeAffiliation, setActiveAffiliation] =
+    useState<Affiliation | null>(null)
   const [clubs, setClubs] = useState<Club[] | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
 
   const reloadOwned = () => {
     doApiRequest(`/clubs/${club.code}/owned_badges/?format=json`)
       .then((resp) => resp.json())
-      .then((badges) => {
-        setBadges(badges)
-        setActiveBadge(badges[0])
+      .then((affiliations) => {
+        setAffiliations(affiliations)
+        setActiveAffiliation(affiliations[0])
       })
   }
 
   useEffect(reloadOwned, [])
 
   useEffect(() => {
-    if (activeBadge != null) {
-      doApiRequest(`/badges/${activeBadge.id}/clubs/?format=json`)
+    if (activeAffiliation != null) {
+      doApiRequest(`/badges/${activeAffiliation.id}/clubs/?format=json`)
         .then((resp) => resp.json())
         .then(setClubs)
     } else {
       setClubs(null)
     }
-  }, [activeBadge])
+  }, [activeAffiliation])
 
   return (
     <>
       <Text>
         If {club.name} is an umbrella {OBJECT_NAME_SINGULAR}, you can use this
-        page to assign badges to {OBJECT_NAME_PLURAL} that are associated with
-        your {OBJECT_NAME_SINGULAR}. All of the badges you have access to are
-        shown below.
+        page to assign affiliations to {OBJECT_NAME_PLURAL} that are associated
+        with your {OBJECT_NAME_SINGULAR}. All of the affiliations you have
+        access to are shown below.
       </Text>
-      {badges != null ? (
+      {affiliations != null ? (
         <div className="columns">
           <div className="column is-one-third">
             <aside className="menu">
-              <p className="menu-label">Your Badges</p>
+              <p className="menu-label">Your Affiliations</p>
               <ul className="menu-list">
-                {badges.map((badge) => (
-                  <li key={badge.id}>
+                {affiliations.map((affiliation) => (
+                  <li key={affiliation.id}>
                     <a
                       className={
-                        badge.id === activeBadge?.id ? 'is-active' : undefined
+                        affiliation.id === activeAffiliation?.id
+                          ? 'is-active'
+                          : undefined
                       }
                       onClick={(e) => {
                         e.preventDefault()
-                        setActiveBadge(badge)
+                        setActiveAffiliation(affiliation)
                       }}
                     >
-                      {badge.label}
+                      {affiliation.label}
                     </a>
                   </li>
                 ))}
-                {badges.length <= 0 && <li>No Badges</li>}
+                {affiliations.length <= 0 && <li>No Affiliations</li>}
               </ul>
             </aside>
           </div>
           <div className="column">
-            {activeBadge != null ? (
+            {activeAffiliation != null ? (
               <>
                 <Subtitle>
                   <Tag
                     className="tag is-rounded mt-1"
                     color={
-                      activeBadge.color.length > 0
-                        ? activeBadge.color
+                      activeAffiliation.color.length > 0
+                        ? activeAffiliation.color
                         : 'd3d3d3'
                     }
                   >
-                    {activeBadge.label}
+                    {activeAffiliation.label}
                   </Tag>{' '}
-                  {activeBadge.description}
+                  {activeAffiliation.description}
                 </Subtitle>
                 {clubs != null ? (
                   <>
                     <Text>
                       There are {clubs.length} {OBJECT_NAME_PLURAL} with this
-                      badge. You can use the form below to add this badge to a{' '}
-                      {OBJECT_NAME_SINGULAR}.
+                      affiliation. You can use the form below to add this
+                      affiliation to a {OBJECT_NAME_SINGULAR}.
                     </Text>
                     <div className="mb-5">
                       <Formik
@@ -152,21 +155,25 @@ const ClubManagementCard = ({
                             toast.error(
                               <>
                                 You must specify a club to add the{' '}
-                                <b>{activeBadge.label}</b> badge to.
+                                <b>{activeAffiliation.label}</b> affiliation to.
                               </>,
                             )
                             setSubmitting(false)
                             return
                           }
-                          doApiRequest(`/badges/${activeBadge.id}/clubs/`, {
-                            method: 'POST',
-                            body: data,
-                          }).then(() => {
+                          doApiRequest(
+                            `/badges/${activeAffiliation.id}/clubs/`,
+                            {
+                              method: 'POST',
+                              body: data,
+                            },
+                          ).then(() => {
                             setSubmitting(false)
                             reloadOwned()
                             toast.success(
                               <>
-                                Added badge <b>{activeBadge.label}</b> to{' '}
+                                Added affiliation{' '}
+                                <b>{activeAffiliation.label}</b> to{' '}
                                 {OBJECT_NAME_SINGULAR} <b>{data.club}</b>.
                               </>,
                             )
@@ -183,7 +190,7 @@ const ClubManagementCard = ({
                                 className="button is-success is-small"
                                 disabled={isSubmitting}
                               >
-                                <Icon name="plus" /> Add Badge to{' '}
+                                <Icon name="plus" /> Add Affiliation to{' '}
                                 {OBJECT_NAME_TITLE_SINGULAR}
                               </button>
                             </FormStyle>
@@ -217,21 +224,21 @@ const ClubManagementCard = ({
                                 )
                                 setLoading(true)
                                 doApiRequest(
-                                  `/badges/${activeBadge.id}/clubs/${club.code}/?format=json`,
+                                  `/badges/${activeAffiliation.id}/clubs/${club.code}/?format=json`,
                                   { method: 'DELETE' },
                                 ).then(() => {
                                   toast.success(
                                     <>
-                                      Removed badge <b>{activeBadge.label}</b>{' '}
-                                      from {OBJECT_NAME_SINGULAR}{' '}
-                                      <b>{club.name}</b>.
+                                      Removed affiliation{' '}
+                                      <b>{activeAffiliation.label}</b> from{' '}
+                                      {OBJECT_NAME_SINGULAR} <b>{club.name}</b>.
                                     </>,
                                   )
                                   setLoading(false)
                                 })
                               }}
                             >
-                              Remove Badge
+                              Remove Affiliation
                             </button>
                           </div>
                         </div>
@@ -245,8 +252,8 @@ const ClubManagementCard = ({
             ) : (
               <Text>
                 It does not look like your {OBJECT_NAME_PLURAL} has access to
-                any badges. If you believe this is a mistake, please contact{' '}
-                <Contact />.
+                any affiliations. If you believe this is a mistake, please
+                contact <Contact />.
               </Text>
             )}
           </div>

--- a/frontend/components/ClubPage/Header.tsx
+++ b/frontend/components/ClubPage/Header.tsx
@@ -35,7 +35,7 @@ type ClubDiff = {
 }
 
 const Header = ({ club, style }: HeaderProps): ReactElement => {
-  const { active, name, tags, badges } = club
+  const { active, name, tags, affiliations } = club
   const canApprove = apiCheckPermission('clubs.approve_club')
 
   const NewHeader = () => {
@@ -48,7 +48,7 @@ const Header = ({ club, style }: HeaderProps): ReactElement => {
           </Title>
         </Wrapper>
         <div style={{ marginBottom: '1rem' }}>
-          <TagGroup tags={[...tags, ...badges]} />
+          <TagGroup tags={[...tags, ...affiliations]} />
         </div>
       </div>
     )
@@ -105,7 +105,7 @@ const Header = ({ club, style }: HeaderProps): ReactElement => {
           </Title>
         </Wrapper>
         <div style={{ marginBottom: '1rem' }}>
-          <TagGroup tags={[...tags, ...badges]} />
+          <TagGroup tags={[...tags, ...affiliations]} />
         </div>
       </div>
     )

--- a/frontend/components/Settings/BulkEditTab.tsx
+++ b/frontend/components/Settings/BulkEditTab.tsx
@@ -2,7 +2,7 @@ import { Field, Form, Formik } from 'formik'
 import React, { ReactElement, useState } from 'react'
 import { toast } from 'react-toastify'
 
-import { Badge, ClubFair, Tag } from '../../types'
+import { Affiliation, ClubFair, Tag } from '../../types'
 import { doApiRequest } from '../../utils'
 import {
   OBJECT_NAME_PLURAL,
@@ -64,10 +64,10 @@ const ClubNameLookup = (): ReactElement<any> => {
 export interface BulkEditTabProps {
   tags: Tag[]
   clubfairs: ClubFair[]
-  badges: Badge[]
+  affiliations: Affiliation[]
 }
 
-const BulkEditTab = ({ tags, clubfairs, badges }: BulkEditTabProps) => {
+const BulkEditTab = ({ tags, clubfairs, affiliations }: BulkEditTabProps) => {
   const bulkSubmit = async (data, { setSubmitting }) => {
     try {
       const resp = await doApiRequest('/clubs/bulk/?format=json', {
@@ -185,9 +185,9 @@ const BulkEditTab = ({ tags, clubfairs, badges }: BulkEditTabProps) => {
               />
               <Field
                 name="badges"
-                label="Badges"
+                label="Affiliations"
                 as={SelectField}
-                choices={badges}
+                choices={affiliations}
                 deserialize={({ id, label, description, purpose }) => ({
                   value: id,
                   label,
@@ -205,9 +205,9 @@ const BulkEditTab = ({ tags, clubfairs, badges }: BulkEditTabProps) => {
                     <span className="has-text-grey">{description}</span>
                   </>
                 )}
-                valueDeserialize={fixDeserialize(badges)}
+                valueDeserialize={fixDeserialize(affiliations)}
                 isMulti
-                helpText={`Add or remove all of the specified badges.`}
+                helpText={`Add or remove all of the specified affiliations.`}
               />
               <Field
                 name="fairs"

--- a/frontend/components/common/TagGroup.tsx
+++ b/frontend/components/common/TagGroup.tsx
@@ -1,13 +1,13 @@
 import { ReactElement } from 'react'
 
-import { Badge, Tag } from '../../types'
+import { Affiliation, Tag } from '../../types'
 import { BlueTag, Tag as DefaultTag } from './Tags'
 
 type TagGroupProps = {
-  tags?: (Tag | Badge)[]
+  tags?: (Tag | Affiliation)[]
 }
 
-function isBadge(tag): tag is Badge {
+function isAffiliation(tag): tag is Affiliation {
   return tag.label !== undefined || tag.color !== undefined
 }
 
@@ -16,15 +16,15 @@ export const TagGroup = ({
 }: TagGroupProps): ReactElement<any> | null => {
   if (!tags || !tags.length) return null
 
-  // sometimes there will be duplicate badges, or a badge will end up with the same content as a tag
-  // when there are duplicate badges, choose one arbitrarily
-  // when there's a tag and a badge with the same content, render the badge
+  // sometimes there will be duplicate affiliations, or an affiliation will end up with the same content as a tag
+  // when there are duplicate affiliations, choose one arbitrarily
+  // when there's a tag and an affiliation with the same content, render the affiliation
 
   const uniqueTags = tags.reduce((acc, tag) => {
-    const key = isBadge(tag) ? tag.label : tag.name
+    const key = isAffiliation(tag) ? tag.label : tag.name
     if (!acc.has(key)) {
       acc.set(key, tag)
-    } else if (isBadge(tag)) {
+    } else if (isAffiliation(tag)) {
       acc.set(key, tag)
     }
     return acc
@@ -32,20 +32,20 @@ export const TagGroup = ({
 
   return (
     <>
-      {Array.from(uniqueTags.values()) // display badges after tags
+      {Array.from(uniqueTags.values()) // display affiliations after tags
         .sort((a, b) => {
-          if (isBadge(a) && !isBadge(b)) return 1
-          if (!isBadge(a) && isBadge(b)) return -1
-          if (isBadge(a) && isBadge(b)) {
-            // badges should be sorted by color
+          if (isAffiliation(a) && !isAffiliation(b)) return 1
+          if (!isAffiliation(a) && isAffiliation(b)) return -1
+          if (isAffiliation(a) && isAffiliation(b)) {
+            // affiliations should be sorted by color
             return a.color.localeCompare(b.color)
           }
           return 0
         })
         .map((tag) =>
-          isBadge(tag) ? (
+          isAffiliation(tag) ? (
             <DefaultTag
-              key={`${tag.id}-badge`}
+              key={`${tag.id}-affiliation`}
               color={tag.color}
               className="tag is-rounded"
             >

--- a/frontend/components/reports/ReportForm.tsx
+++ b/frontend/components/reports/ReportForm.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import { Checkbox, CheckboxLabel, Icon, Text } from '../../components/common'
 import { CLUBS_GREY } from '../../constants/colors'
-import { Badge, Report, Tag } from '../../types'
+import { Affiliation, Report, Tag } from '../../types'
 import { doApiRequest } from '../../utils'
 import { OBJECT_NAME_PLURAL } from '../../utils/branding'
 import { CheckboxField, SelectField, TextField } from '../FormComponents'
@@ -41,7 +41,7 @@ const ReportBox = ({
 type Props = {
   fields: [string, [string, string][]][]
   initial?: Report
-  badges: Badge[]
+  affiliations: Affiliation[]
   tags: Tag[]
   onSubmit: (report: Report) => void
 }
@@ -76,7 +76,7 @@ const ReportForm = ({
   fields,
   onSubmit,
   initial,
-  badges,
+  affiliations,
   tags,
 }: Props): ReactElement<any> => {
   const generateCheckboxGroup = (
@@ -263,12 +263,12 @@ const ReportForm = ({
               />
               <Field
                 name="badges__in"
-                label="Badges"
+                label="Affiliations"
                 as={SelectField}
-                choices={badges}
-                valueDeserialize={fixDeserialize(badges)}
+                choices={affiliations}
+                valueDeserialize={fixDeserialize(affiliations)}
                 isMulti
-                helpText={`Select only ${OBJECT_NAME_PLURAL} with all of the specified badges.`}
+                helpText={`Select only ${OBJECT_NAME_PLURAL} with all of the specified affiliations.`}
               />
             </ReportBox>
             <ReportBox title="Included Fields">

--- a/frontend/components/reports/ReportPage.tsx
+++ b/frontend/components/reports/ReportPage.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router'
 import React, { ReactElement, ReactNode } from 'react'
 
 import { BG_GRADIENT, REPORT_LIST_ROUTE, WHITE } from '../../constants'
-import { Badge, Report, Tag } from '../../types'
+import { Affiliation, Report, Tag } from '../../types'
 import { API_BASE_URL, apiCheckPermission, titleize } from '../../utils'
 import { OBJECT_NAME_TITLE_SINGULAR, SITE_NAME } from '../../utils/branding'
 import { Contact, Container, Icon, Metadata, Title } from '../common'
@@ -79,7 +79,7 @@ type EditReportPageProps = {
   nameToCode: { [cat: string]: { [key: string]: string } }
   report: Report | null
   authenticated: boolean | null
-  badges: Badge[]
+  affiliations: Affiliation[]
   tags: Tag[]
 }
 
@@ -87,7 +87,7 @@ export const EditReportPage = ({
   nameToCode,
   report,
   authenticated,
-  badges,
+  affiliations,
   tags,
 }: EditReportPageProps): ReactElement<any> => {
   const fields = Object.entries(nameToCode).map(([key, value]) => [
@@ -118,7 +118,7 @@ export const EditReportPage = ({
       authenticated={authenticated}
     >
       <ReportForm
-        badges={badges}
+        affiliations={affiliations}
         tags={tags}
         fields={fields}
         onSubmit={(report: Report): void => {

--- a/frontend/pages/admin/[[...slug]].tsx
+++ b/frontend/pages/admin/[[...slug]].tsx
@@ -11,7 +11,7 @@ import { NextPageContext } from 'next'
 import { useRouter } from 'next/router'
 import React, { ReactElement } from 'react'
 import renderPage from 'renderPage'
-import { Badge, ClubFair, Report, Tag, Template } from 'types'
+import { Affiliation, ClubFair, Report, Tag, Template } from 'types'
 import { apiCheckPermission, doBulkLookup } from 'utils'
 
 import TemplatesTab from '~/components/Settings/TemplatesTab'
@@ -20,7 +20,7 @@ import { ADMIN_ROUTE, BG_GRADIENT, WHITE } from '~/constants'
 function AdminPage({
   userInfo,
   tags,
-  badges,
+  affiliations,
   templates,
   clubfairs,
   scripts,
@@ -47,7 +47,11 @@ function AdminPage({
       name: 'bulk',
       label: 'Club Management',
       content: () => (
-        <BulkEditTab badges={badges} clubfairs={clubfairs} tags={tags} />
+        <BulkEditTab
+          affiliations={affiliations}
+          clubfairs={clubfairs}
+          tags={tags}
+        />
       ),
     },
     {
@@ -105,7 +109,7 @@ function AdminPage({
 
 type BulkResp = {
   tags: Tag[]
-  badges: Badge[]
+  affiliations: Affiliation[]
   templates: Template[]
   clubfairs: ClubFair[]
   scripts: any[]
@@ -116,7 +120,7 @@ AdminPage.getInitialProps = async (ctx: NextPageContext) => {
   const data: BulkResp = (await doBulkLookup(
     [
       'tags',
-      ['badges', '/badges/?all=true&format=json'],
+      ['affiliations', '/badges/?all=true&format=json'],
       'templates',
       'clubfairs',
       'scripts',

--- a/frontend/pages/admin/reports/[report]/index.tsx
+++ b/frontend/pages/admin/reports/[report]/index.tsx
@@ -2,13 +2,13 @@ import { EditReportPage } from 'components/reports/ReportPage'
 import { NextPageContext } from 'next'
 import { ReactElement } from 'react'
 import renderPage from 'renderPage'
-import { Badge, Report, Tag } from 'types'
+import { Affiliation, Report, Tag } from 'types'
 import { doBulkLookup } from 'utils'
 
 type CreateReportPageProps = {
   nameToCode: { [cat: string]: { [key: string]: string } }
   authenticated: boolean | null
-  badges: Badge[]
+  affiliations: Affiliation[]
   tags: Tag[]
   report: Report
 }
@@ -21,7 +21,7 @@ CreateReportPage.getInitialProps = async (ctx: NextPageContext) => {
   return await doBulkLookup(
     [
       ['nameToCode', '/clubs/fields/?format=json'],
-      ['badges', '/badges/?format=json'],
+      ['affiliations', '/badges/?format=json'],
       ['tags', '/tags/?format=json'],
       ['report', `/reports/${ctx.query.report}/?format=json`],
     ],

--- a/frontend/pages/admin/reports/create.tsx
+++ b/frontend/pages/admin/reports/create.tsx
@@ -2,13 +2,13 @@ import { EditReportPage } from 'components/reports/ReportPage'
 import { NextPageContext } from 'next'
 import { ReactElement } from 'react'
 import renderPage from 'renderPage'
-import { Badge, Tag } from 'types'
+import { Affiliation, Tag } from 'types'
 import { doBulkLookup } from 'utils'
 
 type CreateReportPageProps = {
   nameToCode: { [cat: string]: { [key: string]: string } }
   authenticated: boolean | null
-  badges: Badge[]
+  affiliations: Affiliation[]
   tags: Tag[]
 }
 
@@ -20,7 +20,7 @@ CreateReportPage.getInitialProps = async (ctx: NextPageContext) => {
   return await doBulkLookup(
     [
       ['nameToCode', '/clubs/fields/?format=json'],
-      ['badges', '/badges/?format=json'],
+      ['affiliations', '/badges/?format=json'],
       ['tags', '/tags/?format=json'],
     ],
     ctx,

--- a/frontend/pages/club/[club]/index.tsx
+++ b/frontend/pages/club/[club]/index.tsx
@@ -204,13 +204,16 @@ const ClubPage = ({
       {userInfo != null && (
         <ClubApprovalDialog club={club} userInfo={userInfo} />
       )}
-      {club.badges.length > 0 &&
-        club.badges
-          .filter((badge) => badge.message && badge.message.length > 0)
-          .map((badge) => (
-            <div className="notification is-info is-light" key={badge.id}>
+      {club.affiliations.length > 0 &&
+        club.affiliations
+          .filter(
+            (affiliation) =>
+              affiliation.message && affiliation.message.length > 0,
+          )
+          .map((affiliation) => (
+            <div className="notification is-info is-light" key={affiliation.id}>
               <Icon name="alert-circle" style={{ marginTop: '-3px' }} />{' '}
-              {badge.message}
+              {affiliation.message}
             </div>
           ))}
       <div className="columns">

--- a/frontend/pages/events/[id]/index.tsx
+++ b/frontend/pages/events/[id]/index.tsx
@@ -465,9 +465,12 @@ const EventPage: React.FC<EventPageProps> = ({ baseProps, club, event }) => {
                 )}
               </Subtitle>
               <div>
-                {event.badges?.map((badge) => (
-                  <Tag key={badge.id} style={{ backgroundColor: badge.color }}>
-                    {badge.label}
+                {event.affiliations?.map((affiliation) => (
+                  <Tag
+                    key={affiliation.id}
+                    style={{ backgroundColor: affiliation.color }}
+                  >
+                    {affiliation.label}
                   </Tag>
                 ))}
               </div>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -25,7 +25,15 @@ import {
 } from 'react'
 import { PaginatedClubPage, renderListPage } from 'renderPage'
 import styled from 'styled-components'
-import { Badge, Maybe, School, StudentType, Tag, UserInfo, Year } from 'types'
+import {
+  Affiliation,
+  Maybe,
+  School,
+  StudentType,
+  Tag,
+  UserInfo,
+  Year,
+} from 'types'
 import { doApiRequest, doBulkLookup, isClubFieldShown, useSetting } from 'utils'
 import {
   OBJECT_NAME_PLURAL,
@@ -84,7 +92,7 @@ type SplashProps = {
   userInfo: UserInfo
   clubs: PaginatedClubPage
   tags: Tag[]
-  badges: Badge[]
+  affiliations: Affiliation[]
   schools: School[]
   years: Year[]
   studentTypes: StudentType[]
@@ -367,15 +375,15 @@ const Splash = (props: SplashProps): ReactElement<any> => {
     [props.tags],
   )
 
-  const badgeOptions = useMemo<FuseTag[]>(
+  const affiliationOptions = useMemo<FuseTag[]>(
     () =>
-      props.badges.map(({ id, label, color, description }) => ({
+      props.affiliations.map(({ id, label, color, description }) => ({
         value: id,
         label,
         color,
         description,
       })),
-    [props.badges],
+    [props.affiliations],
   )
 
   const applicationRequiredOptions = [
@@ -448,11 +456,11 @@ const Splash = (props: SplashProps): ReactElement<any> => {
             label="Tags"
             options={tagOptions}
           />
-          {isClubFieldShown('badges') && (
+          {isClubFieldShown('affiliations') && (
             <SearchBarTagItem
               param="badges__in"
-              label="Filters"
-              options={badgeOptions}
+              label="Affiliations"
+              options={affiliationOptions}
             />
           )}
           <SearchBarOptionItem param="ordering" label="Ordering" />
@@ -585,7 +593,7 @@ const Splash = (props: SplashProps): ReactElement<any> => {
               setSearchInput={setSearchInput}
               optionMapping={{
                 tags__in: tagOptions,
-                badges__in: badgeOptions,
+                badges__in: affiliationOptions,
                 application_required__in: applicationRequiredOptions,
                 size__in: sizeOptions,
                 target_schools__in: schoolOptions,

--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -23,7 +23,15 @@ import {
 } from './constants/colors'
 import { NAV_HEIGHT } from './constants/measurements'
 import { BODY_FONT } from './constants/styles'
-import { Badge, Club, School, StudentType, Tag, UserInfo, Year } from './types'
+import {
+  Affiliation,
+  Club,
+  School,
+  StudentType,
+  Tag,
+  UserInfo,
+  Year,
+} from './types'
 import {
   cache,
   doApiRequest,
@@ -394,7 +402,7 @@ export type PaginatedClubPage = {
 }
 
 type ListPageProps = {
-  badges: Badge[]
+  affiliations: Affiliation[]
   clubs: PaginatedClubPage
   schools: School[]
   studentTypes: StudentType[]
@@ -449,7 +457,7 @@ const getPublicCachedContent = async () => {
       ])
 
       return {
-        badges: badgesResponse as Badge[],
+        affiliations: badgesResponse as Affiliation[],
         schools: schoolResponse as School[],
         studentTypes: studentTypesResponse as StudentType[],
         tags: tagsResponse as Tag[],

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -51,7 +51,7 @@ export enum ClubEventType {
 
 export interface ClubEvent {
   showings?: EventShowing[]
-  badges: Badge[]
+  affiliations: Affiliation[]
   club: string | null
   club_name: string | null
   description: string
@@ -140,7 +140,7 @@ export interface Tag {
   clubs?: number
 }
 
-export interface Badge {
+export interface Affiliation {
   id: number
   label: string
   color: string
@@ -190,7 +190,7 @@ export interface Club {
   approved_by: string | null
   approved_comment: string | null
   available_virtually: boolean
-  badges: Badge[]
+  affiliations: Affiliation[]
   category: Category
   beta: boolean
   code: string

--- a/frontend/utils/branding.tsx
+++ b/frontend/utils/branding.tsx
@@ -51,7 +51,7 @@ const sites = {
     CLUB_FIELDS: [
       'accepting_members',
       'application_required',
-      'badges',
+      'affiliations',
       'email_public',
       'founded',
       'github',


### PR DESCRIPTION
This PR moves from using `badges` to `affilliations` in code and in communication, but maintains references in communication with the backend such as filters and routes. `badges in backend == affiliations on frontend`

Closses #822 