### PR TITLE
Added banner for incident status

### DIFF
--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -94,6 +94,7 @@ class BaseDocument extends Document {
             rel="stylesheet"
             key="editor-css"
           />
+          <script src="https://status.pennlabs.org/banner.js" defer />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
Reference for more information:
https://github.com/pennlabs/status/pull/4
https://github.com/pennlabs/office-hours-queue/pull/339

This is part of an ongoing effort to add status banners during incidents to every labs page when we're experiencing an outage.