### PR TITLE
Optimize report generation

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -1176,7 +1176,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             # only prefetch members if exporting to Excel with "members" field
             if export_members:
                 membership_queryset = Membership.objects.select_related(
-                    "person", "person__profile"
+                    "person__profile"
                 )
 
                 queryset = queryset.prefetch_related(


### PR DESCRIPTION
One major problem with report generations before there's a N+1 query when the Members field is selected.  We solve this by prefetching person and person_profile associated with memberships of a club. In a local instance with 59 clubs, 3620 memberships, and 108 users, query runtime is decreased from ~50 seconds to ~2 seconds.

closes #839 