### PR TITLE
update conn_max_age to disable it, as it is not supported by asgi

### DIFF
--- a/backend/pennclubs/settings/base.py
+++ b/backend/pennclubs/settings/base.py
@@ -89,7 +89,7 @@ TEMPLATES = [
 
 DATABASES = {
     "default": dj_database_url.config(
-        default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3"), conn_max_age=20
+        default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3"), conn_max_age=0
     )
 }
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/6.1/topics/async/

I was looking at connections and saw penn-clubs holding over 400 connections by itself. I believe the problem has to do with Django ASGI and a setting we had on which would leak DB connections (conn_max_age).

> [Persistent database connections](https://docs.djangoproject.com/en/6.1/ref/databases/#persistent-database-connections), set via the [CONN_MAX_AGE](https://docs.djangoproject.com/en/6.1/ref/settings/#std-setting-CONN_MAX_AGE) setting, should also be disabled in async mode. Instead, use your database backend’s built-in connection pooling if available, or investigate a third-party connection pooling option if required. As in synchronous Django, concurrent requests in a single process share that pool, so size it to the target in-flight query concurrency.

We also don't have pooling, we should set up PgBouncer soon!