### PR TITLE
Keep the status banner and navbar pinned together on scroll

### DIFF
--- a/frontend/components/BaseLayout.tsx
+++ b/frontend/components/BaseLayout.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import AuthPrompt from '~/components/common/AuthPrompt'
 import Footer from '~/components/Footer'
 import Header from '~/components/Header'
-import { NAV_HEIGHT, SNOW } from '~/constants'
+import { NAV_HEIGHT, SNOW, STATUS_BANNER_HEIGHT } from '~/constants'
 import { RenderPageWrapper, ToastStyle } from '~/renderPage'
 import { PermissionsContext } from '~/utils'
 import { createBasePropFetcher } from '~/utils/getBaseProps'
@@ -17,7 +17,7 @@ type BaseLayoutProps = Awaited<
 }
 
 export const Wrapper = styled.div`
-  min-height: calc(100vh - ${NAV_HEIGHT});
+  min-height: calc(100vh - ${NAV_HEIGHT} - ${STATUS_BANNER_HEIGHT});
   background: ${SNOW};
 `
 

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { ReactElement, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
+import { useStatusBannerHeight } from '~/hooks/useStatusBannerHeight'
 import { LOGIN_URL } from '~/utils'
 import { logEvent } from '~/utils/analytics'
 
@@ -17,6 +18,7 @@ import {
   mediaMaxWidth,
   NAV_HEIGHT,
   PHONE,
+  STATUS_BANNER_HEIGHT,
   TITLE_MARGIN,
   TITLE_SIZE,
   TITLE_SPACING,
@@ -44,6 +46,7 @@ const Nav = styled.nav`
   box-shadow: 0 1px 4px 0 ${BORDER};
   width: 100%;
   position: fixed;
+  top: ${STATUS_BANNER_HEIGHT};
   z-index: 1001;
   box-shadow: ${HEADER_SHADOW};
 
@@ -59,7 +62,7 @@ const ImageHead = styled.div`
   box-shadow: 0 1px 4px 0 ${BORDER};
   width: 100%;
   position: absolute;
-  top: ${NAV_HEIGHT};
+  top: calc(${NAV_HEIGHT} + ${STATUS_BANNER_HEIGHT});
   z-index: 999;
   background-size: cover;
   background-repeat: no-repeat;
@@ -74,7 +77,7 @@ const ImageHead = styled.div`
 const NavSpacer = styled.div`
   width: 100%;
   display: block;
-  height: ${FULL_NAV_HEIGHT};
+  height: calc(${FULL_NAV_HEIGHT} + ${STATUS_BANNER_HEIGHT});
 `
 
 const Logo = styled.img`
@@ -172,6 +175,8 @@ const Header = ({
 }: HeaderProps): ReactElement<any> => {
   const [show, setShow] = useState(false)
   const router = useRouter()
+
+  useStatusBannerHeight()
 
   const toggle = () => setShow(!show)
 

--- a/frontend/components/SearchBar.tsx
+++ b/frontend/components/SearchBar.tsx
@@ -24,6 +24,7 @@ import {
   MD,
   mediaMaxWidth,
   NAV_HEIGHT,
+  STATUS_BANNER_HEIGHT,
 } from '../constants/measurements'
 import { BODY_FONT } from '../constants/styles'
 import { Icon } from './common'
@@ -43,12 +44,12 @@ export const SearchbarRightContainer = styled.div`
 `
 
 const Wrapper = styled.div`
-  height: 100vh;
+  height: calc(100vh - ${STATUS_BANNER_HEIGHT});
   width: 20vw;
   overflow-x: hidden;
   overflow-y: auto;
   position: fixed;
-  top: 0;
+  top: ${STATUS_BANNER_HEIGHT};
   padding-top: ${NAV_HEIGHT};
   color: ${H1_TEXT};
 
@@ -92,7 +93,7 @@ const Content = styled.div<{ $show?: boolean }>`
     z-index: 1000;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.075);
     background: ${WHITE};
-    top: ${NAV_HEIGHT};
+    top: calc(${NAV_HEIGHT} + ${STATUS_BANNER_HEIGHT});
 
     .mobile-only {
       display: block;
@@ -106,7 +107,7 @@ const MobileToggle = styled.button`
     z-index: 999;
     display: block;
     position: fixed;
-    top: ${NAV_HEIGHT};
+    top: calc(${NAV_HEIGHT} + ${STATUS_BANNER_HEIGHT});
     right: 16px;
     background-color: ${WHITE};
     padding: 5px 8px;

--- a/frontend/components/common/Container.tsx
+++ b/frontend/components/common/Container.tsx
@@ -7,6 +7,7 @@ import {
   MD,
   mediaMinWidth,
   NAV_HEIGHT,
+  STATUS_BANNER_HEIGHT,
   XL,
 } from '../../constants/measurements'
 
@@ -41,7 +42,7 @@ const Wrapper = styled.div<WrapperProps>`
   ${({ $fullHeight }) =>
     $fullHeight &&
     `
-    min-height: calc(100vh - ${NAV_HEIGHT});
+    min-height: calc(100vh - ${NAV_HEIGHT} - ${STATUS_BANNER_HEIGHT});
   `}
 `
 

--- a/frontend/constants/measurements.ts
+++ b/frontend/constants/measurements.ts
@@ -50,6 +50,13 @@ export const CARD_HEADING = MEASUREMENTS[SITE_ID].CARD_HEADING
 export const BANNER_HEIGHT = MEASUREMENTS[SITE_ID].BANNER_HEIGHT
 export const FULL_NAV_HEIGHT = MEASUREMENTS[SITE_ID].FULL_NAV_HEIGHT
 
+/**
+ * Height of the Penn Labs status banner injected by the script in
+ * `pages/_document.tsx`, published by `useStatusBannerHeight`. Falls back to
+ * `0px` when no banner is present, which is the default layout.
+ */
+export const STATUS_BANNER_HEIGHT = 'var(--status-banner-height, 0px)'
+
 export const BORDER_RADIUS = '4px'
 export const BORDER_RADIUS_LG = '8px'
 

--- a/frontend/hooks/useStatusBannerHeight.ts
+++ b/frontend/hooks/useStatusBannerHeight.ts
@@ -1,0 +1,95 @@
+import { useEffect } from 'react'
+
+/**
+ * The banner injected by https://status.pennlabs.org/banner.js, which is loaded
+ * in `pages/_document.tsx`. The script inserts it as the first child of
+ * `document.body` (before the Next.js root) with `position: relative`, so by
+ * default it sits in normal flow and scrolls away while our fixed navbar stays
+ * pinned below where the banner used to be.
+ */
+const BANNER_ID = 'pennlabs-status-banner'
+
+/** Must stay in sync with `STATUS_BANNER_HEIGHT` in `constants/measurements`. */
+const HEIGHT_VARIABLE = '--status-banner-height'
+
+/**
+ * Matches the navbar (1001) and stays below modals (1002), so that modals and
+ * their shade still cover the banner. The injected script sets 99999, which
+ * would otherwise float the banner over every overlay once it is pinned.
+ */
+const BANNER_Z_INDEX = '1001'
+
+/**
+ * Pins the Penn Labs status banner to the top of the viewport and publishes its
+ * height as the `--status-banner-height` CSS variable on the document root.
+ *
+ * The banner is injected asynchronously by a third party script, can be
+ * dismissed by the user, and wraps to multiple lines on narrow viewports, so its
+ * height has to be measured at runtime rather than hardcoded. Anything that
+ * offsets off the navbar consumes the variable via `STATUS_BANNER_HEIGHT`, which
+ * falls back to `0px` when no banner is present.
+ */
+export const useStatusBannerHeight = (): void => {
+  useEffect(() => {
+    const root = document.documentElement
+
+    // Only write when the value actually changes. Setting a custom property
+    // from inside a ResizeObserver callback relayouts everything that consumes
+    // it, which otherwise trips the "ResizeObserver loop" error.
+    let published: string | null = null
+    const setHeight = (height: number) => {
+      const value = `${height}px`
+      if (value === published) {
+        return
+      }
+      published = value
+      root.style.setProperty(HEIGHT_VARIABLE, value)
+    }
+
+    let banner: HTMLElement | null = null
+    const resizeObserver = new ResizeObserver(() => {
+      if (banner != null) {
+        setHeight(banner.offsetHeight)
+      }
+    })
+
+    const sync = () => {
+      const found = document.getElementById(BANNER_ID)
+      if (found === banner) {
+        return
+      }
+
+      resizeObserver.disconnect()
+      banner = found
+
+      if (banner == null) {
+        setHeight(0)
+        return
+      }
+
+      banner.style.position = 'fixed'
+      banner.style.top = '0'
+      banner.style.left = '0'
+      banner.style.zIndex = BANNER_Z_INDEX
+
+      setHeight(banner.offsetHeight)
+      resizeObserver.observe(banner)
+    }
+
+    sync()
+
+    // The script is deferred and fetches before rendering, so the banner is
+    // usually inserted after hydration. Watch for it appearing and for the user
+    // dismissing it.
+    const mutationObserver = new MutationObserver(sync)
+    mutationObserver.observe(document.body, { childList: true })
+
+    return () => {
+      mutationObserver.disconnect()
+      resizeObserver.disconnect()
+      // Deliberately leave the variable in place. The header unmounts and
+      // remounts on every client side route change, and clearing it here would
+      // collapse the offset in between.
+    }
+  }, [])
+}

--- a/frontend/renderPage.tsx
+++ b/frontend/renderPage.tsx
@@ -19,7 +19,7 @@ import {
   SNOW,
   WHITE,
 } from './constants/colors'
-import { NAV_HEIGHT } from './constants/measurements'
+import { NAV_HEIGHT, STATUS_BANNER_HEIGHT } from './constants/measurements'
 import { BODY_FONT } from './constants/styles'
 import {
   Affiliation,
@@ -86,7 +86,7 @@ export const ToastStyle = styled.div`
 `
 
 export const Wrapper = styled.div`
-  min-height: calc(100vh - ${NAV_HEIGHT});
+  min-height: calc(100vh - ${NAV_HEIGHT} - ${STATUS_BANNER_HEIGHT});
   background: ${SNOW};
 `
 


### PR DESCRIPTION
## Problem

The Penn Labs status banner and the navbar come apart as soon as you scroll.

The banner isn't rendered by this repo. `frontend/pages/_document.tsx` loads `https://status.pennlabs.org/banner.js`, which injects

```html
<div id="pennlabs-status-banner" style="position: relative; ...">
```

as the **first child of `<body>`** — before the Next.js root, in normal document flow.

Meanwhile `Nav` in `frontend/components/Header/index.tsx` is `position: fixed` with **no `top` declaration**, so it falls back to its static position. The in-flow banner pushes that static position down by the banner's height, and a fixed box never re-resolves it on scroll.

The result: the banner scrolls away, the navbar stays pinned ~39px down, and page content scrolls through the gap above it. Measured on `master` at `scrollY: 600` — banner at `top: -600`, navbar still at `top: 39.2`.

The same root cause clipped the `/clubs` filter sidebar, which pins to the viewport independently of the navbar.

## Fix

Pin the banner to the top of the viewport and let the navbar sit directly beneath it, so the two behave as one block at any scroll position.

The banner's height can't be hardcoded — it's third-party, injected asynchronously after hydration, dismissible, and wraps to multiple lines on narrow viewports (39px at 1440px wide, 76px at 375px). So `frontend/hooks/useStatusBannerHeight.ts` measures it and publishes the value as a `--status-banner-height` CSS variable on the document root:

- a `MutationObserver` on `document.body` catches the async insertion and the removal when the user dismisses it
- a `ResizeObserver` tracks line-wrap changes
- writes are deduped, so it can't trip the "ResizeObserver loop" error

Everything that anchors to the navbar consumes it through a new `STATUS_BANNER_HEIGHT` constant in `constants/measurements.ts`:

```ts
export const STATUS_BANNER_HEIGHT = 'var(--status-banner-height, 0px)'
```

The `0px` fallback matters — it's a plain string baked into the styled-components CSS at module-eval time, identical on server and client, so there's no hydration mismatch and **the layout is unchanged when no banner is present** (no banner, adblock, script 404, or dismissed).

Consumers updated:

| File | Change |
|---|---|
| `components/Header/index.tsx` | `Nav` gets `top`; `NavSpacer` and `ImageHead` grow by the offset |
| `components/SearchBar.tsx` | sidebar `Wrapper`, mobile `Content`, `MobileToggle` |
| `renderPage.tsx`, `components/BaseLayout.tsx`, `components/common/Container.tsx` | `min-height: calc(100vh - NAV_HEIGHT)` |

Those three `min-height` sites aren't incidental: pinning the banner takes it out of flow, so without subtracting it every page would gain a ~39px scrollbar.

The hook also lowers the banner's `z-index` from the script's `99999` to `1001`. Without that, a pinned banner would float over every modal's shade — a pre-existing bug that only showed at `scrollY: 0`, now fixed as a side effect.

## Verification

`tsc --noemit` and eslint clean. Measured with Playwright against the real banner script (there's a live `degraded` incident, so it loads on localhost too):

| Case | Banner | Navbar | Gap |
|---|---|---|---|
| Desktop, scrolled | 0–39.2 (fixed) | 39–91 | ~0 |
| `/clubs`, scrolled 600 | 0–39.2 | 39–91 | ~0 |
| Mobile 375, scrolled | 0–75.6 (3 lines) | 76–128 | ~0 |
| Dismissed via `×` | gone, var → `0px` | 0–52 | — |

Also checked: content still starts below the navbar at `scrollY: 0`, the `/clubs` sidebar Search field clears the navbar, and dismissing the banner mid-scroll doesn't jump the navbar.

Not exercised locally: the `fyh` hub build (`ImageHead` / `LogoBackground` render only when `SITE_ID === 'fyh'`). Those offsets were updated for consistency and are covered by the same `0px` fallback, but a hub reviewer may want to eyeball them.

## Alternative considered

Making the navbar `position: sticky` and letting the banner scroll away needs no measurement at all, and is the more common announcement-bar pattern. Rejected because the desired behavior here is for the banner to stay visible while scrolled — during an incident, that's the point of it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hzzw8TjPF98orwVN3STPpZ
