### PR TITLE
Add custom subject to email blast

### DIFF
--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2725,6 +2725,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
                 {"detail": "Content must be specified"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        subject = request.data.get("subject", "").strip()
 
         target_role = roles[target]
 
@@ -2736,7 +2737,7 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
 
         send_mail_helper(
             name="blast",
-            subject=f"Update from {settings.BRANDING_SITE_NAME}",
+            subject=subject or f"Update from {settings.BRANDING_SITE_NAME}",
             emails=emails,
             context={
                 "sender": settings.BRANDING_SITE_NAME,

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -7,6 +7,7 @@ from collections import Counter
 from unittest.mock import MagicMock, patch
 
 from dateutil.parser import isoparse
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -4725,23 +4726,35 @@ class ClubTestCase(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Blast sent to 1 recipients", resp.data["detail"])
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            mail.outbox[-1].subject, f"Update from {settings.BRANDING_SITE_NAME}"
+        )
+
         resp = self.client.post(
             reverse("clubs-email-blast"),
-            {"target": "officers", "content": "test"},
+            {
+                "target": "officers",
+                "subject": "Custom Blast Subject",
+                "content": "test",
+            },
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Blast sent to 2 recipients", resp.data["detail"])
         self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(mail.outbox[-1].subject, "Custom Blast Subject")
 
         resp = self.client.post(
             reverse("clubs-email-blast"),
-            {"target": "all", "content": "test"},
+            {"target": "all", "subject": "   ", "content": "test"},
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Blast sent to 3 recipients", resp.data["detail"])
         self.assertEqual(len(mail.outbox), 3)
+        self.assertEqual(
+            mail.outbox[-1].subject, f"Update from {settings.BRANDING_SITE_NAME}"
+        )
 
     def test_application_submission_requires_complete_profile(self):
         """

--- a/frontend/components/Settings/BulkEditTab.tsx
+++ b/frontend/components/Settings/BulkEditTab.tsx
@@ -9,6 +9,7 @@ import {
   OBJECT_NAME_SINGULAR,
   OBJECT_NAME_TITLE,
   OBJECT_NAME_TITLE_SINGULAR,
+  SITE_NAME,
 } from '../../utils/branding'
 import { Icon, Text } from '../common'
 import { DateTimeField, SelectField, TextField } from '../FormComponents'
@@ -94,13 +95,13 @@ const BulkEditTab = ({ tags, clubfairs, affiliations }: BulkEditTabProps) => {
         <Text>
           Sends an email blast to the selected group of users. Select a target
           group and provide the message content. All active users with roles
-          equivalent to or higher than the selected group will be notified. The
-          subject line is nondescriptive, so it is recommended to explicitly
-          state the sender within the email body.
+          equivalent to or higher than the selected group will be notified.
+          Leave the subject blank to use the default subject line.
         </Text>
         <Formik
           initialValues={{
             target: { id: 'leaders', name: 'Leaders' },
+            subject: '',
             content: '',
           }}
           onSubmit={async (values, { setSubmitting, resetForm }) => {
@@ -111,19 +112,23 @@ const BulkEditTab = ({ tags, clubfairs, affiliations }: BulkEditTabProps) => {
                   method: 'POST',
                   body: {
                     target: values.target.id,
+                    subject: values.subject,
                     content: values.content,
                   },
                 },
               )
               const data = await resp.json()
-              if (data.error) {
-                toast.error(data.error, { hideProgressBar: true })
-              } else if (data.detail) {
+              if (resp.ok) {
                 toast.success(data.detail, { hideProgressBar: true })
+                resetForm()
+              } else {
+                toast.error(
+                  data.detail || data.error || 'Failed to send email blast.',
+                  { hideProgressBar: true },
+                )
               }
             } finally {
               setSubmitting(false)
-              resetForm()
             }
           }}
         >
@@ -138,6 +143,12 @@ const BulkEditTab = ({ tags, clubfairs, affiliations }: BulkEditTabProps) => {
                   { value: 'all', label: 'All' },
                 ]}
                 label="Target Group"
+              />
+              <Field
+                name="subject"
+                as={TextField}
+                label="Subject"
+                helpText={`Leave blank to use "Update from ${SITE_NAME}" as the subject line.`}
               />
               <Field
                 name="content"


### PR DESCRIPTION
this PR allows user to:
- set a custom subject. we currently have "Update from Penn Clubs" as the default subject for the email blast
- fixes toast bug that returns success even for 400 responses