### PR TITLE
fix: harden HTML sanitization for applications, fairs, and imported events (XSS mitigation)

### DIFF
--- a/backend/clubs/management/commands/import_paideia_events.py
+++ b/backend/clubs/management/commands/import_paideia_events.py
@@ -10,6 +10,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from clubs.models import Club, Event, EventShowing
+from clubs.utils import clean
 
 
 class Command(BaseCommand):
@@ -43,7 +44,7 @@ class Command(BaseCommand):
                     ev.type = Event.OTHER
                     ev.code = event["slug"]
                     ev.name = unescape(event["title"]["rendered"])
-                    ev.description = unescape(event["excerpt"])
+                    ev.description = clean(unescape(event["excerpt"]))
                     ev.url = event["link"]
                     ev.save()
 

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -3276,6 +3276,12 @@ class ClubApplicationSerializer(ClubRouteMixin, serializers.ModelSerializer):
 
         return data
 
+    def validate_description(self, value):
+        """
+        Sanitize application description HTML with an allowlist and linkify URLs.
+        """
+        return clean(bleach.linkify(value))
+
     @transaction.atomic
     def save(self):
         application_obj = super().save()
@@ -3474,6 +3480,12 @@ class AdminNoteSerializer(ClubRouteMixin, serializers.ModelSerializer):
 
 class WritableClubFairSerializer(ClubFairSerializer):
     time = serializers.CharField(required=False, allow_blank=True)
+
+    def validate_information(self, value):
+        return clean(bleach.linkify(value))
+
+    def validate_registration_information(self, value):
+        return clean(bleach.linkify(value))
 
     class Meta(ClubFairSerializer.Meta):
         pass


### PR DESCRIPTION
#568 

- Sanitize HTML for content rendered via `dangerouslySetInnerHTML` by cleaning on the backend.
- Add allowlist-based sanitization for Club Applications and Club Fairs.
- Sanitize third-party imported event descriptions (SNF Paideia) before saving.