### PR TITLE
Reject club permission

### DIFF
--- a/backend/clubs/migrations/0143_split_club_reject_permission.py
+++ b/backend/clubs/migrations/0143_split_club_reject_permission.py
@@ -27,15 +27,19 @@ def grant_reject_permission(apps, schema_editor):
     club_content_type, _ = ContentType.objects.using(database).get_or_create(
         app_label="clubs", model="club"
     )
-    reject_club, _ = Permission.objects.using(database).get_or_create(
+    # update_or_create rather than get_or_create: Django only ever creates
+    # missing permissions, so the label on an already-existing row is never
+    # refreshed from the model. approve_club exists on every deployed database
+    # already, and its label needs to say that it grants rejection too.
+    reject_club, _ = Permission.objects.using(database).update_or_create(
         content_type=club_content_type,
         codename="reject_club",
-        defaults={"name": "Can reject pending clubs"},
+        defaults={"name": "Can reject pending clubs (cannot approve)"},
     )
-    approve_club, _ = Permission.objects.using(database).get_or_create(
+    approve_club, _ = Permission.objects.using(database).update_or_create(
         content_type=club_content_type,
         codename="approve_club",
-        defaults={"name": "Can approve pending clubs"},
+        defaults={"name": "Can approve and reject pending clubs"},
     )
 
     # groups and users with approve_club keep the ability to reject clubs
@@ -63,8 +67,8 @@ class Migration(migrations.Migration):
             options={
                 "ordering": ["name"],
                 "permissions": [
-                    ("approve_club", "Can approve pending clubs"),
-                    ("reject_club", "Can reject pending clubs"),
+                    ("approve_club", "Can approve and reject pending clubs"),
+                    ("reject_club", "Can reject pending clubs (cannot approve)"),
                     (
                         "see_pending_clubs",
                         "View pending clubs that are not one's own",

--- a/backend/clubs/migrations/0143_split_club_reject_permission.py
+++ b/backend/clubs/migrations/0143_split_club_reject_permission.py
@@ -1,0 +1,87 @@
+"""
+OSA has more reviewers helping clear the backlog of pending clubs, but they
+should only be able to reject clubs, not approve them (final approval stays
+with existing OSA administrators).
+
+This migration splits the "approve_club" permission by introducing a
+dedicated "reject_club" permission. Existing "approve_club" holders are
+granted "reject_club" as well so their access is unchanged, and the
+"Reviewers (OSA)" group (added in 0142) is granted "reject_club" so they can
+now reject pending clubs, without gaining the ability to approve them.
+"""
+
+from django.conf import settings
+from django.db import migrations
+
+
+REVIEWER_GROUP_NAME = "Reviewers (OSA)"
+
+
+def grant_reject_permission(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+    User = apps.get_model(*settings.AUTH_USER_MODEL.split("."))
+    database = schema_editor.connection.alias
+
+    club_content_type, _ = ContentType.objects.using(database).get_or_create(
+        app_label="clubs", model="club"
+    )
+    reject_club, _ = Permission.objects.using(database).get_or_create(
+        content_type=club_content_type,
+        codename="reject_club",
+        defaults={"name": "Can reject pending clubs"},
+    )
+    approve_club, _ = Permission.objects.using(database).get_or_create(
+        content_type=club_content_type,
+        codename="approve_club",
+        defaults={"name": "Can approve pending clubs"},
+    )
+
+    # groups and users with approve_club keep the ability to reject clubs
+    for group in Group.objects.using(database).filter(permissions=approve_club):
+        group.permissions.add(reject_club)
+
+    for user in User.objects.using(database).filter(user_permissions=approve_club):
+        user.user_permissions.add(reject_club)
+
+    # reviewers can now reject pending clubs, but still cannot approve them
+    reviewer_group, _ = Group.objects.using(database).get_or_create(
+        name=REVIEWER_GROUP_NAME
+    )
+    reviewer_group.permissions.add(reject_club)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("clubs", "0142_create_osa_reviewers_group"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="club",
+            options={
+                "ordering": ["name"],
+                "permissions": [
+                    ("approve_club", "Can approve pending clubs"),
+                    ("reject_club", "Can reject pending clubs"),
+                    (
+                        "see_pending_clubs",
+                        "View pending clubs that are not one's own",
+                    ),
+                    (
+                        "see_fair_status",
+                        "See whether or not a club has registered for the SAC fair",
+                    ),
+                    ("manage_club", "Manipulate club object and related objects"),
+                    ("run_management_scripts", "Can run management scripts"),
+                    ("send_club_email_blast", "Can send club email blasts"),
+                    (
+                        "manage_registration_queue",
+                        "Can manage registration queue settings",
+                    ),
+                ],
+            },
+        ),
+        migrations.RunPython(grant_reject_permission, migrations.RunPython.noop),
+    ]

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -805,6 +805,7 @@ class Club(models.Model):
         ordering = ["name"]
         permissions = [
             ("approve_club", "Can approve pending clubs"),
+            ("reject_club", "Can reject pending clubs"),
             ("see_pending_clubs", "View pending clubs that are not one's own"),
             (
                 "see_fair_status",

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -804,8 +804,8 @@ class Club(models.Model):
     class Meta:
         ordering = ["name"]
         permissions = [
-            ("approve_club", "Can approve pending clubs"),
-            ("reject_club", "Can reject pending clubs"),
+            ("approve_club", "Can approve and reject pending clubs"),
+            ("reject_club", "Can reject pending clubs (cannot approve)"),
             ("see_pending_clubs", "View pending clubs that are not one's own"),
             (
                 "see_fair_status",

--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -152,10 +152,16 @@ class ClubPermission(permissions.BasePermission):
             return True
 
         # club approvers can update the club
-        if view.action in ["update", "partial_update"] and (
-            request.user.has_perm("clubs.approve_club")
-        ):
-            return True
+        if view.action in ["update", "partial_update"]:
+            if request.user.has_perm("clubs.approve_club"):
+                return True
+
+            # rejecters are only granted access to the approval fields
+            # themselves, not to general club editing
+            if request.user.has_perm("clubs.reject_club") and not (
+                set(request.data.keys()) - {"approved", "approved_comment"}
+            ):
+                return True
 
         # DRF calls DELETE "destroy", although ClubViewSet soft-archives the club.
         # Keep that action separate from global club management.

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2500,36 +2500,59 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
         Only users with specific permissions can modify the approval field.
 
         Approving a club (approved=True) requires clubs.approve_club. Rejecting
-        a club (approved=False) or writing the approval comment requires either
-        clubs.approve_club or clubs.reject_club.
+        a pending club (approved=False) requires either clubs.approve_club or
+        clubs.reject_club.
 
-        Resetting a club to pending (approved=None) is deliberately left to the
-        regular object permissions, since club officers use it to request
-        another review after addressing a rejection.
+        Club officers may reset their own rejected club to pending
+        (approved=None) to request another review. Approvers may also reset an
+        approval status or edit an approval comment.
         """
         approved_provided = "approved" in request.data
-        requested_approval = request.data.get("approved")
-        comment_provided = request.data.get("approved_comment", None) is not None
+        comment_provided = "approved_comment" in request.data
 
         if approved_provided or comment_provided:
-            if requested_approval is True:
-                # only users with approve permission can approve
-                if not request.user.has_perm("clubs.approve_club"):
-                    raise PermissionDenied
-            elif requested_approval is False or comment_provided:
-                # rejecting a club or writing the approval comment
-                if not (
-                    request.user.has_perm("clubs.approve_club")
-                    or request.user.has_perm("clubs.reject_club")
-                ):
-                    raise PermissionDenied
-
             # an approval request must not modify any other fields
             if set(request.data.keys()) - {"approved", "approved_comment"}:
                 raise DRFValidationError(
                     "You can only pass the approved and approved_comment fields "
                     "when performing club approval."
                 )
+
+            club = self.get_object()
+            can_approve = request.user.has_perm("clubs.approve_club")
+            can_reject = request.user.has_perm("clubs.reject_club")
+
+            if not approved_provided:
+                # Rejecters provide comments as part of the pending -> rejected
+                # transition; only approvers may edit a comment independently.
+                if not can_approve:
+                    raise PermissionDenied
+                return
+
+            # Normalize before authorization. DRF accepts values such as 1 and
+            # "true" for BooleanFields, so checking raw request values with
+            # identity comparisons would allow those forms to bypass this gate.
+            requested_approval = serializers.BooleanField(
+                allow_null=True
+            ).run_validation(request.data.get("approved"))
+
+            if requested_approval is True:
+                if not can_approve:
+                    raise PermissionDenied
+            elif requested_approval is False:
+                # Rejection is only a valid transition from pending.
+                if club.approved is not None or not (can_approve or can_reject):
+                    raise PermissionDenied
+            elif not can_approve:
+                # Non-approvers may only reset their own rejected club after
+                # addressing the rejection. They may not alter the comment.
+                membership = find_membership_helper(request.user, club)
+                is_officer = (
+                    membership is not None
+                    and membership.role <= Membership.ROLE_OFFICER
+                )
+                if club.approved is not False or not is_officer or comment_provided:
+                    raise PermissionDenied
 
         if request.data.get("fair", None) is not None:
             if set(request.data.keys()) - {"fair"}:

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -2498,14 +2498,31 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
     def check_approval_permission(self, request):
         """
         Only users with specific permissions can modify the approval field.
+
+        Approving a club (approved=True) requires clubs.approve_club. Rejecting
+        a club (approved=False) or writing the approval comment requires either
+        clubs.approve_club or clubs.reject_club.
+
+        Resetting a club to pending (approved=None) is deliberately left to the
+        regular object permissions, since club officers use it to request
+        another review after addressing a rejection.
         """
-        if (
-            request.data.get("approved", None) is not None
-            or request.data.get("approved_comment", None) is not None
-        ):
-            # users without approve permission cannot approve
-            if not request.user.has_perm("clubs.approve_club"):
-                raise PermissionDenied
+        approved_provided = "approved" in request.data
+        requested_approval = request.data.get("approved")
+        comment_provided = request.data.get("approved_comment", None) is not None
+
+        if approved_provided or comment_provided:
+            if requested_approval is True:
+                # only users with approve permission can approve
+                if not request.user.has_perm("clubs.approve_club"):
+                    raise PermissionDenied
+            elif requested_approval is False or comment_provided:
+                # rejecting a club or writing the approval comment
+                if not (
+                    request.user.has_perm("clubs.approve_club")
+                    or request.user.has_perm("clubs.reject_club")
+                ):
+                    raise PermissionDenied
 
             # an approval request must not modify any other fields
             if set(request.data.keys()) - {"approved", "approved_comment"}:
@@ -5656,6 +5673,7 @@ class UserGroupAPIView(APIView):
         """
         perms = [
             "approve_club",
+            "reject_club",
             "generate_reports",
             "manage_club",
             "manage_registration_queue",

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -9185,9 +9185,26 @@ class AdminNoteViewSet(viewsets.ModelViewSet):
 
 
 class ClubApprovalResponseTemplateViewSet(viewsets.ModelViewSet):
+    """
+    Templates are the canned reasons sent when a club is approved or rejected,
+    so anyone with approval authority needs to read them. Authoring them stays
+    with superusers.
+    """
+
     serializer_class = ClubApprovalResponseTemplateSerializer
     permission_classes = [IsSuperuser]
     lookup_field = "id"
+
+    def get_permissions(self):
+        if self.action in {"list", "retrieve"}:
+            return [
+                (
+                    DjangoPermission("clubs.approve_club")
+                    | DjangoPermission("clubs.reject_club")
+                    | IsSuperuser
+                )()
+            ]
+        return [IsSuperuser()]
 
     def get_queryset(self):
         return ClubApprovalResponseTemplate.objects.all().order_by("-created_at")

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1616,6 +1616,130 @@ class ClubTestCase(TestCase):
         self.assertIsNotNone(self.club1.approved_on)
         self.assertIsNotNone(self.club1.approved_by)
 
+    def test_club_reject_permission_split_from_approve(self):
+        """
+        A user with only clubs.reject_club can reject a pending club, but
+        cannot approve one. A user with neither permission can do neither.
+        """
+        content_type = ContentType.objects.get_for_model(Club)
+        reject_club = Permission.objects.get(
+            codename="reject_club", content_type=content_type
+        )
+        self.user2.user_permissions.add(reject_club)
+
+        self.club1.approved = None
+        self.club1.save(update_fields=["approved"])
+
+        self.client.login(username=self.user2.username, password="test")
+
+        # reject-only user cannot approve
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": True, "approved_comment": "Looks great!"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.club1.refresh_from_db()
+        self.assertIsNone(self.club1.approved)
+
+        # reject-only user can reject
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": False, "approved_comment": "Needs more info."},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.club1.refresh_from_db()
+        self.assertFalse(self.club1.approved)
+        self.assertEqual(self.club1.approved_comment, "Needs more info.")
+        self.assertEqual(self.club1.approved_by, self.user2)
+        self.assertIsNotNone(self.club1.approved_on)
+
+        # reject permission does not grant general club editing
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"name": "Renamed By Reviewer"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+
+        # ...nor can other fields be smuggled alongside an approval change
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": None, "name": "Renamed By Reviewer"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+        self.club1.refresh_from_db()
+        self.assertEqual(self.club1.name, "Test Club")
+
+        # user with neither permission can do neither
+        self.club1.approved = None
+        self.club1.save(update_fields=["approved"])
+
+        self.user2.user_permissions.remove(reject_club)
+        self.client.login(username=self.user2.username, password="test")
+
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": False, "approved_comment": "Needs more info."},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+
+    def test_club_approve_permission_still_grants_rejection(self):
+        """
+        Splitting out clubs.reject_club must not remove the ability of existing
+        clubs.approve_club holders to reject clubs.
+        """
+        content_type = ContentType.objects.get_for_model(Club)
+        self.user2.user_permissions.add(
+            Permission.objects.get(codename="approve_club", content_type=content_type)
+        )
+        self.club1.approved = None
+        self.club1.save(update_fields=["approved"])
+
+        self.client.login(username=self.user2.username, password="test")
+
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": False, "approved_comment": "Not this year."},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.club1.refresh_from_db()
+        self.assertFalse(self.club1.approved)
+
+    def test_club_officer_can_request_review_without_approval_perms(self):
+        """
+        Officers reset a rejected club to pending to request another review,
+        which must not require any approval permission.
+        """
+        self.club1.approved = False
+        self.club1.save(update_fields=["approved"])
+        Membership.objects.create(
+            person=self.user2, club=self.club1, role=Membership.ROLE_OFFICER
+        )
+
+        self.client.login(username=self.user2.username, password="test")
+
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": None},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.club1.refresh_from_db()
+        self.assertIsNone(self.club1.approved)
+
+        # but officers still cannot write the approval comment themselves
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved_comment": "Approved by me"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+
     def test_club_display_after_deactivation_for_permissioned_vs_non_permissioned(self):
         """
         Test club retrieval after deactivation script runs. Non-permissioned users

--- a/backend/tests/clubs/test_views.py
+++ b/backend/tests/clubs/test_views.py
@@ -1655,6 +1655,51 @@ class ClubTestCase(TestCase):
         self.assertEqual(self.club1.approved_by, self.user2)
         self.assertIsNotNone(self.club1.approved_on)
 
+        # reject-only users cannot reset a rejected club to pending
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": None},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.club1.refresh_from_db()
+        self.assertFalse(self.club1.approved)
+
+        # serializer-coercible boolean values cannot bypass the approval check
+        self.club1.approved = None
+        self.club1.save(update_fields=["approved"])
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": 1},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.club1.refresh_from_db()
+        self.assertIsNone(self.club1.approved)
+
+        # reject permission only applies to pending clubs
+        self.club1.approved = True
+        self.club1.approved_comment = "Original comment"
+        self.club1.save(update_fields=["approved", "approved_comment"])
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": False, "approved_comment": "Unauthorized rejection"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.club1.refresh_from_db()
+        self.assertTrue(self.club1.approved)
+
+        # ...and does not allow comments to be edited independently
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved_comment": "Tampered comment"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.club1.refresh_from_db()
+        self.assertEqual(self.club1.approved_comment, "Original comment")
+
         # reject permission does not grant general club editing
         resp = self.client.patch(
             reverse("clubs-detail", args=(self.club1.code,)),
@@ -1739,6 +1784,17 @@ class ClubTestCase(TestCase):
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, 403, resp.content)
+
+        # DRF coerces numeric and string boolean values after permission checks;
+        # officers still must not be able to use those forms to self-approve.
+        resp = self.client.patch(
+            reverse("clubs-detail", args=(self.club1.code,)),
+            {"approved": 1},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.club1.refresh_from_db()
+        self.assertIsNone(self.club1.approved)
 
     def test_club_display_after_deactivation_for_permissioned_vs_non_permissioned(self):
         """

--- a/frontend/components/ClubPage/ClubApprovalDialog.tsx
+++ b/frontend/components/ClubPage/ClubApprovalDialog.tsx
@@ -165,6 +165,8 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
   const [selectedTemplates, setSelectedTemplates] = useState<Template[]>([])
 
   const canApprove = apiCheckPermission('clubs.approve_club')
+  const canReject = apiCheckPermission('clubs.reject_club')
+  const canApproveOrReject = canApprove || canReject
   const seeFairStatus = apiCheckPermission('clubs.see_fair_status')
   const canDeleteClub = apiCheckPermission('clubs.delete_club')
 
@@ -182,13 +184,13 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
         .then(setFairs)
     }
 
-    if (canApprove) {
+    if (canApproveOrReject) {
       doApiRequest('/templates/?format=json')
         .then((resp) => resp.json())
         .then(setTemplates)
     }
 
-    if (isOfficer || canApprove) {
+    if (isOfficer || canApproveOrReject) {
       doApiRequest(`/clubs/${club.code}/history/?format=json`)
         .then((resp) => resp.json())
         .then((data) => {
@@ -339,20 +341,34 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
               </>
             )}
           </Text>
-          {(canApprove || canDeleteClub) && (
+          {(canApproveOrReject || canDeleteClub) && (
             <>
-              {canApprove && club.active && (
+              {canApproveOrReject && club.active && (
                 <>
                   <div className="mb-3">
-                    As an administrator for {SITE_NAME}, you can approve or
-                    reject this request. Approving this request will display it
-                    publically on the {SITE_NAME} website and send out an email
-                    notifying {OBJECT_NAME_SINGULAR} members that their{' '}
-                    {OBJECT_NAME_SINGULAR} has been renewed. Rejecting this
-                    request will send out an email notifying{' '}
-                    {OBJECT_NAME_SINGULAR} members that their{' '}
-                    {OBJECT_NAME_SINGULAR} was not approved and include
-                    instructions on how to request approval again.
+                    As an administrator for {SITE_NAME}, you can{' '}
+                    {canApprove && canReject
+                      ? 'approve or reject'
+                      : canApprove
+                        ? 'approve'
+                        : 'reject'}{' '}
+                    this request.{' '}
+                    {canApprove && (
+                      <>
+                        Approving this request will display it publically on the{' '}
+                        {SITE_NAME} website and send out an email notifying{' '}
+                        {OBJECT_NAME_SINGULAR} members that their{' '}
+                        {OBJECT_NAME_SINGULAR} has been renewed.{' '}
+                      </>
+                    )}
+                    {canReject && (
+                      <>
+                        Rejecting this request will send out an email notifying{' '}
+                        {OBJECT_NAME_SINGULAR} members that their{' '}
+                        {OBJECT_NAME_SINGULAR} was not approved and include
+                        instructions on how to request approval again.
+                      </>
+                    )}
                   </div>
                   {club.files.length ? (
                     <div className="mb-3">
@@ -426,44 +442,44 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
               )}
               <div className="buttons">
                 {canApprove && club.active && (
-                  <>
-                    <button
-                      className="button is-success"
-                      disabled={loading}
-                      onClick={() => {
-                        setLoading(true)
-                        doApiRequest(`/clubs/${club.code}/?format=json`, {
-                          method: 'PATCH',
-                          body: {
-                            approved: true,
-                            approved_comment: comment,
-                          },
-                        })
-                          .then(() => router.reload())
-                          .finally(() => setLoading(false))
-                      }}
-                    >
-                      <Icon name="check" /> Approve
-                    </button>
-                    <button
-                      className="button is-danger"
-                      disabled={loading}
-                      onClick={() => {
-                        setLoading(true)
-                        doApiRequest(`/clubs/${club.code}/?format=json`, {
-                          method: 'PATCH',
-                          body: {
-                            approved: false,
-                            approved_comment: comment,
-                          },
-                        })
-                          .then(() => router.reload())
-                          .finally(() => setLoading(false))
-                      }}
-                    >
-                      <Icon name="x" /> Reject
-                    </button>
-                  </>
+                  <button
+                    className="button is-success"
+                    disabled={loading}
+                    onClick={() => {
+                      setLoading(true)
+                      doApiRequest(`/clubs/${club.code}/?format=json`, {
+                        method: 'PATCH',
+                        body: {
+                          approved: true,
+                          approved_comment: comment,
+                        },
+                      })
+                        .then(() => router.reload())
+                        .finally(() => setLoading(false))
+                    }}
+                  >
+                    <Icon name="check" /> Approve
+                  </button>
+                )}
+                {canReject && club.active && (
+                  <button
+                    className="button is-danger"
+                    disabled={loading}
+                    onClick={() => {
+                      setLoading(true)
+                      doApiRequest(`/clubs/${club.code}/?format=json`, {
+                        method: 'PATCH',
+                        body: {
+                          approved: false,
+                          approved_comment: comment,
+                        },
+                      })
+                        .then(() => router.reload())
+                        .finally(() => setLoading(false))
+                    }}
+                  >
+                    <Icon name="x" /> Reject
+                  </button>
                 )}
                 {canDeleteClub && (
                   <button

--- a/frontend/components/ClubPage/ClubApprovalDialog.tsx
+++ b/frontend/components/ClubPage/ClubApprovalDialog.tsx
@@ -165,8 +165,9 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
   const [selectedTemplates, setSelectedTemplates] = useState<Template[]>([])
 
   const canApprove = apiCheckPermission('clubs.approve_club')
-  const canReject = apiCheckPermission('clubs.reject_club')
-  const canApproveOrReject = canApprove || canReject
+  // approve_club carries rejection authority as well, so anyone who can
+  // approve can also reject
+  const canReject = canApprove || apiCheckPermission('clubs.reject_club')
   const seeFairStatus = apiCheckPermission('clubs.see_fair_status')
   const canDeleteClub = apiCheckPermission('clubs.delete_club')
 
@@ -184,7 +185,7 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
         .then(setFairs)
     }
 
-    if (canApproveOrReject) {
+    if (canReject) {
       // the templates endpoint is superuser only, so non-superuser reviewers
       // get an error object back rather than a list
       doApiRequest('/templates/?format=json')
@@ -192,7 +193,7 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
         .then((data) => setTemplates(Array.isArray(data) ? data : []))
     }
 
-    if (isOfficer || canApproveOrReject) {
+    if (isOfficer || canReject) {
       doApiRequest(`/clubs/${club.code}/history/?format=json`)
         .then((resp) => resp.json())
         .then((data) => {
@@ -343,9 +344,9 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
               </>
             )}
           </Text>
-          {(canApproveOrReject || canDeleteClub) && (
+          {(canReject || canDeleteClub) && (
             <>
-              {canApproveOrReject && club.active && (
+              {canReject && club.active && (
                 <>
                   <div className="mb-3">
                     As an administrator for {SITE_NAME}, you can{' '}

--- a/frontend/components/ClubPage/ClubApprovalDialog.tsx
+++ b/frontend/components/ClubPage/ClubApprovalDialog.tsx
@@ -185,9 +185,11 @@ const ClubApprovalDialog = ({ club }: Props): ReactElement<any> | null => {
     }
 
     if (canApproveOrReject) {
+      // the templates endpoint is superuser only, so non-superuser reviewers
+      // get an error object back rather than a list
       doApiRequest('/templates/?format=json')
         .then((resp) => resp.json())
-        .then(setTemplates)
+        .then((data) => setTemplates(Array.isArray(data) ? data : []))
     }
 
     if (isOfficer || canApproveOrReject) {

--- a/frontend/components/ClubPage/Description.tsx
+++ b/frontend/components/ClubPage/Description.tsx
@@ -40,7 +40,10 @@ type ClubDiff = {
 
 const Description = ({ club }: DescProps): ReactElement => {
   const [diffs, setDiffs] = useState<ClubDiff | null>(null)
-  const canApprove = apiCheckPermission('clubs.approve_club')
+  // reviewers who can only reject still need to see what changed
+  const canReviewApproval =
+    apiCheckPermission('clubs.approve_club') ||
+    apiCheckPermission('clubs.reject_club')
   const canDeleteClub = apiCheckPermission('clubs.delete_club')
 
   const NewDescription = () => {
@@ -60,7 +63,7 @@ const Description = ({ club }: DescProps): ReactElement => {
     )
   }
 
-  if (!canApprove || club.approved === false) {
+  if (!canReviewApproval || club.approved === false) {
     return <NewDescription />
   }
 

--- a/frontend/components/ClubPage/Header.tsx
+++ b/frontend/components/ClubPage/Header.tsx
@@ -36,7 +36,10 @@ type ClubDiff = {
 
 const Header = ({ club, style }: HeaderProps): ReactElement => {
   const { active, name, tags, affiliations, category, classification } = club
-  const canApprove = apiCheckPermission('clubs.approve_club')
+  // reviewers who can only reject still need to see what changed
+  const canReviewApproval =
+    apiCheckPermission('clubs.approve_club') ||
+    apiCheckPermission('clubs.reject_club')
 
   const NewHeader = () => {
     return (
@@ -56,7 +59,7 @@ const Header = ({ club, style }: HeaderProps): ReactElement => {
     )
   }
 
-  if (!canApprove || club.approved === false) {
+  if (!canReviewApproval || club.approved === false) {
     return <NewHeader />
   }
 
@@ -91,7 +94,7 @@ const Header = ({ club, style }: HeaderProps): ReactElement => {
     }, [club.code])
   }
 
-  if (diffs != null && canApprove) {
+  if (diffs != null && canReviewApproval) {
     const display = diffs.name.diff
     return (
       <div style={style}>

--- a/frontend/components/Settings/QueueTab.tsx
+++ b/frontend/components/Settings/QueueTab.tsx
@@ -827,9 +827,11 @@ const QueueTab = (): ReactElement => {
     }
 
     if (canApproveOrReject) {
+      // the templates endpoint is superuser only, so non-superuser reviewers
+      // get an error object back rather than a list
       doApiRequest('/templates/?format=json')
         .then((resp) => resp.json())
-        .then(setTemplates)
+        .then((data) => setTemplates(Array.isArray(data) ? data : []))
     }
 
     if (canApprove) {

--- a/frontend/components/Settings/QueueTab.tsx
+++ b/frontend/components/Settings/QueueTab.tsx
@@ -138,6 +138,7 @@ const QueueTableModal = ({
 
 type QueueTableProps = {
   canApprove: boolean
+  canReject: boolean
   clubs: Club[] | null
   refetchClubs?: () => void
   templates: Template[]
@@ -146,11 +147,13 @@ type QueueTableProps = {
 functionality are disconnected */
 const QueueTable = ({
   canApprove,
+  canReject,
   clubs,
   refetchClubs,
   templates,
 }: QueueTableProps): ReactElement => {
   const router = useRouter()
+  const canApproveOrReject = canApprove || canReject
   const [selectedCodes, setSelectedCodes] = useState<string[]>([])
   const [showModal, setShowModal] = useState<boolean>(false)
   const [approve, setApprove] = useState<boolean>(false)
@@ -184,7 +187,7 @@ const QueueTable = ({
 
   return (
     <>
-      {canApprove && (
+      {canApproveOrReject && (
         <QueueTableModal
           show={showModal}
           closeModal={() => setShowModal(false)}
@@ -201,35 +204,39 @@ const QueueTable = ({
             review. Click on the {OBJECT_NAME_SINGULAR} name to view the{' '}
             {OBJECT_NAME_SINGULAR}.
           </div>
-          {!canApprove && (
+          {!canApproveOrReject && (
             <div className="has-text-info mb-3">
               You do not have permission to approve or reject{' '}
               {OBJECT_NAME_PLURAL}.
             </div>
           )}
         </QueueSectionHeaderText>
-        {canApprove && (
+        {canApproveOrReject && (
           <div className="buttons">
-            <button
-              className="button is-success"
-              disabled={!selectedCodes.length || loading}
-              onClick={() => {
-                setApprove(true)
-                setShowModal(true)
-              }}
-            >
-              <Icon name="check" /> Approve
-            </button>
-            <button
-              className="button is-danger"
-              disabled={!selectedCodes.length || loading}
-              onClick={() => {
-                setApprove(false)
-                setShowModal(true)
-              }}
-            >
-              <Icon name="x" /> Reject
-            </button>
+            {canApprove && (
+              <button
+                className="button is-success"
+                disabled={!selectedCodes.length || loading}
+                onClick={() => {
+                  setApprove(true)
+                  setShowModal(true)
+                }}
+              >
+                <Icon name="check" /> Approve
+              </button>
+            )}
+            {canReject && (
+              <button
+                className="button is-danger"
+                disabled={!selectedCodes.length || loading}
+                onClick={() => {
+                  setApprove(false)
+                  setShowModal(true)
+                }}
+              >
+                <Icon name="x" /> Reject
+              </button>
+            )}
           </div>
         )}
       </QueueSectionHeader>
@@ -247,7 +254,7 @@ const QueueTable = ({
             <thead>
               <tr>
                 <th>
-                  {canApprove && (
+                  {canApproveOrReject && (
                     <Checkbox
                       className="mr-3"
                       checked={allClubsSelected}
@@ -266,7 +273,7 @@ const QueueTable = ({
               {clubs.map((club) => (
                 <tr key={club.code}>
                   <TableRow>
-                    {canApprove && (
+                    {canApproveOrReject && (
                       <Checkbox
                         className="mr-3"
                         checked={selectedCodes.includes(club.code)}
@@ -777,8 +784,11 @@ const QueueTab = (): ReactElement => {
   const [registrationQueueSettings, setRegistrationQueueSettings] =
     useState<RegistrationQueueSettings | null>(null)
   const canApprove = apiCheckPermission('clubs.approve_club') === true
+  const canReject = apiCheckPermission('clubs.reject_club') === true
+  const canApproveOrReject = canApprove || canReject
   const canSeePending = apiCheckPermission([
     'clubs.approve_club',
+    'clubs.reject_club',
     'clubs.manage_club',
     'clubs.see_pending_clubs',
   ])
@@ -816,11 +826,13 @@ const QueueTab = (): ReactElement => {
       refetchClubs()
     }
 
-    if (canApprove) {
+    if (canApproveOrReject) {
       doApiRequest('/templates/?format=json')
         .then((resp) => resp.json())
         .then(setTemplates)
+    }
 
+    if (canApprove) {
       doApiRequest('/clubs/any/ownershiprequests/all/?format=json')
         .then((resp) => resp.json())
         .then(setOwnershipRequests)
@@ -831,7 +843,7 @@ const QueueTab = (): ReactElement => {
         .then((resp) => resp.json())
         .then(setRegistrationQueueSettings)
     }
-  }, [canApprove, canManageQueue, canSeePending])
+  }, [canApprove, canReject, canManageQueue, canSeePending])
 
   if (!canSeePending && !canManageQueue) {
     return <div>You do not have permission to access the approval queue.</div>
@@ -1138,6 +1150,7 @@ const QueueTab = (): ReactElement => {
         <>
           <QueueTable
             canApprove={canApprove}
+            canReject={canReject}
             clubs={pendingClubs}
             refetchClubs={refetchClubs}
             templates={templates}

--- a/frontend/components/Settings/QueueTab.tsx
+++ b/frontend/components/Settings/QueueTab.tsx
@@ -153,7 +153,6 @@ const QueueTable = ({
   templates,
 }: QueueTableProps): ReactElement => {
   const router = useRouter()
-  const canApproveOrReject = canApprove || canReject
   const [selectedCodes, setSelectedCodes] = useState<string[]>([])
   const [showModal, setShowModal] = useState<boolean>(false)
   const [approve, setApprove] = useState<boolean>(false)
@@ -187,7 +186,7 @@ const QueueTable = ({
 
   return (
     <>
-      {canApproveOrReject && (
+      {canReject && (
         <QueueTableModal
           show={showModal}
           closeModal={() => setShowModal(false)}
@@ -204,14 +203,14 @@ const QueueTable = ({
             review. Click on the {OBJECT_NAME_SINGULAR} name to view the{' '}
             {OBJECT_NAME_SINGULAR}.
           </div>
-          {!canApproveOrReject && (
+          {!canReject && (
             <div className="has-text-info mb-3">
               You do not have permission to approve or reject{' '}
               {OBJECT_NAME_PLURAL}.
             </div>
           )}
         </QueueSectionHeaderText>
-        {canApproveOrReject && (
+        {canReject && (
           <div className="buttons">
             {canApprove && (
               <button
@@ -254,7 +253,7 @@ const QueueTable = ({
             <thead>
               <tr>
                 <th>
-                  {canApproveOrReject && (
+                  {canReject && (
                     <Checkbox
                       className="mr-3"
                       checked={allClubsSelected}
@@ -273,7 +272,7 @@ const QueueTable = ({
               {clubs.map((club) => (
                 <tr key={club.code}>
                   <TableRow>
-                    {canApproveOrReject && (
+                    {canReject && (
                       <Checkbox
                         className="mr-3"
                         checked={selectedCodes.includes(club.code)}
@@ -784,8 +783,10 @@ const QueueTab = (): ReactElement => {
   const [registrationQueueSettings, setRegistrationQueueSettings] =
     useState<RegistrationQueueSettings | null>(null)
   const canApprove = apiCheckPermission('clubs.approve_club') === true
-  const canReject = apiCheckPermission('clubs.reject_club') === true
-  const canApproveOrReject = canApprove || canReject
+  // approve_club carries rejection authority as well, so anyone who can
+  // approve can also reject
+  const canReject =
+    canApprove || apiCheckPermission('clubs.reject_club') === true
   const canSeePending = apiCheckPermission([
     'clubs.approve_club',
     'clubs.reject_club',
@@ -826,7 +827,7 @@ const QueueTab = (): ReactElement => {
       refetchClubs()
     }
 
-    if (canApproveOrReject) {
+    if (canReject) {
       // the templates endpoint is superuser only, so non-superuser reviewers
       // get an error object back rather than a list
       doApiRequest('/templates/?format=json')

--- a/frontend/pages/admin/[[...slug]].tsx
+++ b/frontend/pages/admin/[[...slug]].tsx
@@ -19,6 +19,7 @@ import { ADMIN_ROUTE, BG_GRADIENT, WHITE } from '~/constants'
 
 const ADMIN_PERMISSIONS = [
   'clubs.approve_club',
+  'clubs.reject_club',
   'clubs.generate_reports',
   'clubs.manage_club',
   'clubs.manage_registration_queue',

--- a/frontend/pages/club/[club]/index.tsx
+++ b/frontend/pages/club/[club]/index.tsx
@@ -426,6 +426,7 @@ ClubPage.getAdditionalPermissions = (ctx: NextPageContext): string[] => {
 
 ClubPage.permissions = [
   'clubs.approve_club',
+  'clubs.reject_club',
   'clubs.see_fair_status',
   'clubs.delete_club',
 ]

--- a/frontend/pages/renew.tsx
+++ b/frontend/pages/renew.tsx
@@ -13,6 +13,7 @@ import { BG_GRADIENT, WHITE } from '~/constants/colors'
 function UserRenewal({ userInfo, authenticated }): ReactElement<any> {
   const canAccessQueue = apiCheckPermission([
     'clubs.approve_club',
+    'clubs.reject_club',
     'clubs.manage_club',
     'clubs.manage_registration_queue',
     'clubs.see_pending_clubs',
@@ -53,6 +54,7 @@ function UserRenewal({ userInfo, authenticated }): ReactElement<any> {
 
 UserRenewal.permissions = [
   'clubs.approve_club',
+  'clubs.reject_club',
   'clubs.manage_club',
   'clubs.manage_registration_queue',
   'clubs.see_pending_clubs',


### PR DESCRIPTION
Similar to #877 . Adding an additional permission `reject_club`, which gives permission to only reject, not approve a club. `approve_club` still means a user can approve OR reject a club. Adds this new permission to the Reviewers (OSA) group during migration.

Both `approve_club` and `reject_club` now can list/retrieve approval templates, but not create them.

# UI Changes:

## Only `approve_club` has approve button, `reject_club` only shows the reject button

<img width="2166" height="1131" alt="image" src="https://github.com/user-attachments/assets/502949f0-0aa8-4c05-b7b9-c0e22a99bcb1" />

## View of ClubApprovalDialog from Reviewer
<img width="2096" height="590" alt="image" src="https://github.com/user-attachments/assets/dbe6a07f-4d3b-48d4-b108-24f219973491" />