### PR TITLE
Club subscription groups (#867)

### DIFF
--- a/backend/clubs/admin.py
+++ b/backend/clubs/admin.py
@@ -55,6 +55,11 @@ from clubs.models import (
     Status,
     StudentType,
     Subscribe,
+    SubscriptionGroup,
+    SubscriptionMultipleChoice,
+    SubscriptionQuestion,
+    SubscriptionQuestionResponse,
+    SubscriptionSubmission,
     Tag,
     TargetMajor,
     TargetSchool,
@@ -693,3 +698,8 @@ admin.site.register(Type, TypeAdmin)
 admin.site.register(Status, StatusAdmin)
 admin.site.register(Classification, ClassificationAdmin)
 admin.site.register(GroupActivityOption, GroupActivityOptionAdmin)
+admin.site.register(SubscriptionGroup)
+admin.site.register(SubscriptionQuestion)
+admin.site.register(SubscriptionMultipleChoice)
+admin.site.register(SubscriptionSubmission)
+admin.site.register(SubscriptionQuestionResponse)

--- a/backend/clubs/management/commands/populate.py
+++ b/backend/clubs/management/commands/populate.py
@@ -1188,4 +1188,8 @@ class Command(BaseCommand):
                         Ticket.objects.create(showing=showing, type="Premium", price=i)
                     )
 
+        # Anonymous club list API filters to visible_to_public;
+        # match test_club_list_filter.
+        Club.objects.update(visible_to_public=True)
+
         self.stdout.write("Finished populating database!")

--- a/backend/clubs/migrations/0144_subscription_group_models.py
+++ b/backend/clubs/migrations/0144_subscription_group_models.py
@@ -1,0 +1,246 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clubs", "0143_split_club_reject_permission"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # 1. SubscriptionGroup (no FK to Club yet — Club will gain the FK later)
+        migrations.CreateModel(
+            name="SubscriptionGroup",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(blank=True, max_length=255)),
+                ("description", models.TextField(blank=True)),
+                ("is_active", models.BooleanField(default=False)),
+                ("opens_at", models.DateTimeField(blank=True, null=True)),
+                ("closes_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "club",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="subscription_groups",
+                        to="clubs.club",
+                    ),
+                ),
+            ],
+        ),
+        # 2. SubscriptionQuestion
+        migrations.CreateModel(
+            name="SubscriptionQuestion",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "question_type",
+                    models.IntegerField(
+                        choices=[
+                            (1, "Free Response"),
+                            (2, "Multiple Choice"),
+                            (3, "Short Answer"),
+                            (4, "Informational Text"),
+                        ],
+                        default=1,
+                    ),
+                ),
+                ("prompt", models.TextField(blank=True)),
+                ("precedence", models.IntegerField(default=0)),
+                ("word_limit", models.IntegerField(default=0)),
+                ("created_at", models.DateTimeField(auto_now_add=True, null=True)),
+                ("updated_at", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "subscription_group",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="questions",
+                        to="clubs.subscriptiongroup",
+                    ),
+                ),
+            ],
+        ),
+        # 3. SubscriptionMultipleChoice
+        migrations.CreateModel(
+            name="SubscriptionMultipleChoice",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("value", models.TextField(blank=True)),
+                (
+                    "question",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="multiple_choice",
+                        to="clubs.subscriptionquestion",
+                    ),
+                ),
+            ],
+        ),
+        # 4. SubscriptionSubmission
+        migrations.CreateModel(
+            name="SubscriptionSubmission",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "attribution_source",
+                    models.CharField(
+                        choices=[
+                            ("direct", "Direct Club Page"),
+                            ("fair", "Activities Fair Booth"),
+                            ("search", "Search Results"),
+                            ("email", "Email Link"),
+                            ("external", "External Link"),
+                            ("import", "Imported"),
+                            ("unknown", "Unknown"),
+                        ],
+                        default="unknown",
+                        max_length=50,
+                    ),
+                ),
+                ("attribution_context", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "subscribe",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="form_submission",
+                        to="clubs.subscribe",
+                    ),
+                ),
+                (
+                    "subscription_group",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="submissions",
+                        to="clubs.subscriptiongroup",
+                    ),
+                ),
+            ],
+            options={
+                "unique_together": {("subscribe", "subscription_group")},
+            },
+        ),
+        # 5. SubscriptionQuestionResponse
+        migrations.CreateModel(
+            name="SubscriptionQuestionResponse",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("text", models.TextField(blank=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "multiple_choice",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="responses",
+                        to="clubs.subscriptionmultiplechoice",
+                    ),
+                ),
+                (
+                    "question",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="responses",
+                        to="clubs.subscriptionquestion",
+                    ),
+                ),
+                (
+                    "submission",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="responses",
+                        to="clubs.subscriptionsubmission",
+                    ),
+                ),
+            ],
+            options={
+                "unique_together": {("question", "submission")},
+            },
+        ),
+        # 6. Club.default_subscription_group (nullable FK)
+        migrations.AddField(
+            model_name="club",
+            name="default_subscription_group",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="default_for_clubs",
+                to="clubs.subscriptiongroup",
+            ),
+        ),
+        # 7. Subscribe.subscription_group (nullable FK)
+        migrations.AddField(
+            model_name="subscribe",
+            name="subscription_group",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="subscriptions",
+                to="clubs.subscriptiongroup",
+            ),
+        ),
+        # 8. HistoricalClub.default_subscription_group (simple_history shadow field)
+        migrations.AddField(
+            model_name="historicalclub",
+            name="default_subscription_group",
+            field=models.ForeignKey(
+                blank=True,
+                db_constraint=False,
+                null=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name="+",
+                to="clubs.subscriptiongroup",
+            ),
+        ),
+    ]

--- a/backend/clubs/migrations/0145_subscription_group_enhancements.py
+++ b/backend/clubs/migrations/0145_subscription_group_enhancements.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clubs", "0144_subscription_group_models"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="subscriptiongroup",
+            name="is_archived",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="subscriptionquestion",
+            name="required",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/clubs/migrations/0146_cleanup_auto_subscription_groups.py
+++ b/backend/clubs/migrations/0146_cleanup_auto_subscription_groups.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+def cleanup_auto_created_groups(apps, schema_editor):
+    """
+    Remove the empty "Subscribe" groups that the old
+    ``ensure_default_subscription_group`` post_save receiver created on every
+    club save. Only groups with no questions and no submissions are removed, so
+    any form an officer actually built is left untouched.
+    """
+    Club = apps.get_model("clubs", "Club")
+    SubscriptionGroup = apps.get_model("clubs", "SubscriptionGroup")
+
+    auto_created = SubscriptionGroup.objects.filter(
+        name="Subscribe",
+        questions__isnull=True,
+        submissions__isnull=True,
+    )
+    ids = list(auto_created.values_list("pk", flat=True))
+    if not ids:
+        return
+
+    # Clear the FK first so the clubs fall back to instant subscribe.
+    Club.objects.filter(default_subscription_group_id__in=ids).update(
+        default_subscription_group=None
+    )
+    SubscriptionGroup.objects.filter(pk__in=ids).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("clubs", "0145_subscription_group_enhancements"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            cleanup_auto_created_groups,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/clubs/models.py
+++ b/backend/clubs/models.py
@@ -388,6 +388,13 @@ class Club(models.Model):
         choices=RECRUITING_CYCLES, default=RECRUITING_UNKNOWN
     )
     enables_subscription = models.BooleanField(default=True)
+    default_subscription_group = models.ForeignKey(
+        "SubscriptionGroup",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="default_for_clubs",
+    )
     listserv = models.CharField(blank=True, max_length=255)
     ics_import_url = models.URLField(max_length=200, blank=True, null=True)
     image = models.ImageField(upload_to=get_club_file_name, null=True, blank=True)
@@ -1137,6 +1144,13 @@ class Subscribe(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+    subscription_group = models.ForeignKey(
+        "SubscriptionGroup",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="subscriptions",
+    )
 
     def __str__(self):
         return "<Subscribe: {} for {}, with email {}>".format(
@@ -1900,6 +1914,20 @@ class Profile(models.Model):
         return self.user.username
 
 
+class FormDefinitionBehaviorMixin:
+    """
+    Pure Python mixin providing shared interface for form-definition models
+    (ClubApplication, SubscriptionGroup). No Django fields — only methods.
+    Subclasses must implement is_currently_open() and get_display_name().
+    """
+
+    def is_currently_open(self, at=None):
+        raise NotImplementedError
+
+    def get_display_name(self):
+        raise NotImplementedError
+
+
 class ApplicationCycle(models.Model):
     """
     Represents an application cycle attached to club applications
@@ -1914,7 +1942,7 @@ class ApplicationCycle(models.Model):
         return self.name
 
 
-class ClubApplication(CloneModel):
+class ClubApplication(FormDefinitionBehaviorMixin, CloneModel):
     """
     Represents custom club application.
     """
@@ -1960,6 +1988,13 @@ class ClubApplication(CloneModel):
         semester = "Fall" if 8 <= self.application_start_time.month <= 12 else "Spring"
         year = str(self.application_start_time.year)
         return f"{semester} {year}"
+
+    def is_currently_open(self, at=None):
+        now = at or timezone.now()
+        return self.application_start_time <= now <= self.application_end_time
+
+    def get_display_name(self):
+        return self.name or str(self)
 
     @classmethod
     def validate_template(cls, template):
@@ -2258,6 +2293,175 @@ class ApplicationQuestionResponse(models.Model):
 
     class Meta:
         unique_together = (("question", "submission"),)
+
+
+class SubscriptionGroup(FormDefinitionBehaviorMixin, models.Model):
+    """
+    Represents a subscription form/group for a club. Clubs may have multiple
+    subscription groups to segment subscribers (e.g. by semester or interest).
+    """
+
+    club = models.ForeignKey(
+        Club, on_delete=models.CASCADE, related_name="subscription_groups"
+    )
+    name = models.CharField(max_length=255, blank=True)
+    description = models.TextField(blank=True)
+    is_active = models.BooleanField(default=False)
+    is_archived = models.BooleanField(default=False)
+    opens_at = models.DateTimeField(null=True, blank=True)
+    closes_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def is_currently_open(self, at=None):
+        now = at or timezone.now()
+        if not self.is_active:
+            return False
+        if self.opens_at and now < self.opens_at:
+            return False
+        if self.closes_at and now > self.closes_at:
+            return False
+        return True
+
+    def get_display_name(self):
+        return self.name or f"Subscription Group {self.pk}"
+
+    @property
+    def auto_subscribe_eligible(self):
+        """
+        True when the form asks nothing beyond auto-collected profile info, so a
+        magic link can subscribe the user outright instead of showing a form.
+        Informational text is not a question, so it does not block this.
+        """
+        return not self.questions.filter(
+            question_type__in=[
+                SubscriptionQuestion.FREE_RESPONSE,
+                SubscriptionQuestion.MULTIPLE_CHOICE,
+                SubscriptionQuestion.SHORT_ANSWER,
+            ]
+        ).exists()
+
+    def __str__(self):
+        return f"{self.club.name} — {self.get_display_name()}"
+
+
+class SubscriptionQuestion(models.Model):
+    """
+    Represents a question attached to a SubscriptionGroup form.
+    """
+
+    FREE_RESPONSE = 1
+    MULTIPLE_CHOICE = 2
+    SHORT_ANSWER = 3
+    INFO_TEXT = 4
+    QUESTION_TYPES = (
+        (FREE_RESPONSE, "Free Response"),
+        (MULTIPLE_CHOICE, "Multiple Choice"),
+        (SHORT_ANSWER, "Short Answer"),
+        (INFO_TEXT, "Informational Text"),
+    )
+
+    question_type = models.IntegerField(choices=QUESTION_TYPES, default=FREE_RESPONSE)
+    prompt = models.TextField(blank=True)
+    required = models.BooleanField(default=False)
+    precedence = models.IntegerField(default=0)
+    word_limit = models.IntegerField(default=0)
+    subscription_group = models.ForeignKey(
+        SubscriptionGroup, on_delete=models.CASCADE, related_name="questions"
+    )
+    created_at = models.DateTimeField(auto_now_add=True, null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True, null=True, blank=True)
+
+    def __str__(self):
+        return f"{self.subscription_group} — Q{self.precedence}: {self.prompt[:50]}"
+
+
+class SubscriptionMultipleChoice(models.Model):
+    """
+    Represents a multiple choice option for a SubscriptionQuestion.
+    """
+
+    value = models.TextField(blank=True)
+    question = models.ForeignKey(
+        SubscriptionQuestion, on_delete=models.CASCADE, related_name="multiple_choice"
+    )
+
+    def __str__(self):
+        return self.value
+
+
+ATTRIBUTION_SOURCE_CHOICES = (
+    ("direct", "Direct Club Page"),
+    ("fair", "Activities Fair Booth"),
+    ("search", "Search Results"),
+    ("email", "Email Link"),
+    ("external", "External Link"),
+    ("import", "Imported"),
+    ("unknown", "Unknown"),
+)
+
+
+class SubscriptionSubmission(models.Model):
+    """
+    Represents a user's form submission when subscribing via a SubscriptionGroup.
+    """
+
+    subscribe = models.ForeignKey(
+        "Subscribe",
+        on_delete=models.CASCADE,
+        null=True,
+        related_name="form_submission",
+    )
+    subscription_group = models.ForeignKey(
+        SubscriptionGroup,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="submissions",
+    )
+    attribution_source = models.CharField(
+        max_length=50, choices=ATTRIBUTION_SOURCE_CHOICES, default="unknown"
+    )
+    attribution_context = models.JSONField(default=dict, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = (("subscribe", "subscription_group"),)
+
+    def __str__(self):
+        return (
+            f"SubscriptionSubmission(subscribe={self.subscribe_id}, "
+            f"group={self.subscription_group_id})"
+        )
+
+
+class SubscriptionQuestionResponse(models.Model):
+    """
+    Represents a response to a single SubscriptionQuestion within a
+    SubscriptionSubmission.
+    """
+
+    text = models.TextField(blank=True)
+    question = models.ForeignKey(
+        SubscriptionQuestion, on_delete=models.CASCADE, related_name="responses"
+    )
+    submission = models.ForeignKey(
+        SubscriptionSubmission, on_delete=models.CASCADE, related_name="responses"
+    )
+    multiple_choice = models.ForeignKey(
+        SubscriptionMultipleChoice,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="responses",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        unique_together = (("question", "submission"),)
+
+    def __str__(self):
+        return f"Response to Q{self.question_id} in submission {self.submission_id}"
 
 
 class Cart(models.Model):

--- a/backend/clubs/permissions.py
+++ b/backend/clubs/permissions.py
@@ -363,6 +363,28 @@ class ClubSensitiveItemPermission(permissions.BasePermission):
         return membership is not None and membership.role <= Membership.ROLE_OFFICER
 
 
+class SubscriptionGroupPermission(permissions.BasePermission):
+    """
+    Officers and above have full access to subscription form management,
+    subscriber data, and exports. No one else can access these.
+    """
+
+    def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+        if request.user.has_perm("clubs.manage_club"):
+            return True
+        club_code = view.kwargs.get("club_code")
+        if not club_code:
+            return False
+        try:
+            club = Club.objects.get(code=club_code)
+        except Club.DoesNotExist:
+            return False
+        membership = find_membership_helper(request.user, club)
+        return membership is not None and membership.role <= Membership.ROLE_OFFICER
+
+
 class IsSuperuser(permissions.BasePermission):
     """
     Grants permission if the current user is a superuser.

--- a/backend/clubs/serializers.py
+++ b/backend/clubs/serializers.py
@@ -62,6 +62,11 @@ from clubs.models import (
     Status,
     StudentType,
     Subscribe,
+    SubscriptionGroup,
+    SubscriptionMultipleChoice,
+    SubscriptionQuestion,
+    SubscriptionQuestionResponse,
+    SubscriptionSubmission,
     Tag,
     TargetMajor,
     TargetSchool,
@@ -1546,6 +1551,9 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
     youtube = serializers.CharField(required=False, allow_null=True, allow_blank=True)
 
     group_activity_assessment = GroupActivityOptionSerializer(many=True, required=False)
+    default_subscription_group = serializers.PrimaryKeyRelatedField(
+        queryset=SubscriptionGroup.objects.all(), required=False, allow_null=True
+    )
 
     def get_fairs(self, obj):
         return list(obj.clubfair_set.values_list("id", flat=True))
@@ -2193,6 +2201,7 @@ class ClubSerializer(ManyToManySaveMixin, ClubListSerializer):
             "eligibility",
             "classification",
             "group_activity_assessment",
+            "default_subscription_group",
         ]
         save_related_fields = [
             "tags",
@@ -2301,9 +2310,12 @@ class UserSubscribeSerializer(serializers.ModelSerializer):
 
 class UserSubscribeWriteSerializer(UserSubscribeSerializer):
     club = serializers.SlugRelatedField(queryset=Club.objects.all(), slug_field="code")
+    subscription_group = serializers.PrimaryKeyRelatedField(
+        queryset=SubscriptionGroup.objects.all(), required=False, allow_null=True
+    )
 
     class Meta(UserSubscribeSerializer.Meta):
-        pass
+        fields = UserSubscribeSerializer.Meta.fields + ("subscription_group",)
 
 
 class SubscribeSerializer(serializers.ModelSerializer):
@@ -3969,3 +3981,269 @@ class RankingWeightsSerializer(serializers.ModelSerializer):
 
     def get_updated_by(self, obj):
         return obj.updated_by.get_full_name() if obj.updated_by else "N/A"
+
+
+class SubscriptionMultipleChoiceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SubscriptionMultipleChoice
+        fields = ["id", "value", "question"]
+        # question is set from the nested route, never sent in the request body
+        read_only_fields = ["id", "question"]
+
+
+class SubscriptionQuestionSerializer(serializers.ModelSerializer):
+    multiple_choice = SubscriptionMultipleChoiceSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SubscriptionQuestion
+        fields = [
+            "id",
+            "subscription_group",
+            "question_type",
+            "prompt",
+            "required",
+            "precedence",
+            "word_limit",
+            "multiple_choice",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "subscription_group", "created_at", "updated_at"]
+
+    def save(self, **kwargs):
+        question_obj = super().save(**kwargs)
+        # manually create multiple choice options as Django does not
+        # support nested serializers out of the box
+        request = self.context["request"].data
+        if "multiple_choice" in request:
+            SubscriptionMultipleChoice.objects.filter(question=question_obj).delete()
+            for choice in request["multiple_choice"]:
+                value = choice["value"] if isinstance(choice, dict) else choice
+                SubscriptionMultipleChoice.objects.create(
+                    value=value,
+                    question=question_obj,
+                )
+        return question_obj
+
+
+class SubscriptionGroupListSerializer(serializers.ModelSerializer):
+    question_count = serializers.IntegerField(read_only=True)
+    submission_count = serializers.IntegerField(read_only=True)
+    subscriber_count = serializers.IntegerField(read_only=True)
+    is_default = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SubscriptionGroup
+        fields = [
+            "id",
+            "name",
+            "description",
+            "is_active",
+            "is_archived",
+            "opens_at",
+            "closes_at",
+            "is_default",
+            "question_count",
+            "submission_count",
+            "subscriber_count",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+    def get_is_default(self, obj):
+        return obj.club.default_subscription_group_id == obj.pk
+
+
+class SubscriptionGroupDetailSerializer(SubscriptionGroupListSerializer):
+    questions = SubscriptionQuestionSerializer(many=True, read_only=True)
+
+    class Meta(SubscriptionGroupListSerializer.Meta):
+        fields = SubscriptionGroupListSerializer.Meta.fields + ["questions"]
+
+
+class SubscriptionGroupWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SubscriptionGroup
+        fields = ["name", "description", "is_active", "opens_at", "closes_at"]
+
+    def validate(self, data):
+        """
+        A form cannot close before it opens, which would leave it permanently
+        shut. On a PATCH only one of the two may be supplied, so fall back to
+        the stored value for whichever is absent.
+        """
+        opens_at = data.get(
+            "opens_at", self.instance.opens_at if self.instance else None
+        )
+        closes_at = data.get(
+            "closes_at", self.instance.closes_at if self.instance else None
+        )
+
+        if opens_at and closes_at and closes_at <= opens_at:
+            raise serializers.ValidationError(
+                {
+                    "closes_at": [
+                        "The close date must be after the open date. "
+                        "Leave it blank to keep the form open indefinitely."
+                    ]
+                }
+            )
+        return data
+
+
+# Keep old name for backward compatibility (used in existing imports)
+SubscriptionGroupSerializer = SubscriptionGroupListSerializer
+
+
+class PublicSubscriptionQuestionSerializer(serializers.ModelSerializer):
+    multiple_choice = SubscriptionMultipleChoiceSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SubscriptionQuestion
+        fields = [
+            "id",
+            "question_type",
+            "prompt",
+            "required",
+            "precedence",
+            "word_limit",
+            "multiple_choice",
+        ]
+
+
+class PublicSubscriptionGroupSerializer(serializers.ModelSerializer):
+    questions = PublicSubscriptionQuestionSerializer(many=True, read_only=True)
+    auto_subscribe_eligible = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SubscriptionGroup
+        fields = [
+            "id",
+            "name",
+            "description",
+            "is_active",
+            "opens_at",
+            "closes_at",
+            "questions",
+            "auto_subscribe_eligible",
+        ]
+
+    def get_auto_subscribe_eligible(self, obj):
+        return obj.auto_subscribe_eligible
+
+
+class SubscriberListSerializer(serializers.ModelSerializer):
+    user_id = serializers.IntegerField(source="subscribe.person.pk", read_only=True)
+    name = serializers.SerializerMethodField()
+    email = serializers.EmailField(source="subscribe.person.email", read_only=True)
+    graduation_year = serializers.SerializerMethodField()
+    subscribed_at = serializers.DateTimeField(source="created_at", read_only=True)
+    submission_id = serializers.IntegerField(source="pk", read_only=True)
+
+    class Meta:
+        model = SubscriptionSubmission
+        fields = [
+            "submission_id",
+            "user_id",
+            "name",
+            "email",
+            "graduation_year",
+            "attribution_source",
+            "attribution_context",
+            "subscribed_at",
+        ]
+
+    def get_name(self, obj):
+        if obj.subscribe and obj.subscribe.person:
+            return obj.subscribe.person.get_full_name()
+        return ""
+
+    def get_graduation_year(self, obj):
+        if obj.subscribe and obj.subscribe.person:
+            profile = getattr(obj.subscribe.person, "profile", None)
+            if profile:
+                return getattr(profile, "graduation_year", None)
+        return None
+
+
+class SubscriberDetailSerializer(SubscriberListSerializer):
+    responses = serializers.SerializerMethodField()
+
+    class Meta(SubscriberListSerializer.Meta):
+        fields = SubscriberListSerializer.Meta.fields + ["responses"]
+
+    def get_responses(self, obj):
+        result = []
+        for response in obj.responses.all():
+            result.append(
+                {
+                    "question_id": response.question_id,
+                    "prompt": response.question.prompt if response.question else "",
+                    "question_type": (
+                        response.question.question_type if response.question else None
+                    ),
+                    "text": response.text,
+                    "multiple_choice_value": (
+                        response.multiple_choice.value
+                        if response.multiple_choice
+                        else None
+                    ),
+                }
+            )
+        return result
+
+
+class SubscriptionAnswerSerializer(serializers.Serializer):
+    question = serializers.PrimaryKeyRelatedField(
+        queryset=SubscriptionQuestion.objects.all()
+    )
+    text = serializers.CharField(required=False, allow_blank=True, default="")
+    multiple_choice = serializers.PrimaryKeyRelatedField(
+        queryset=SubscriptionMultipleChoice.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+
+
+class SubscriptionSubmitSerializer(serializers.Serializer):
+    # Accepted for backwards compatibility but ignored: the subscription group
+    # is identified by the URL, which is the authoritative source.
+    subscription_group = serializers.PrimaryKeyRelatedField(
+        queryset=SubscriptionGroup.objects.all(), required=False
+    )
+    answers = SubscriptionAnswerSerializer(many=True, required=False, default=list)
+    # Deliberately not a ChoiceField: a stale or unknown source recorded on a
+    # magic link should be stored as "unknown" rather than rejecting a
+    # legitimate subscription. The view validates against the choices.
+    attribution_source = serializers.CharField(required=False, default="direct")
+    attribution_context = serializers.JSONField(required=False, default=dict)
+
+
+class SubscriptionSubmissionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SubscriptionSubmission
+        fields = [
+            "id",
+            "subscribe",
+            "subscription_group",
+            "attribution_source",
+            "attribution_context",
+            "created_at",
+        ]
+        read_only_fields = ["id", "created_at"]
+
+
+class SubscriptionQuestionResponseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SubscriptionQuestionResponse
+        fields = [
+            "id",
+            "submission",
+            "question",
+            "text",
+            "multiple_choice",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]

--- a/backend/clubs/urls.py
+++ b/backend/clubs/urls.py
@@ -58,6 +58,14 @@ from clubs.views import (
     StatusViewSet,
     StudentTypeViewSet,
     SubscribeViewSet,
+    SubscriptionEntryView,
+    SubscriptionGroupViewSet,
+    SubscriptionMagicLinkResolveView,
+    SubscriptionMultipleChoiceViewSet,
+    SubscriptionPublicGroupView,
+    SubscriptionQuestionViewSet,
+    SubscriptionSubmissionAdminViewSet,
+    SubscriptionSubmitView,
     TagViewSet,
     TestimonialViewSet,
     TicketViewSet,
@@ -156,10 +164,32 @@ clubs_router.register(
     r"applications", ClubApplicationViewSet, basename="club-applications"
 )
 clubs_router.register(r"adminnotes", AdminNoteViewSet, basename="adminnotes")
+clubs_router.register(
+    r"subscription-groups",
+    SubscriptionGroupViewSet,
+    basename="club-subscription-groups",
+)
 
 club_events_router = routers.NestedSimpleRouter(clubs_router, r"events", lookup="event")
 club_events_router.register(
     r"showings", ClubEventShowingViewSet, basename="club-events-showings"
+)
+
+subscription_groups_router = routers.NestedSimpleRouter(
+    clubs_router, r"subscription-groups", lookup="subscription_group"
+)
+subscription_groups_router.register(
+    r"questions", SubscriptionQuestionViewSet, basename="sub-group-questions"
+)
+subscription_groups_router.register(
+    r"subscribers", SubscriptionSubmissionAdminViewSet, basename="sub-group-subscribers"
+)
+
+sub_questions_router = routers.NestedSimpleRouter(
+    subscription_groups_router, r"questions", lookup="question"
+)
+sub_questions_router.register(
+    r"options", SubscriptionMultipleChoiceViewSet, basename="sub-question-options"
 )
 
 badges_router = routers.NestedSimpleRouter(router, r"badges", lookup="badge")
@@ -250,6 +280,26 @@ urlpatterns = [
         RankingWeightsView.as_view(),
         name="ranking-weights",
     ),
+    path(
+        "clubs/<slug:club_code>/subscription-entry/",
+        SubscriptionEntryView.as_view(),
+        name="subscription-entry",
+    ),
+    path(
+        "subscription-groups/<int:pk>/public/",
+        SubscriptionPublicGroupView.as_view(),
+        name="subscription-group-public",
+    ),
+    path(
+        "subscription-groups/<int:pk>/submit/",
+        SubscriptionSubmitView.as_view(),
+        name="subscription-group-submit",
+    ),
+    path(
+        "subscription-links/<str:token>/",
+        SubscriptionMagicLinkResolveView.as_view(),
+        name="subscription-link-resolve",
+    ),
 ]
 
 urlpatterns += router.urls
@@ -258,3 +308,5 @@ urlpatterns += badges_router.urls
 urlpatterns += applications_router.urls
 urlpatterns += events_router.urls
 urlpatterns += club_events_router.urls
+urlpatterns += subscription_groups_router.urls
+urlpatterns += sub_questions_router.urls

--- a/backend/clubs/views.py
+++ b/backend/clubs/views.py
@@ -38,9 +38,9 @@ from django.core.files.uploadedfile import UploadedFile
 from django.core.mail import EmailMultiAlternatives
 from django.core.management import call_command, get_commands, load_command_class
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
+from django.core.signing import BadSignature, SignatureExpired, Signer, TimestampSigner
 from django.core.validators import validate_email
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import (
     Case,
     CharField,
@@ -85,10 +85,15 @@ from rest_framework.views import APIView
 from social_django.utils import load_strategy
 from tatsu.exceptions import FailedParse
 
-from clubs.filters import RandomOrderingFilter, RandomPageNumberPagination
+from clubs.filters import (
+    OptionalPageNumberPagination,
+    RandomOrderingFilter,
+    RandomPageNumberPagination,
+)
 from clubs.management.commands.sync import Command as SyncCommand
 from clubs.mixins import XLSXFormatterMixin
 from clubs.models import (
+    ATTRIBUTION_SOURCE_CHOICES,
     AdminNote,
     Advisor,
     ApplicationCycle,
@@ -130,6 +135,10 @@ from clubs.models import (
     Status,
     StudentType,
     Subscribe,
+    SubscriptionGroup,
+    SubscriptionMultipleChoice,
+    SubscriptionQuestion,
+    SubscriptionSubmission,
     Tag,
     Testimonial,
     Ticket,
@@ -160,6 +169,7 @@ from clubs.permissions import (
     ProfilePermission,
     QuestionAnswerPermission,
     ReadOnly,
+    SubscriptionGroupPermission,
     WhartonApplicationPermission,
     find_membership_helper,
 )
@@ -211,6 +221,7 @@ from clubs.serializers import (
     MinimalUserProfileSerializer,
     NoteSerializer,
     OwnershipRequestSerializer,
+    PublicSubscriptionGroupSerializer,
     QuestionAnswerSerializer,
     RankingWeightsSerializer,
     RegistrationQueueSettingsSerializer,
@@ -221,7 +232,15 @@ from clubs.serializers import (
     StatusSerializer,
     StudentTypeSerializer,
     SubscribeBookmarkSerializer,
+    SubscriberDetailSerializer,
+    SubscriberListSerializer,
     SubscribeSerializer,
+    SubscriptionGroupDetailSerializer,
+    SubscriptionGroupListSerializer,
+    SubscriptionGroupWriteSerializer,
+    SubscriptionMultipleChoiceSerializer,
+    SubscriptionQuestionSerializer,
+    SubscriptionSubmitSerializer,
     TagSerializer,
     TestimonialSerializer,
     TicketSerializer,
@@ -245,6 +264,7 @@ from clubs.serializers import (
     validate_constitution_file,
 )
 from clubs.utils import fuzzy_lookup_club, html_to_text
+from clubs.workflows import SubscriptionFormWorkflow
 from pennclubs.analytics import LabsAnalytics
 
 
@@ -1602,9 +1622,52 @@ class ClubViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
             or bypass
             or self.action not in {"list"}
         ):
-            return queryset
+            final_qs = queryset
         else:
-            return queryset.filter(Q(approved=True) | Q(ghost=True))
+            final_qs = queryset.filter(Q(approved=True) | Q(ghost=True))
+
+        # #region agent log
+        if self.action == "list":
+            try:
+                _db_name = connection.settings_dict.get("NAME")
+                _total = Club.objects.count()
+                _vtp = Club.objects.filter(visible_to_public=True).count()
+                _pub = is_public_viewer(self.request)
+                _cnt = final_qs.count()
+                with open(
+                    "/Users/smaran/Desktop/penn-clubs/.cursor/debug.log", "a"
+                ) as _df:
+                    _df.write(
+                        json.dumps(
+                            {
+                                "id": "club_list_qs",
+                                "timestamp": int(timezone.now().timestamp() * 1000),
+                                "location": "clubs/views.py:ClubViewSet.get_queryset",
+                                "message": "club list queryset",
+                                "hypothesisId": "H1-H4",
+                                "data": {
+                                    "db_name": str(_db_name)[:200],
+                                    "is_public_viewer": _pub,
+                                    "club_objects_count": _total,
+                                    "visible_to_public_count": _vtp,
+                                    "filtered_count": _cnt,
+                                    "auth": bool(
+                                        getattr(
+                                            self.request.user,
+                                            "is_authenticated",
+                                            False,
+                                        )
+                                    ),
+                                },
+                            }
+                        )
+                        + "\n"
+                    )
+            except Exception:
+                pass
+        # #endregion
+
+        return final_qs
 
     def _has_elevated_view_perms(self, instance):
         """
@@ -4785,9 +4848,11 @@ class SubscribeViewSet(viewsets.ModelViewSet):
     http_method_names = ["get", "post", "delete"]
 
     def get_queryset(self):
-        queryset = Subscribe.objects.filter(
-            person=self.request.user, club__archived=False
-        ).prefetch_related("club__tags")
+        queryset = (
+            Subscribe.objects.filter(person=self.request.user, club__archived=False)
+            .select_related("subscription_group")
+            .prefetch_related("club__tags")
+        )
 
         person = self.request.user
         queryset = queryset.prefetch_related(
@@ -4814,6 +4879,857 @@ class SubscribeViewSet(viewsets.ModelViewSet):
         if self.action == "create":
             return UserSubscribeWriteSerializer
         return UserSubscribeSerializer
+
+
+SUBSCRIPTION_LINK_SALT = "sub-group-link"
+
+# Export shapes offered for listserv-style platforms. XLSX is not listed here;
+# it is served through DRF's XLSXRenderer via the standard ?format=xlsx param.
+SUBSCRIPTION_EXPORT_FORMATS = ("csv", "tsv", "txt", "mailchimp", "google-groups")
+
+
+def subscription_link_base(request=None):
+    """
+    Base URL that subscription magic links and QR codes point at.
+
+    Production always uses the canonical domain so a printed QR code stays valid.
+    Under DEBUG we honour the calling frontend's own origin instead, so links are
+    actually followable on localhost whichever port the dev server uses. The
+    origin is only trusted if it is already whitelisted in CSRF_TRUSTED_ORIGINS,
+    so a caller cannot point links at an arbitrary host.
+    """
+    if settings.DEBUG and request is not None:
+        origin = request.META.get("HTTP_ORIGIN") or request.META.get("HTTP_REFERER")
+        if origin:
+            parsed = urlparse(origin)
+            if parsed.scheme and parsed.netloc:
+                candidate = f"{parsed.scheme}://{parsed.netloc}"
+                if candidate in settings.CSRF_TRUSTED_ORIGINS:
+                    return candidate
+    return f"https://{settings.DEFAULT_DOMAIN}"
+
+
+def build_subscription_magic_link(group, request=None):
+    """
+    Return the signed, user-facing magic link for a subscription form. Points at
+    the frontend route, matching the existing club QR action.
+    """
+    signer = Signer(salt=f"{SUBSCRIPTION_LINK_SALT}:{group.pk}")
+    token = signer.sign(str(group.pk))
+    return f"{subscription_link_base(request)}/subscribe/link/{token}"
+
+
+def subscription_export_response(rows, fmt, basename, columns=None):
+    """
+    Render subscriber `rows` (a list of dicts) in one of the text-based export
+    formats and return it as a file download. Mirrors the pandas/to_csv idiom
+    used by the club application submission export.
+    """
+    if fmt == "txt":
+        body = "".join(f"{row['email']}\n" for row in rows)
+        return HttpResponse(
+            body,
+            content_type="text/plain; charset=utf-8",
+            headers={"Content-Disposition": f"attachment;filename={basename}-list.txt"},
+        )
+
+    if fmt == "mailchimp":
+        rows = [
+            {
+                "Email Address": row["email"],
+                "First Name": row.get("first_name", ""),
+                "Last Name": row.get("last_name", ""),
+            }
+            for row in rows
+        ]
+        columns = ["Email Address", "First Name", "Last Name"]
+    elif fmt == "google-groups":
+        rows = [
+            {
+                "Group Email [Required]": row.get("group_email", ""),
+                "Member Email": row["email"],
+                "Member Type": "USER",
+                "Member Role": "MEMBER",
+            }
+            for row in rows
+        ]
+        columns = [
+            "Group Email [Required]",
+            "Member Email",
+            "Member Type",
+            "Member Role",
+        ]
+    elif columns is not None:
+        rows = [{k: row.get(k, "") for k in columns} for row in rows]
+
+    sep = "\t" if fmt == "tsv" else ","
+    extension = "tsv" if fmt == "tsv" else "csv"
+    # Mailchimp and Google Groups are both CSV; without a distinct filename all
+    # three land in the download bar as "emails.csv" and look identical.
+    suffix = f"-{fmt}" if fmt in ("mailchimp", "google-groups") else ""
+    content_type = (
+        "text/tab-separated-values; charset=utf-8"
+        if fmt == "tsv"
+        else "text/csv; charset=utf-8"
+    )
+
+    # Render to a buffer and hand HttpResponse the finished string. Writing
+    # directly into the response re-encodes on every pandas write, so a
+    # utf-8-sig charset would repeat the BOM mid-file. The single leading BOM
+    # is what makes Excel open the download as UTF-8.
+    buffer = io.StringIO()
+    pd.DataFrame(rows, columns=columns).to_csv(buffer, index=False, sep=sep)
+    return HttpResponse(
+        "\ufeff" + buffer.getvalue(),
+        content_type=content_type,
+        headers={
+            "Content-Disposition": (
+                f"attachment;filename={basename}{suffix}.{extension}"
+            )
+        },
+    )
+
+
+class SubscriptionGroupViewSet(XLSXFormatterMixin, viewsets.ModelViewSet):
+    """
+    list: Return subscription groups for a club.
+
+    create: Create a new subscription group for a club.
+
+    retrieve: Return a single subscription group.
+
+    update: Update a subscription group.
+
+    destroy: Delete a subscription group.
+    """
+
+    permission_classes = [SubscriptionGroupPermission | IsSuperuser]
+    http_method_names = ["get", "post", "put", "patch", "delete"]
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return SubscriptionGroupListSerializer
+        if self.action == "retrieve":
+            return SubscriptionGroupDetailSerializer
+        if self.action in ("create", "update", "partial_update"):
+            return SubscriptionGroupWriteSerializer
+        return SubscriptionGroupListSerializer
+
+    def get_queryset(self):
+        return SubscriptionGroup.objects.filter(
+            club__code=self.kwargs.get("club_code")
+        ).annotate(
+            question_count=Count("questions", distinct=True),
+            submission_count=Count("submissions", distinct=True),
+            # Count the people who submitted this form, not Subscribe rows
+            # pointing back at it: the submit path only sets that FK when it is
+            # null, so anyone already subscribed to the club never counted.
+            subscriber_count=Count("submissions__subscribe__person", distinct=True),
+        )
+
+    def perform_create(self, serializer):
+        club = get_object_or_404(Club, code=self.kwargs.get("club_code"))
+        serializer.save(club=club)
+
+    @action(detail=True, methods=["post"], url_path="set-default")
+    def set_default(self, request, **kwargs):
+        """
+        Set this subscription form as the club's default form.
+        ---
+        requestBody:
+            content: {}
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+            "400":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        group = self.get_object()
+        if group.is_archived:
+            return Response(
+                {"detail": "Archived forms cannot be set as default."}, status=400
+            )
+        club = group.club
+        club.default_subscription_group = group
+        club.save(update_fields=["default_subscription_group"])
+        return Response({"detail": "Default subscription form updated."})
+
+    @action(detail=True, methods=["post"])
+    def archive(self, request, **kwargs):
+        """
+        Archive this subscription form so it no longer accepts submissions.
+        ---
+        requestBody:
+            content: {}
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        group = self.get_object()
+        club = group.club
+        if club.default_subscription_group_id == group.pk:
+            club.default_subscription_group = None
+            club.save(update_fields=["default_subscription_group"])
+        group.is_archived = True
+        group.is_active = False
+        group.save(update_fields=["is_archived", "is_active"])
+        return Response({"detail": "Form archived."})
+
+    @action(detail=True, methods=["post"])
+    def unarchive(self, request, **kwargs):
+        """
+        Restore an archived subscription form.
+        ---
+        requestBody:
+            content: {}
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        group = self.get_object()
+        group.is_archived = False
+        group.save(update_fields=["is_archived"])
+        return Response({"detail": "Form unarchived."})
+
+    @action(detail=True, methods=["get"], url_path="magic-link")
+    def magic_link(self, request, **kwargs):
+        """
+        Return a signed magic link URL and token for sharing the subscription form.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                url:
+                                    type: string
+                                token:
+                                    type: string
+                                auto_subscribe_eligible:
+                                    type: boolean
+        ---
+        """
+        group = self.get_object()
+        url = build_subscription_magic_link(group, request)
+        return Response(
+            {
+                "url": url,
+                "token": url.rsplit("/", 1)[-1],
+                "auto_subscribe_eligible": group.auto_subscribe_eligible,
+            }
+        )
+
+    @action(detail=True, methods=["get"], url_path="qr-code")
+    def qr_code(self, request, **kwargs):
+        """
+        Return a PNG QR code image linking to this subscription form.
+        ---
+        responses:
+            "200":
+                description: PNG image of a QR code.
+                content:
+                    image/png:
+                        schema:
+                            type: string
+                            format: binary
+        ---
+        """
+        group = self.get_object()
+        url = build_subscription_magic_link(group, request)
+        response = HttpResponse(content_type="image/png")
+        qr_image = qrcode.make(url, box_size=20, border=0)
+        qr_image.save(response, "PNG")
+        return response
+
+    def _subscriber_rows(self, group):
+        """
+        Base row set shared by every export shape, ordered oldest first.
+        Submissions whose Subscribe row was deleted are skipped.
+        """
+        qs = (
+            SubscriptionSubmission.objects.filter(subscription_group=group)
+            .select_related("subscribe__person__profile")
+            .order_by("created_at")
+        )
+        rows = []
+        for s in qs:
+            if not s.subscribe:
+                continue
+            person = s.subscribe.person
+            rows.append(
+                {
+                    "email": person.email,
+                    "name": person.get_full_name(),
+                    "first_name": person.first_name,
+                    "last_name": person.last_name,
+                    "source": s.attribution_source,
+                    "subscribed_at": s.created_at.isoformat(),
+                    "group_email": group.club.listserv,
+                }
+            )
+        return rows
+
+    def _requested_export_format(self, request):
+        """
+        Read and validate the export shape from ?fmt=. Note this is deliberately
+        not ?format=, which DRF reserves for renderer content negotiation
+        (?format=xlsx is handled by the XLSXRenderer instead).
+        """
+        fmt = request.query_params.get("fmt", "csv").lower()
+        if fmt not in SUBSCRIPTION_EXPORT_FORMATS:
+            raise DRFValidationError(
+                {
+                    "detail": "Unsupported export format '{}'. Choose one of: {}, "
+                    "or request ?format=xlsx for a spreadsheet.".format(
+                        fmt, ", ".join(SUBSCRIPTION_EXPORT_FORMATS)
+                    )
+                }
+            )
+        return fmt
+
+    @action(detail=True, methods=["get"], url_path="export/emails")
+    def export_emails(self, request, **kwargs):
+        """
+        Export subscriber emails in a listserv-compatible format.
+
+        Pass ?fmt=csv|tsv|txt|mailchimp|google-groups to choose the shape, or
+        ?format=xlsx for a spreadsheet.
+        ---
+        responses:
+            "200":
+                content:
+                    text/csv:
+                        schema:
+                            type: string
+        ---
+        """
+        group = self.get_object()
+        rows = self._subscriber_rows(group)
+        columns = ["email", "name", "source", "subscribed_at"]
+
+        if request.query_params.get("format") == "xlsx":
+            return Response([{k: row[k] for k in columns} for row in rows])
+
+        fmt = self._requested_export_format(request)
+        return subscription_export_response(rows, fmt, "emails", columns=columns)
+
+    @action(detail=True, methods=["get"], url_path="export/responses")
+    def export_responses(self, request, **kwargs):
+        """
+        Export subscriber responses, one column per question.
+
+        Pass ?fmt=csv|tsv|txt|mailchimp|google-groups to choose the shape, or
+        ?format=xlsx for a spreadsheet. The email-list shapes (txt, mailchimp,
+        google-groups) carry contact columns only, without question answers.
+        ---
+        responses:
+            "200":
+                content:
+                    text/csv:
+                        schema:
+                            type: string
+        ---
+        """
+        group = self.get_object()
+        questions = list(group.questions.order_by("precedence"))
+        qs = (
+            SubscriptionSubmission.objects.filter(subscription_group=group)
+            .select_related("subscribe__person__profile")
+            .prefetch_related("responses__question", "responses__multiple_choice")
+            .order_by("created_at")
+        )
+        rows = []
+        for s in qs:
+            if not s.subscribe:
+                continue
+            person = s.subscribe.person
+            row = {
+                "email": person.email,
+                "name": person.get_full_name(),
+                "first_name": person.first_name,
+                "last_name": person.last_name,
+                "source": s.attribution_source,
+                "subscribed_at": s.created_at.isoformat(),
+                "group_email": group.club.listserv,
+            }
+            response_map = {r.question_id: r for r in s.responses.all()}
+            for q in questions:
+                r = response_map.get(q.pk)
+                if r:
+                    row[q.prompt or f"Q{q.pk}"] = (
+                        r.multiple_choice.value if r.multiple_choice else r.text
+                    )
+                else:
+                    row[q.prompt or f"Q{q.pk}"] = ""
+            rows.append(row)
+        if request.query_params.get("format") == "xlsx":
+            hidden = {"first_name", "last_name", "group_email"}
+            return Response(
+                [{k: v for k, v in row.items() if k not in hidden} for row in rows]
+            )
+
+        fmt = self._requested_export_format(request)
+        if fmt in ("csv", "tsv"):
+            hidden = {"first_name", "last_name", "group_email"}
+            rows = [{k: v for k, v in row.items() if k not in hidden} for row in rows]
+        return subscription_export_response(rows, fmt, "responses")
+
+
+class SubscriptionQuestionViewSet(viewsets.ModelViewSet):
+    serializer_class = SubscriptionQuestionSerializer
+    permission_classes = [SubscriptionGroupPermission | IsSuperuser]
+    http_method_names = ["get", "post", "put", "patch", "delete"]
+
+    def get_queryset(self):
+        return (
+            SubscriptionQuestion.objects.filter(
+                subscription_group__club__code=self.kwargs["club_code"],
+                subscription_group__pk=self.kwargs["subscription_group_pk"],
+            )
+            .order_by("precedence")
+            .prefetch_related("multiple_choice")
+        )
+
+    def perform_create(self, serializer):
+        group = get_object_or_404(
+            SubscriptionGroup,
+            pk=self.kwargs["subscription_group_pk"],
+            club__code=self.kwargs["club_code"],
+        )
+        serializer.save(subscription_group=group)
+
+    @action(detail=False, methods=["post"])
+    def reorder(self, request, **kwargs):
+        """
+        Reorder questions on this subscription form by precedence.
+        ---
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        properties:
+                            question_ids:
+                                type: array
+                                items:
+                                    type: integer
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        ids = request.data.get("question_ids", [])
+        qs = self.get_queryset()
+        id_to_obj = {q.pk: q for q in qs}
+        for idx, qid in enumerate(ids):
+            if qid in id_to_obj:
+                id_to_obj[qid].precedence = idx
+                id_to_obj[qid].save(update_fields=["precedence"])
+        return Response({"detail": "Questions reordered."})
+
+
+class SubscriptionMultipleChoiceViewSet(viewsets.ModelViewSet):
+    serializer_class = SubscriptionMultipleChoiceSerializer
+    permission_classes = [SubscriptionGroupPermission | IsSuperuser]
+    http_method_names = ["get", "post", "put", "patch", "delete"]
+
+    def get_queryset(self):
+        return SubscriptionMultipleChoice.objects.filter(
+            question__subscription_group__club__code=self.kwargs["club_code"],
+            question__subscription_group__pk=self.kwargs["subscription_group_pk"],
+            question__pk=self.kwargs["question_pk"],
+        )
+
+    def perform_create(self, serializer):
+        question = get_object_or_404(
+            SubscriptionQuestion,
+            pk=self.kwargs["question_pk"],
+            subscription_group__pk=self.kwargs["subscription_group_pk"],
+            subscription_group__club__code=self.kwargs["club_code"],
+        )
+        serializer.save(question=question)
+
+
+class SubscriptionSubmissionAdminViewSet(viewsets.ReadOnlyModelViewSet):
+    """Club-owner view of subscribers and their responses."""
+
+    permission_classes = [SubscriptionGroupPermission | IsSuperuser]
+    pagination_class = OptionalPageNumberPagination
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return SubscriberDetailSerializer
+        return SubscriberListSerializer
+
+    def get_queryset(self):
+        qs = (
+            SubscriptionSubmission.objects.filter(
+                subscription_group__club__code=self.kwargs["club_code"],
+                subscription_group__pk=self.kwargs["subscription_group_pk"],
+            )
+            .select_related("subscribe__person__profile")
+            .prefetch_related("responses__question", "responses__multiple_choice")
+        )
+
+        search = self.request.query_params.get("search")
+        if search:
+            qs = qs.filter(
+                Q(subscribe__person__email__icontains=search)
+                | Q(subscribe__person__first_name__icontains=search)
+                | Q(subscribe__person__last_name__icontains=search)
+            )
+        source = self.request.query_params.get("source")
+        if source:
+            qs = qs.filter(attribution_source=source)
+
+        ordering = self.request.query_params.get("ordering", "-created_at")
+        if ordering in (
+            "created_at",
+            "-created_at",
+            "subscribe__person__email",
+            "-subscribe__person__email",
+        ):
+            qs = qs.order_by(ordering)
+
+        return qs
+
+
+class SubscriptionEntryView(APIView):
+    """
+    Public endpoint: whether a club uses instant subscribe or a subscription form.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, club_code):
+        """
+        Return instant vs form mode and optional default form id.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                mode:
+                                    type: string
+                                    enum: [instant, form]
+                                subscription_group_id:
+                                    type: integer
+                                attribution_source:
+                                    type: string
+            "404":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        club = get_object_or_404(Club, code=club_code, archived=False)
+        group = club.default_subscription_group
+        if group is None or group.is_archived or not group.is_currently_open():
+            return Response({"mode": "instant"})
+
+        # Echo back a validated attribution source so the caller can pass it
+        # straight through to the form page and on into the submission.
+        source = request.query_params.get("source", "direct")
+        if source not in dict(ATTRIBUTION_SOURCE_CHOICES):
+            source = "unknown"
+
+        return Response(
+            {
+                "mode": "form",
+                "subscription_group_id": group.pk,
+                "attribution_source": source,
+            }
+        )
+
+
+class SubscriptionPublicGroupView(APIView):
+    """
+    Public subscription form definition for filling out the form.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, pk):
+        """
+        Return the public fields and questions for a subscription form.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                id:
+                                    type: integer
+                                name:
+                                    type: string
+                                description:
+                                    type: string
+                                is_active:
+                                    type: boolean
+                                opens_at:
+                                    type: string
+                                    format: date-time
+                                    nullable: true
+                                closes_at:
+                                    type: string
+                                    format: date-time
+                                    nullable: true
+                                questions:
+                                    type: array
+                                    items:
+                                        type: object
+                                        properties:
+                                            id:
+                                                type: integer
+                                auto_subscribe_eligible:
+                                    type: boolean
+            "404":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        group = get_object_or_404(SubscriptionGroup, pk=pk, is_archived=False)
+        return Response(PublicSubscriptionGroupSerializer(group).data)
+
+
+class SubscriptionSubmitView(APIView):
+    """
+    Submit answers for a subscription form (authenticated user subscribes).
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, pk):
+        """
+        Validate and save subscription form responses for the current user.
+        ---
+        requestBody:
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        properties:
+                            answers:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        question:
+                                            type: integer
+                                        text:
+                                            type: string
+                                        multiple_choice:
+                                            type: integer
+                                            nullable: true
+                            attribution_source:
+                                type: string
+                            attribution_context:
+                                type: object
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                subscribed:
+                                    type: boolean
+                                club_code:
+                                    type: string
+                                subscription_group_id:
+                                    type: integer
+                                submission_id:
+                                    type: integer
+            "400":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        group = get_object_or_404(SubscriptionGroup, pk=pk)
+        if group.is_archived or not group.is_currently_open():
+            return Response(
+                {"detail": "This form is not currently accepting submissions."},
+                status=400,
+            )
+
+        serializer = SubscriptionSubmitSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        required_ids = set(
+            group.questions.filter(required=True).values_list("pk", flat=True)
+        )
+        answered_ids = {a["question"].pk for a in data.get("answers", [])}
+        missing = required_ids - answered_ids
+        if missing:
+            return Response(
+                {
+                    "detail": "Required questions not answered.",
+                    "missing_questions": list(missing),
+                },
+                status=400,
+            )
+
+        source = data.get("attribution_source", "direct")
+        if source not in dict(ATTRIBUTION_SOURCE_CHOICES):
+            source = "unknown"
+
+        with transaction.atomic():
+            subscribe, _ = Subscribe.objects.get_or_create(
+                person=request.user, club=group.club
+            )
+            if subscribe.subscription_group is None:
+                subscribe.subscription_group = group
+                subscribe.save(update_fields=["subscription_group"])
+
+            workflow = SubscriptionFormWorkflow(
+                form_definition=group,
+                user=request.user,
+                subscribe=subscribe,
+                attribution_source=source,
+                attribution_context=data.get("attribution_context", {}),
+            )
+            submission = workflow.submit(
+                [
+                    {
+                        "question": answer["question"],
+                        "text": answer.get("text", ""),
+                        "multiple_choice": answer.get("multiple_choice"),
+                    }
+                    for answer in data.get("answers", [])
+                ]
+            )
+
+        return Response(
+            {
+                "subscribed": True,
+                "club_code": group.club.code,
+                "subscription_group_id": group.pk,
+                "submission_id": submission.pk,
+            }
+        )
+
+
+class SubscriptionMagicLinkResolveView(APIView):
+    """
+    Resolve a signed subscription magic link token to group metadata.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, token):
+        """
+        Validate a subscription link token and return group summary for attribution.
+        ---
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                subscription_group_id:
+                                    type: integer
+                                club_code:
+                                    type: string
+                                group_name:
+                                    type: string
+                                is_active:
+                                    type: boolean
+                                is_archived:
+                                    type: boolean
+                                auto_subscribe_eligible:
+                                    type: boolean
+                                attribution_source:
+                                    type: string
+            "400":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                detail:
+                                    type: string
+        ---
+        """
+        try:
+            raw = token.rsplit(":", 1)[0]
+            group_id = int(raw)
+        except (ValueError, IndexError):
+            return Response({"detail": "Invalid link."}, status=400)
+
+        signer = Signer(salt=f"sub-group-link:{group_id}")
+        try:
+            signer.unsign(token)
+        except BadSignature:
+            return Response({"detail": "Invalid or tampered link."}, status=400)
+
+        group = get_object_or_404(SubscriptionGroup, pk=group_id)
+        return Response(
+            {
+                "subscription_group_id": group.pk,
+                "club_code": group.club.code,
+                "group_name": group.get_display_name(),
+                "is_active": group.is_active,
+                "is_archived": group.is_archived,
+                "auto_subscribe_eligible": group.auto_subscribe_eligible,
+                "attribution_source": "email",
+            }
+        )
 
 
 class ClubVisitViewSet(viewsets.ModelViewSet):

--- a/backend/clubs/workflows.py
+++ b/backend/clubs/workflows.py
@@ -1,0 +1,99 @@
+"""
+Service classes for orchestrating form submission workflows.
+
+`ClubApplication` and `SubscriptionGroup` are both ordered groups of questions a
+user answers, so the submit-and-respond sequence is shared here rather than
+duplicated in each view. `SubscriptionSubmitView` drives `SubscriptionFormWorkflow`;
+an `ApplicationFormWorkflow` can subclass `BaseFormWorkflow` the same way.
+"""
+
+
+class BaseFormWorkflow:
+    """
+    Shared submit-and-respond orchestration for form-definition models.
+    Subclasses must override get_or_create_submission() and save_response().
+    """
+
+    def __init__(self, form_definition, user):
+        self.form_definition = form_definition
+        self.user = user
+
+    def validate_open(self):
+        if not self.form_definition.is_currently_open():
+            raise ValueError(
+                f"'{self.form_definition.get_display_name()}' is not currently open."
+            )
+
+    def get_or_create_submission(self):
+        raise NotImplementedError
+
+    def save_response(self, submission, question, answer_data):
+        raise NotImplementedError
+
+    def submit(self, answers):
+        """
+        Orchestrate a full submission: validate the open window, create or fetch
+        the submission, persist every response, then run post_submit_effects().
+
+        `answers` is a list of dicts shaped {"question": <obj>, ...answer fields}.
+        The caller's dicts are not mutated.
+        """
+        self.validate_open()
+        submission = self.get_or_create_submission()
+        for answer in answers:
+            answer = dict(answer)
+            question = answer.pop("question")
+            self.save_response(submission, question, answer)
+        self.post_submit_effects(submission)
+        return submission
+
+    def post_submit_effects(self, submission):
+        """Hook called after all responses are saved. No-op by default."""
+        pass
+
+
+class SubscriptionFormWorkflow(BaseFormWorkflow):
+    """
+    Workflow for SubscriptionGroup form submissions. Submitting subscribes the
+    user to the club, in contrast to an application, where membership is only
+    created once a club officer accepts the applicant.
+    """
+
+    def __init__(
+        self,
+        form_definition,
+        user,
+        subscribe,
+        attribution_source="unknown",
+        attribution_context=None,
+    ):
+        super().__init__(form_definition, user)
+        self.subscribe = subscribe
+        self.attribution_source = attribution_source
+        self.attribution_context = attribution_context or {}
+
+    def get_or_create_submission(self):
+        from clubs.models import SubscriptionSubmission
+
+        submission, _ = SubscriptionSubmission.objects.get_or_create(
+            subscribe=self.subscribe,
+            subscription_group=self.form_definition,
+            defaults={
+                "attribution_source": self.attribution_source,
+                "attribution_context": self.attribution_context,
+            },
+        )
+        return submission
+
+    def save_response(self, submission, question, answer_data):
+        from clubs.models import SubscriptionQuestionResponse
+
+        SubscriptionQuestionResponse.objects.update_or_create(
+            question=question,
+            submission=submission,
+            defaults=answer_data,
+        )
+
+    def post_submit_effects(self, submission):
+        """Hook for future side-effects (e.g. welcome emails). No-op for now."""
+        pass

--- a/backend/tests/clubs/test_subscription.py
+++ b/backend/tests/clubs/test_subscription.py
@@ -1,0 +1,839 @@
+"""
+Integration tests for the subscription form API.
+"""
+
+import csv
+import io
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from clubs.models import (
+    Club,
+    Membership,
+    Subscribe,
+    SubscriptionGroup,
+    SubscriptionMultipleChoice,
+    SubscriptionQuestion,
+    SubscriptionSubmission,
+)
+
+
+User = get_user_model()
+
+
+class SubscriptionAPITestCase(TestCase):
+    def setUp(self):
+        self.club = Club.objects.create(
+            code="testclub",
+            name="Test Club",
+            approved=True,
+            active=True,
+            listserv="testclub@upenn.edu",
+        )
+        self.officer = User.objects.create_user(
+            "officer", "officer@sas.upenn.edu", "test"
+        )
+        self.officer.first_name = "Olivia"
+        self.officer.last_name = "Officer"
+        self.officer.save()
+        Membership.objects.create(
+            person=self.officer,
+            club=self.club,
+            role=Membership.ROLE_OFFICER,
+        )
+
+        self.student = User.objects.create_user(
+            "student", "student@sas.upenn.edu", "test"
+        )
+        self.student.first_name = "Sam"
+        self.student.last_name = "Student"
+        self.student.save()
+
+        self.group = SubscriptionGroup.objects.create(
+            club=self.club,
+            name="Spring 2026",
+            is_active=True,
+        )
+        self.question = SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.FREE_RESPONSE,
+            prompt="Tell us about yourself",
+            required=True,
+        )
+
+    # ------------------------------------------------------------------ helpers
+    def _list_url(self):
+        return reverse("club-subscription-groups-list", args=(self.club.code,))
+
+    def _detail_url(self, pk=None):
+        return reverse(
+            "club-subscription-groups-detail",
+            args=(self.club.code, pk or self.group.pk),
+        )
+
+    def _action_url(self, action, pk=None):
+        return reverse(
+            f"club-subscription-groups-{action}",
+            args=(self.club.code, pk or self.group.pk),
+        )
+
+    def _questions_url(self):
+        return reverse("sub-group-questions-list", args=(self.club.code, self.group.pk))
+
+    def _question_detail_url(self, question_pk):
+        return reverse(
+            "sub-group-questions-detail",
+            args=(self.club.code, self.group.pk, question_pk),
+        )
+
+    def _options_url(self, question_pk):
+        return reverse(
+            "sub-question-options-list",
+            args=(self.club.code, self.group.pk, question_pk),
+        )
+
+    def _subscribers_url(self):
+        return reverse(
+            "sub-group-subscribers-list", args=(self.club.code, self.group.pk)
+        )
+
+    def _entry_url(self):
+        return reverse("subscription-entry", args=(self.club.code,))
+
+    def _public_url(self, pk=None):
+        return reverse("subscription-group-public", args=(pk or self.group.pk,))
+
+    def _submit_url(self, pk=None):
+        return reverse("subscription-group-submit", args=(pk or self.group.pk,))
+
+    def _subscribe_student(self, source="direct"):
+        """Create a subscriber with one answer, bypassing the API."""
+        subscribe = Subscribe.objects.create(person=self.student, club=self.club)
+        return SubscriptionSubmission.objects.create(
+            subscribe=subscribe,
+            subscription_group=self.group,
+            attribution_source=source,
+        )
+
+    # ------------------------------------------------------------------ list / create
+    def test_list_forms_officer(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._list_url())
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        self.assertEqual(len(data), 1, resp.content)
+        self.assertIn("question_count", data[0])
+        self.assertIn("submission_count", data[0])
+        self.assertIn("subscriber_count", data[0])
+
+    def test_subscriber_count_matches_actual_subscribers(self):
+        """
+        Regression: subscriber_count counted Subscribe rows whose FK pointed at
+        the group, but the submit path only sets that FK when it is null, so a
+        student already subscribed to the club was never counted. The Overview
+        tile then read 0 while the Subscribers tab listed people.
+        """
+        # already subscribed to the club before this form existed
+        Subscribe.objects.create(person=self.student, club=self.club)
+        self.client.login(username=self.student.username, password="test")
+        self.client.post(
+            self._submit_url(),
+            {"answers": [{"question": self.question.pk, "text": "hello"}]},
+            content_type="application/json",
+        )
+
+        self.client.login(username=self.officer.username, password="test")
+        data = self.client.get(self._list_url()).json()
+        group = next(g for g in data if g["id"] == self.group.pk)
+        self.assertEqual(group["subscriber_count"], 1, data)
+
+        subscribers = self.client.get(self._subscribers_url()).json()
+        if isinstance(subscribers, dict):
+            subscribers = subscribers.get("results", subscribers)
+        self.assertEqual(
+            group["subscriber_count"],
+            len(subscribers),
+            "Overview count must agree with the Subscribers tab",
+        )
+
+    def test_list_forms_non_officer_rejected(self):
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.get(self._list_url())
+        self.assertEqual(resp.status_code, 403, resp.content)
+
+    def test_create_form_officer(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(
+            self._list_url(),
+            {"name": "Fall 2026", "is_active": False},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.content)
+        self.assertTrue(SubscriptionGroup.objects.filter(name="Fall 2026").exists())
+
+    def test_create_form_non_officer_rejected(self):
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.post(
+            self._list_url(),
+            {"name": "Fall 2026", "is_active": False},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+
+    # ------------------------------------------------------------------ actions
+    def test_set_default(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(self._action_url("set-default"))
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.club.refresh_from_db()
+        self.assertEqual(self.club.default_subscription_group_id, self.group.pk)
+
+    def test_set_default_archived_rejected(self):
+        self.group.is_archived = True
+        self.group.save()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(self._action_url("set-default"))
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_archive_unsets_default(self):
+        self.club.default_subscription_group = self.group
+        self.club.save()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(self._action_url("archive"))
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.club.refresh_from_db()
+        self.assertIsNone(self.club.default_subscription_group)
+        self.group.refresh_from_db()
+        self.assertTrue(self.group.is_archived)
+
+    def test_archive_default_stays_unset_after_club_save(self):
+        """
+        Regression: a post_save receiver used to re-create a default form on
+        every club save, making archive a no-op and instant subscribe
+        unreachable. Saving the club must not resurrect a default.
+        """
+        self.club.default_subscription_group = self.group
+        self.club.save()
+        self.client.login(username=self.officer.username, password="test")
+        self.client.post(self._action_url("archive"))
+
+        self.club.refresh_from_db()
+        self.club.name = "Test Club Renamed"
+        self.club.save()
+
+        self.club.refresh_from_db()
+        self.assertIsNone(self.club.default_subscription_group)
+        self.assertEqual(SubscriptionGroup.objects.filter(club=self.club).count(), 1)
+
+    def test_close_before_open_rejected(self):
+        self.client.login(username=self.officer.username, password="test")
+        now = timezone.now()
+        resp = self.client.patch(
+            self._detail_url(),
+            {
+                "opens_at": (now + timezone.timedelta(days=5)).isoformat(),
+                "closes_at": (now + timezone.timedelta(days=1)).isoformat(),
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+        self.assertIn("closes_at", resp.json())
+
+    def test_close_equal_to_open_rejected(self):
+        self.client.login(username=self.officer.username, password="test")
+        stamp = (timezone.now() + timezone.timedelta(days=2)).isoformat()
+        resp = self.client.patch(
+            self._detail_url(),
+            {"opens_at": stamp, "closes_at": stamp},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_close_before_stored_open_rejected_on_partial_update(self):
+        """A PATCH sending only closes_at must still be checked against the
+        opens_at already stored on the form."""
+        now = timezone.now()
+        self.group.opens_at = now + timezone.timedelta(days=5)
+        self.group.save()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.patch(
+            self._detail_url(),
+            {"closes_at": (now + timezone.timedelta(days=1)).isoformat()},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_valid_window_accepted(self):
+        self.client.login(username=self.officer.username, password="test")
+        now = timezone.now()
+        resp = self.client.patch(
+            self._detail_url(),
+            {
+                "opens_at": (now + timezone.timedelta(days=1)).isoformat(),
+                "closes_at": (now + timezone.timedelta(days=5)).isoformat(),
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.group.refresh_from_db()
+        self.assertLess(self.group.opens_at, self.group.closes_at)
+
+    def test_open_date_alone_accepted(self):
+        """Either bound may be left blank; only the pair is constrained."""
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.patch(
+            self._detail_url(),
+            {"opens_at": (timezone.now() + timezone.timedelta(days=1)).isoformat()},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+
+    def test_create_with_close_before_open_rejected(self):
+        self.client.login(username=self.officer.username, password="test")
+        now = timezone.now()
+        resp = self.client.post(
+            self._list_url(),
+            {
+                "name": "Bad Window",
+                "opens_at": (now + timezone.timedelta(days=5)).isoformat(),
+                "closes_at": (now + timezone.timedelta(days=1)).isoformat(),
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+        self.assertFalse(SubscriptionGroup.objects.filter(name="Bad Window").exists())
+
+    def test_unarchive(self):
+        self.group.is_archived = True
+        self.group.save()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(self._action_url("unarchive"))
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.group.refresh_from_db()
+        self.assertFalse(self.group.is_archived)
+
+    def test_actions_reject_non_officer(self):
+        self.client.login(username=self.student.username, password="test")
+        for action in ("set-default", "archive", "unarchive"):
+            resp = self.client.post(self._action_url(action))
+            self.assertEqual(resp.status_code, 403, f"{action}: {resp.content}")
+
+    # ------------------------------------------------------------------ entry
+    def test_subscription_entry_no_default(self):
+        resp = self.client.get(self._entry_url())
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.json()["mode"], "instant")
+
+    def test_subscription_entry_with_default(self):
+        self.club.default_subscription_group = self.group
+        self.club.save()
+        resp = self.client.get(self._entry_url())
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        self.assertEqual(data["mode"], "form")
+        self.assertEqual(data["subscription_group_id"], self.group.pk)
+        self.assertEqual(data["attribution_source"], "direct")
+
+    def test_subscription_entry_echoes_valid_source(self):
+        self.club.default_subscription_group = self.group
+        self.club.save()
+        resp = self.client.get(self._entry_url(), {"source": "fair"})
+        self.assertEqual(resp.json()["attribution_source"], "fair")
+
+    def test_subscription_entry_rejects_unknown_source(self):
+        self.club.default_subscription_group = self.group
+        self.club.save()
+        resp = self.client.get(self._entry_url(), {"source": "not-a-source"})
+        self.assertEqual(resp.json()["attribution_source"], "unknown")
+
+    def test_subscription_entry_closed_default_falls_back_to_instant(self):
+        self.group.is_active = False
+        self.group.save()
+        self.club.default_subscription_group = self.group
+        self.club.save()
+        resp = self.client.get(self._entry_url())
+        self.assertEqual(resp.json()["mode"], "instant")
+
+    # ------------------------------------------------------------------ public
+    def test_public_group_visible_to_anonymous(self):
+        resp = self.client.get(self._public_url())
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        self.assertEqual(data["id"], self.group.pk)
+        self.assertFalse(data["auto_subscribe_eligible"])
+        self.assertEqual(len(data["questions"]), 1)
+
+    def test_public_group_auto_subscribe_when_no_questions(self):
+        self.question.delete()
+        resp = self.client.get(self._public_url())
+        self.assertTrue(resp.json()["auto_subscribe_eligible"])
+
+    def test_public_group_info_text_still_auto_subscribes(self):
+        """Informational text is not a question, so it should not block."""
+        self.question.delete()
+        SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.INFO_TEXT,
+            prompt="Welcome!",
+        )
+        resp = self.client.get(self._public_url())
+        self.assertTrue(resp.json()["auto_subscribe_eligible"], resp.content)
+
+    # ------------------------------------------------------------------ submit
+    def test_submit_requires_authentication(self):
+        resp = self.client.post(
+            self._submit_url(),
+            {"answers": [{"question": self.question.pk, "text": "Hi"}]},
+            content_type="application/json",
+        )
+        self.assertIn(resp.status_code, [401, 403], resp.content)
+        self.assertFalse(SubscriptionSubmission.objects.exists())
+
+    def test_submit_creates_subscribe(self):
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.post(
+            self._submit_url(),
+            {
+                "subscription_group": self.group.pk,
+                "answers": [{"question": self.question.pk, "text": "Hello world"}],
+                "attribution_source": "direct",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertTrue(
+            Subscribe.objects.filter(person=self.student, club=self.club).exists()
+        )
+        submission = SubscriptionSubmission.objects.get(
+            subscribe__person=self.student, subscription_group=self.group
+        )
+        self.assertEqual(submission.responses.count(), 1)
+        self.assertEqual(submission.responses.first().text, "Hello world")
+
+    def test_submit_records_attribution_source(self):
+        self.client.login(username=self.student.username, password="test")
+        self.client.post(
+            self._submit_url(),
+            {
+                "answers": [{"question": self.question.pk, "text": "Hi"}],
+                "attribution_source": "fair",
+            },
+            content_type="application/json",
+        )
+        submission = SubscriptionSubmission.objects.get(subscription_group=self.group)
+        self.assertEqual(submission.attribution_source, "fair")
+
+    def test_submit_coerces_invalid_attribution_source(self):
+        self.client.login(username=self.student.username, password="test")
+        self.client.post(
+            self._submit_url(),
+            {
+                "answers": [{"question": self.question.pk, "text": "Hi"}],
+                "attribution_source": "definitely-not-valid",
+            },
+            content_type="application/json",
+        )
+        submission = SubscriptionSubmission.objects.get(subscription_group=self.group)
+        self.assertEqual(submission.attribution_source, "unknown")
+
+    def test_submit_multiple_choice_answer(self):
+        question = SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.MULTIPLE_CHOICE,
+            prompt="Which committee?",
+        )
+        option = SubscriptionMultipleChoice.objects.create(
+            question=question, value="Design"
+        )
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.post(
+            self._submit_url(),
+            {
+                "answers": [
+                    {"question": self.question.pk, "text": "Hi"},
+                    {"question": question.pk, "multiple_choice": option.pk},
+                ]
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        submission = SubscriptionSubmission.objects.get(subscription_group=self.group)
+        response = submission.responses.get(question=question)
+        self.assertEqual(response.multiple_choice_id, option.pk)
+
+    def test_submit_idempotent(self):
+        self.client.login(username=self.student.username, password="test")
+        payload = {
+            "answers": [{"question": self.question.pk, "text": "Hello"}],
+            "attribution_source": "direct",
+        }
+        self.client.post(self._submit_url(), payload, content_type="application/json")
+        self.client.post(self._submit_url(), payload, content_type="application/json")
+        self.assertEqual(
+            Subscribe.objects.filter(person=self.student, club=self.club).count(), 1
+        )
+        self.assertEqual(
+            SubscriptionSubmission.objects.filter(
+                subscribe__person=self.student, subscription_group=self.group
+            ).count(),
+            1,
+        )
+
+    def test_submit_updates_answer_on_resubmit(self):
+        self.client.login(username=self.student.username, password="test")
+        for text in ("first answer", "second answer"):
+            self.client.post(
+                self._submit_url(),
+                {"answers": [{"question": self.question.pk, "text": text}]},
+                content_type="application/json",
+            )
+        submission = SubscriptionSubmission.objects.get(subscription_group=self.group)
+        self.assertEqual(submission.responses.count(), 1)
+        self.assertEqual(submission.responses.first().text, "second answer")
+
+    def test_submit_closed_form_rejected(self):
+        self.group.is_active = False
+        self.group.save()
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.post(
+            self._submit_url(),
+            {"answers": [{"question": self.question.pk, "text": "Hi"}]},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_submit_outside_window_rejected(self):
+        self.group.closes_at = timezone.now() - timezone.timedelta(days=1)
+        self.group.save()
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.post(
+            self._submit_url(),
+            {"answers": [{"question": self.question.pk, "text": "Hi"}]},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_submit_missing_required_rejected(self):
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.post(
+            self._submit_url(),
+            {"answers": [], "attribution_source": "direct"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+        self.assertIn("missing_questions", resp.json())
+        self.assertFalse(SubscriptionSubmission.objects.exists())
+
+    # ------------------------------------------------------------------ questions
+    def test_create_question(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(
+            self._questions_url(),
+            {
+                "question_type": SubscriptionQuestion.SHORT_ANSWER,
+                "prompt": "Favourite color?",
+                "required": False,
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.content)
+        self.assertEqual(self.group.questions.count(), 2)
+
+    def test_edit_question(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.patch(
+            self._question_detail_url(self.question.pk),
+            {"prompt": "Updated prompt"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.question.refresh_from_db()
+        self.assertEqual(self.question.prompt, "Updated prompt")
+
+    def test_delete_question(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.delete(self._question_detail_url(self.question.pk))
+        self.assertEqual(resp.status_code, 204, resp.content)
+        self.assertEqual(self.group.questions.count(), 0)
+
+    def test_question_multiple_choice_written_from_nested_payload(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(
+            self._questions_url(),
+            {
+                "question_type": SubscriptionQuestion.MULTIPLE_CHOICE,
+                "prompt": "Which committee?",
+                "multiple_choice": [{"value": "Design"}, {"value": "Engineering"}],
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.content)
+        question = self.group.questions.get(prompt="Which committee?")
+        self.assertEqual(
+            sorted(question.multiple_choice.values_list("value", flat=True)),
+            ["Design", "Engineering"],
+        )
+
+    def test_multiple_choice_option_crud(self):
+        question = SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.MULTIPLE_CHOICE,
+            prompt="Which committee?",
+        )
+        self.client.login(username=self.officer.username, password="test")
+
+        resp = self.client.post(
+            self._options_url(question.pk),
+            {"value": "Design"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.content)
+        option_id = resp.json()["id"]
+
+        resp = self.client.get(self._options_url(question.pk))
+        self.assertEqual(len(resp.json()), 1, resp.content)
+
+        resp = self.client.delete(
+            reverse(
+                "sub-question-options-detail",
+                args=(self.club.code, self.group.pk, question.pk, option_id),
+            )
+        )
+        self.assertEqual(resp.status_code, 204, resp.content)
+        self.assertEqual(question.multiple_choice.count(), 0)
+
+    def test_reorder_questions(self):
+        second = SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.SHORT_ANSWER,
+            prompt="Second",
+            precedence=1,
+        )
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.post(
+            reverse(
+                "sub-group-questions-reorder", args=(self.club.code, self.group.pk)
+            ),
+            {"question_ids": [second.pk, self.question.pk]},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        second.refresh_from_db()
+        self.question.refresh_from_db()
+        self.assertEqual(second.precedence, 0)
+        self.assertEqual(self.question.precedence, 1)
+
+    def test_questions_reject_non_officer(self):
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.get(self._questions_url())
+        self.assertEqual(resp.status_code, 403, resp.content)
+
+    # ------------------------------------------------------------------ subscribers
+    def test_subscriber_list_officer_only(self):
+        self.client.login(username=self.student.username, password="test")
+        resp = self.client.get(self._subscribers_url())
+        self.assertEqual(resp.status_code, 403, resp.content)
+
+    def test_subscriber_list_returns_data(self):
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._subscribers_url())
+        self.assertEqual(resp.status_code, 200, resp.content)
+        results = resp.json()
+        if isinstance(results, dict):
+            results = results.get("results", results)
+        self.assertEqual(len(results), 1, resp.content)
+        self.assertEqual(results[0]["email"], self.student.email)
+
+    def test_subscriber_list_filters_by_source(self):
+        self._subscribe_student(source="fair")
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._subscribers_url(), {"source": "search"})
+        results = resp.json()
+        if isinstance(results, dict):
+            results = results.get("results", results)
+        self.assertEqual(len(results), 0, resp.content)
+
+    # ------------------------------------------------------------------ exports
+    def _export_url(self, kind="emails"):
+        return reverse(
+            f"club-subscription-groups-export-{kind}",
+            args=(self.club.code, self.group.pk),
+        )
+
+    def test_export_emails_csv_default(self):
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url())
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertIn("text/csv", resp["Content-Type"])
+        self.assertIn("filename=emails.csv", resp["Content-Disposition"])
+        content = resp.content.decode("utf-8-sig")
+        self.assertIn("email,name,source,subscribed_at", content)
+        self.assertIn(self.student.email, content)
+        # helper-only columns must not leak into the download
+        self.assertNotIn("first_name", content)
+        self.assertNotIn("group_email", content)
+
+    def test_export_emails_tsv_has_tsv_extension(self):
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url(), {"fmt": "tsv"})
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertIn("tab-separated", resp["Content-Type"])
+        self.assertIn("filename=emails.tsv", resp["Content-Disposition"])
+        self.assertIn("\t", resp.content.decode("utf-8-sig"))
+
+    def test_export_emails_plain_text_list(self):
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url(), {"fmt": "txt"})
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertIn("text/plain", resp["Content-Type"])
+        self.assertIn("filename=emails-list.txt", resp["Content-Disposition"])
+        self.assertEqual(resp.content.decode("utf-8").strip(), self.student.email)
+
+    def test_export_emails_mailchimp_headers(self):
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url(), {"fmt": "mailchimp"})
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = list(csv.reader(io.StringIO(resp.content.decode("utf-8-sig"))))
+        self.assertEqual(rows[0], ["Email Address", "First Name", "Last Name"])
+        self.assertEqual(rows[1], [self.student.email, "Sam", "Student"])
+
+    def test_export_emails_google_groups_headers(self):
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url(), {"fmt": "google-groups"})
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = list(csv.reader(io.StringIO(resp.content.decode("utf-8-sig"))))
+        self.assertEqual(
+            rows[0],
+            [
+                "Group Email [Required]",
+                "Member Email",
+                "Member Type",
+                "Member Role",
+            ],
+        )
+        self.assertEqual(
+            rows[1],
+            [self.club.listserv, self.student.email, "USER", "MEMBER"],
+        )
+
+    def test_export_filenames_are_distinct_per_format(self):
+        """
+        CSV, Mailchimp and Google Groups are all CSV files. If they share a
+        filename they are indistinguishable in the browser's download list.
+        """
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        names = {}
+        for fmt in ("csv", "tsv", "txt", "mailchimp", "google-groups"):
+            resp = self.client.get(self._export_url(), {"fmt": fmt})
+            self.assertEqual(resp.status_code, 200, resp.content)
+            names[fmt] = resp["Content-Disposition"].split("filename=")[1]
+        self.assertEqual(
+            len(set(names.values())), len(names), f"duplicate filenames: {names}"
+        )
+        self.assertEqual(names["mailchimp"], "emails-mailchimp.csv")
+        self.assertEqual(names["google-groups"], "emails-google-groups.csv")
+
+    def test_export_formats_have_distinct_contents(self):
+        """The formats must differ in substance, not only in filename."""
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        bodies = {
+            fmt: self.client.get(self._export_url(), {"fmt": fmt}).content
+            for fmt in ("csv", "tsv", "txt", "mailchimp", "google-groups")
+        }
+        self.assertEqual(len(set(bodies.values())), len(bodies))
+
+    def test_export_emails_xlsx(self):
+        self._subscribe_student()
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url(), {"format": "xlsx"})
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(len(resp.data), 1)
+
+    def test_export_unknown_format_rejected(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url(), {"fmt": "parquet"})
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_export_responses_includes_question_columns(self):
+        submission = self._subscribe_student()
+        submission.responses.create(question=self.question, text="my answer")
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._export_url("responses"))
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertIn("filename=responses.csv", resp["Content-Disposition"])
+        content = resp.content.decode("utf-8-sig")
+        self.assertIn(self.question.prompt, content)
+        self.assertIn("my answer", content)
+
+    def test_export_rejects_non_officer(self):
+        self.client.login(username=self.student.username, password="test")
+        for kind in ("emails", "responses"):
+            resp = self.client.get(self._export_url(kind))
+            self.assertEqual(resp.status_code, 403, f"{kind}: {resp.content}")
+
+    # ------------------------------------------------------------------ magic link
+    def test_magic_link_round_trip(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._action_url("magic-link"))
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        self.assertIn("/subscribe/link/", data["url"])
+        self.assertNotIn("/api/subscription-links/", data["url"])
+        self.assertFalse(data["auto_subscribe_eligible"])
+
+        self.client.logout()
+        resolve_resp = self.client.get(
+            reverse("subscription-link-resolve", args=(data["token"],))
+        )
+        self.assertEqual(resolve_resp.status_code, 200, resolve_resp.content)
+        resolved = resolve_resp.json()
+        self.assertEqual(resolved["subscription_group_id"], self.group.pk)
+        self.assertEqual(resolved["club_code"], self.club.code)
+
+    def test_magic_link_uses_default_domain(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._action_url("magic-link"))
+        self.assertTrue(
+            resp.json()["url"].startswith(f"https://{settings.DEFAULT_DOMAIN}/"),
+            resp.content,
+        )
+
+    def test_magic_link_matches_qr_code_target(self):
+        """The QR image and the copyable link must point at the same URL."""
+        self.client.login(username=self.officer.username, password="test")
+        link = self.client.get(self._action_url("magic-link")).json()["url"]
+
+        from clubs.views import build_subscription_magic_link
+
+        self.assertEqual(link, build_subscription_magic_link(self.group))
+
+    def test_magic_link_invalid_token(self):
+        resp = self.client.get(
+            reverse("subscription-link-resolve", args=("999:tampered",))
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_qr_code_returns_png(self):
+        self.client.login(username=self.officer.username, password="test")
+        resp = self.client.get(self._action_url("qr-code"))
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp["Content-Type"], "image/png")
+        self.assertTrue(resp.content.startswith(b"\x89PNG"))
+
+    def test_magic_link_rejects_non_officer(self):
+        self.client.login(username=self.student.username, password="test")
+        for action in ("magic-link", "qr-code"):
+            resp = self.client.get(self._action_url(action))
+            self.assertEqual(resp.status_code, 403, f"{action}: {resp.content}")

--- a/backend/tests/clubs/test_subscription_models.py
+++ b/backend/tests/clubs/test_subscription_models.py
@@ -1,0 +1,325 @@
+"""
+Unit tests for the subscription form models and the shared form workflow.
+These exercise model methods and service classes directly, without HTTP.
+"""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+from django.utils import timezone
+
+from clubs.models import (
+    Club,
+    ClubApplication,
+    Subscribe,
+    SubscriptionGroup,
+    SubscriptionMultipleChoice,
+    SubscriptionQuestion,
+    SubscriptionQuestionResponse,
+    SubscriptionSubmission,
+)
+from clubs.views import build_subscription_magic_link, subscription_link_base
+from clubs.workflows import BaseFormWorkflow, SubscriptionFormWorkflow
+
+
+User = get_user_model()
+
+
+class SubscriptionGroupModelTestCase(TestCase):
+    def setUp(self):
+        self.club = Club.objects.create(code="testclub", name="Test Club")
+        self.group = SubscriptionGroup.objects.create(
+            club=self.club, name="Spring 2026", is_active=True
+        )
+        self.now = timezone.now()
+
+    def test_inactive_group_is_never_open(self):
+        self.group.is_active = False
+        self.assertFalse(self.group.is_currently_open())
+
+    def test_active_group_with_no_window_is_open(self):
+        self.assertTrue(self.group.is_currently_open())
+
+    def test_not_open_before_opens_at(self):
+        self.group.opens_at = self.now + timezone.timedelta(days=1)
+        self.assertFalse(self.group.is_currently_open())
+
+    def test_not_open_after_closes_at(self):
+        self.group.closes_at = self.now - timezone.timedelta(days=1)
+        self.assertFalse(self.group.is_currently_open())
+
+    def test_open_inside_window(self):
+        self.group.opens_at = self.now - timezone.timedelta(days=1)
+        self.group.closes_at = self.now + timezone.timedelta(days=1)
+        self.assertTrue(self.group.is_currently_open())
+
+    def test_at_argument_overrides_now(self):
+        self.group.opens_at = self.now + timezone.timedelta(days=5)
+        self.group.closes_at = self.now + timezone.timedelta(days=10)
+        self.assertFalse(self.group.is_currently_open())
+        self.assertTrue(
+            self.group.is_currently_open(at=self.now + timezone.timedelta(days=7))
+        )
+
+    def test_display_name_falls_back_when_unnamed(self):
+        unnamed = SubscriptionGroup.objects.create(club=self.club, name="")
+        self.assertEqual(unnamed.get_display_name(), f"Subscription Group {unnamed.pk}")
+
+    def test_display_name_uses_name_when_set(self):
+        self.assertEqual(self.group.get_display_name(), "Spring 2026")
+
+    def test_auto_subscribe_eligible_with_no_questions(self):
+        self.assertTrue(self.group.auto_subscribe_eligible)
+
+    def test_info_text_does_not_block_auto_subscribe(self):
+        SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.INFO_TEXT,
+            prompt="Welcome to the club!",
+        )
+        self.assertTrue(self.group.auto_subscribe_eligible)
+
+    def test_optional_question_still_blocks_auto_subscribe(self):
+        """
+        An optional question is still something the student should get the
+        chance to answer, so it must not be silently skipped.
+        """
+        SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.SHORT_ANSWER,
+            prompt="Favourite color?",
+            required=False,
+        )
+        self.assertFalse(self.group.auto_subscribe_eligible)
+
+    def test_saving_club_creates_no_subscription_group(self):
+        """
+        Regression: a post_save receiver used to auto-create a default form for
+        every club, which made instant subscribe unreachable. Clubs must opt in.
+        """
+        club = Club.objects.create(code="fresh-club", name="Fresh Club")
+        self.assertTrue(club.enables_subscription)
+        self.assertIsNone(club.default_subscription_group)
+        self.assertEqual(SubscriptionGroup.objects.filter(club=club).count(), 0)
+
+        club.name = "Fresh Club Renamed"
+        club.save()
+        club.refresh_from_db()
+        self.assertIsNone(club.default_subscription_group)
+        self.assertEqual(SubscriptionGroup.objects.filter(club=club).count(), 0)
+
+
+class FormDefinitionMixinTestCase(TestCase):
+    """
+    ClubApplication is the other implementor of FormDefinitionBehaviorMixin, so
+    the workflow contract must hold for it too.
+    """
+
+    def setUp(self):
+        self.club = Club.objects.create(code="testclub", name="Test Club")
+        self.now = timezone.now()
+
+    def _application(self, start_offset, end_offset, name="Fall Application"):
+        return ClubApplication.objects.create(
+            name=name,
+            club=self.club,
+            application_start_time=self.now + timezone.timedelta(days=start_offset),
+            application_end_time=self.now + timezone.timedelta(days=end_offset),
+            result_release_time=self.now + timezone.timedelta(days=end_offset + 1),
+        )
+
+    def test_application_open_inside_window(self):
+        self.assertTrue(self._application(-1, 1).is_currently_open())
+
+    def test_application_closed_before_start(self):
+        self.assertFalse(self._application(1, 2).is_currently_open())
+
+    def test_application_closed_after_end(self):
+        self.assertFalse(self._application(-2, -1).is_currently_open())
+
+    def test_application_display_name(self):
+        self.assertEqual(
+            self._application(-1, 1).get_display_name(), "Fall Application"
+        )
+
+    def test_base_workflow_requires_subclass_implementations(self):
+        workflow = BaseFormWorkflow(self._application(-1, 1), None)
+        with self.assertRaises(NotImplementedError):
+            workflow.get_or_create_submission()
+        with self.assertRaises(NotImplementedError):
+            workflow.save_response(None, None, {})
+
+
+class SubscriptionFormWorkflowTestCase(TestCase):
+    def setUp(self):
+        self.club = Club.objects.create(code="testclub", name="Test Club")
+        self.user = User.objects.create_user("student", "s@upenn.edu", "test")
+        self.group = SubscriptionGroup.objects.create(
+            club=self.club, name="Spring 2026", is_active=True
+        )
+        self.question = SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.FREE_RESPONSE,
+            prompt="Why this club?",
+        )
+        self.subscribe = Subscribe.objects.create(person=self.user, club=self.club)
+
+    def _workflow(self, source="direct"):
+        return SubscriptionFormWorkflow(
+            form_definition=self.group,
+            user=self.user,
+            subscribe=self.subscribe,
+            attribution_source=source,
+        )
+
+    def test_validate_open_raises_on_closed_form(self):
+        self.group.is_active = False
+        self.group.save()
+        with self.assertRaises(ValueError) as ctx:
+            self._workflow().validate_open()
+        self.assertIn("Spring 2026", str(ctx.exception))
+
+    def test_validate_open_passes_on_open_form(self):
+        self._workflow().validate_open()
+
+    def test_get_or_create_submission_is_idempotent(self):
+        workflow = self._workflow()
+        first = workflow.get_or_create_submission()
+        second = workflow.get_or_create_submission()
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(SubscriptionSubmission.objects.count(), 1)
+
+    def test_submit_persists_responses(self):
+        submission = self._workflow().submit(
+            [{"question": self.question, "text": "Because it is great"}]
+        )
+        self.assertEqual(submission.responses.count(), 1)
+        self.assertEqual(submission.responses.first().text, "Because it is great")
+
+    def test_submit_records_attribution_source(self):
+        submission = self._workflow(source="fair").submit([])
+        self.assertEqual(submission.attribution_source, "fair")
+
+    def test_submit_updates_existing_response(self):
+        workflow = self._workflow()
+        workflow.submit([{"question": self.question, "text": "first"}])
+        workflow.submit([{"question": self.question, "text": "second"}])
+        self.assertEqual(SubscriptionQuestionResponse.objects.count(), 1)
+        self.assertEqual(SubscriptionQuestionResponse.objects.first().text, "second")
+
+    def test_submit_saves_multiple_choice(self):
+        mc_question = SubscriptionQuestion.objects.create(
+            subscription_group=self.group,
+            question_type=SubscriptionQuestion.MULTIPLE_CHOICE,
+            prompt="Committee?",
+        )
+        option = SubscriptionMultipleChoice.objects.create(
+            question=mc_question, value="Design"
+        )
+        submission = self._workflow().submit(
+            [{"question": mc_question, "text": "", "multiple_choice": option}]
+        )
+        self.assertEqual(
+            submission.responses.get(question=mc_question).multiple_choice_id,
+            option.pk,
+        )
+
+    def test_submit_does_not_mutate_caller_answers(self):
+        """
+        The workflow pops "question" off each answer; it must copy first so the
+        caller can reuse or re-inspect the list it passed in.
+        """
+        answers = [{"question": self.question, "text": "hello"}]
+        self._workflow().submit(answers)
+        self.assertIn("question", answers[0])
+        self.assertEqual(answers[0]["question"], self.question)
+
+    def test_submit_raises_on_closed_form_before_writing(self):
+        self.group.is_active = False
+        self.group.save()
+        with self.assertRaises(ValueError):
+            self._workflow().submit(
+                [{"question": self.question, "text": "should not persist"}]
+            )
+        self.assertEqual(SubscriptionSubmission.objects.count(), 0)
+        self.assertEqual(SubscriptionQuestionResponse.objects.count(), 0)
+
+    def test_post_submit_effects_is_called(self):
+        called = []
+
+        class RecordingWorkflow(SubscriptionFormWorkflow):
+            def post_submit_effects(self, submission):
+                called.append(submission)
+
+        RecordingWorkflow(
+            form_definition=self.group,
+            user=self.user,
+            subscribe=self.subscribe,
+        ).submit([])
+        self.assertEqual(len(called), 1)
+
+
+class SubscriptionLinkBaseTestCase(TestCase):
+    """
+    Magic links and QR codes must point at the production domain in production,
+    but at the calling dev frontend under DEBUG so they can be followed locally.
+    """
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.club = Club.objects.create(code="testclub", name="Test Club")
+        self.group = SubscriptionGroup.objects.create(
+            club=self.club, name="Spring 2026", is_active=True
+        )
+        self.dev_origin = "http://localhost:3001"
+
+    def _request(self, origin=None, referer=None):
+        headers = {}
+        if origin:
+            headers["HTTP_ORIGIN"] = origin
+        if referer:
+            headers["HTTP_REFERER"] = referer
+        return self.factory.get("/", **headers)
+
+    def test_defaults_to_production_domain(self):
+        self.assertEqual(subscription_link_base(), f"https://{settings.DEFAULT_DOMAIN}")
+
+    def test_no_request_uses_production_domain(self):
+        with override_settings(DEBUG=True):
+            self.assertEqual(
+                subscription_link_base(None), f"https://{settings.DEFAULT_DOMAIN}"
+            )
+
+    @override_settings(DEBUG=True, CSRF_TRUSTED_ORIGINS=["http://localhost:3001"])
+    def test_trusted_dev_origin_is_honoured(self):
+        base = subscription_link_base(self._request(origin=self.dev_origin))
+        self.assertEqual(base, self.dev_origin)
+
+    @override_settings(DEBUG=True, CSRF_TRUSTED_ORIGINS=["http://localhost:3001"])
+    def test_referer_used_when_origin_absent(self):
+        base = subscription_link_base(
+            self._request(referer=f"{self.dev_origin}/club/testclub/edit/")
+        )
+        self.assertEqual(base, self.dev_origin)
+
+    @override_settings(DEBUG=True, CSRF_TRUSTED_ORIGINS=["http://localhost:3001"])
+    def test_untrusted_origin_is_ignored(self):
+        base = subscription_link_base(self._request(origin="https://evil.example"))
+        self.assertEqual(base, f"https://{settings.DEFAULT_DOMAIN}")
+
+    @override_settings(DEBUG=False, CSRF_TRUSTED_ORIGINS=["http://localhost:3001"])
+    def test_origin_ignored_outside_debug(self):
+        base = subscription_link_base(self._request(origin=self.dev_origin))
+        self.assertEqual(base, f"https://{settings.DEFAULT_DOMAIN}")
+
+    @override_settings(DEBUG=True, CSRF_TRUSTED_ORIGINS=["http://localhost:3001"])
+    def test_magic_link_uses_the_resolved_base(self):
+        url = build_subscription_magic_link(
+            self.group, self._request(origin=self.dev_origin)
+        )
+        self.assertTrue(url.startswith(f"{self.dev_origin}/subscribe/link/"))
+
+    def test_magic_link_token_round_trips(self):
+        url = build_subscription_magic_link(self.group)
+        token = url.rsplit("/", 1)[-1]
+        self.assertTrue(token.startswith(f"{self.group.pk}:"))

--- a/frontend/components/ClubDetails.tsx
+++ b/frontend/components/ClubDetails.tsx
@@ -130,6 +130,7 @@ const Details = ({ club }: DetailsProps): ReactElement<any> => {
               <SubscribeIcon
                 club={club}
                 padding="0"
+                source="search"
                 onSubscribe={(status) => {
                   updateClub?.(club.code, 'subscribe', status)
                 }}

--- a/frontend/components/ClubEditPage.tsx
+++ b/frontend/components/ClubEditPage.tsx
@@ -12,6 +12,7 @@ import InviteCard from '../components/ClubEditPage/InviteCard'
 import MemberExperiencesCard from '../components/ClubEditPage/MemberExperiencesCard'
 import MembersCard from '../components/ClubEditPage/MembersCard'
 import QRCodeCard, { QRCodeType } from '../components/ClubEditPage/QRCodeCard'
+import SubscriptionsPage from '../components/ClubEditPage/SubscriptionsPage'
 import {
   CLUB_EDIT_ROUTE,
   CLUB_RENEW_ROUTE,
@@ -371,6 +372,11 @@ const ClubForm = ({
         label: `Applications Page`,
         content: <ApplicationsPage club={club} />,
         disabled: !SHOW_APPLICATIONS,
+      },
+      {
+        name: 'subscriptions',
+        label: 'Subscriptions',
+        content: <SubscriptionsPage club={club} />,
       },
       {
         name: 'resources',

--- a/frontend/components/ClubEditPage/ApplicationsPage.tsx
+++ b/frontend/components/ClubEditPage/ApplicationsPage.tsx
@@ -6,7 +6,6 @@ import Select from 'react-select'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
 
-import { ALLBIRDS_GRAY, CLUBS_BLUE, MD, mediaMaxWidth, SNOW } from '~/constants'
 import {
   computeWordCount,
   formatQuestionType,
@@ -31,30 +30,11 @@ import {
   TextField,
 } from '../FormComponents'
 import ModelForm from '../ModelForm'
-
-const StyledHeader = styled.div.attrs({ className: 'is-clearfix' })`
-  margin-bottom: 20px;
-  color: ${CLUBS_BLUE};
-  font-size: 18px;
-  & > .info {
-    float: left;
-  }
-  .tools {
-    float: right;
-    margin: 0;
-    margin-left: auto;
-    & > div {
-      margin-left: 20px;
-      display: inline-block;
-    }
-  }
-
-  ${mediaMaxWidth(MD)} {
-    .tools {
-      margin-top: 20px;
-    }
-  }
-`
+import {
+  FormWrapper,
+  ScrollWrapper,
+  StyledHeader,
+} from './FormManagementStyles'
 
 const TableWrapper = styled.div`
 transform:rotateX(180deg);
@@ -62,27 +42,6 @@ transform:rotateX(180deg);
 -webkit-transform:rotateX(180deg);
 font-size: 14px;
 over
-`
-
-const ScrollWrapper = styled.div`
-  transform: rotateX(180deg);
-  -ms-transform: rotateX(180deg); /* IE 9 */
-  -webkit-transform: rotateX(180deg);
-  overflow-y: auto;
-  margin-top: 1rem;
-`
-
-const FormWrapper = styled.div`
-  border-bottom: 1px solid ${ALLBIRDS_GRAY};
-  padding: 12px;
-  cursor: pointer;
-
-  &:hover,
-  &:active,
-  &:focus {
-    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.2);
-    background-color: ${SNOW};
-  }
 `
 
 export const APPLICATION_STATUS: Array<{ value: number; label: string }> = [

--- a/frontend/components/ClubEditPage/FormManagementStyles.ts
+++ b/frontend/components/ClubEditPage/FormManagementStyles.ts
@@ -1,0 +1,73 @@
+import styled from 'styled-components'
+
+import { ALLBIRDS_GRAY, CLUBS_BLUE, MD, mediaMaxWidth, SNOW } from '~/constants'
+
+/**
+ * Layout primitives shared by the club-edit pages that manage question-based
+ * forms (applications and subscription forms). Both screens present the same
+ * shape — a titled header with a right-aligned tool slot, a list of clickable
+ * form rows, and modal bodies — so the styles live here rather than being
+ * duplicated per page.
+ */
+
+export const StyledHeader = styled.div.attrs({ className: 'is-clearfix' })`
+  margin-bottom: 20px;
+  color: ${CLUBS_BLUE};
+  font-size: 18px;
+  & > .info {
+    float: left;
+  }
+  .tools {
+    float: right;
+    margin: 0;
+    margin-left: auto;
+    & > div {
+      margin-left: 20px;
+      display: inline-block;
+    }
+  }
+
+  ${mediaMaxWidth(MD)} {
+    .tools {
+      margin-top: 20px;
+    }
+  }
+`
+
+export const FormWrapper = styled.div`
+  border-bottom: 1px solid ${ALLBIRDS_GRAY};
+  padding: 12px;
+  cursor: pointer;
+
+  &:hover,
+  &:active,
+  &:focus {
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.2);
+    background-color: ${SNOW};
+  }
+`
+
+export const ModalContainer = styled.div`
+  text-align: left;
+  padding: 20px;
+`
+
+/**
+ * Flips the scroll container so its horizontal scrollbar sits above the table.
+ * The content inside MUST be counter-rotated by a second wrapper, or it renders
+ * upside down — see ApplicationsPage's TableWrapper. Prefer TableScroll below
+ * unless you specifically want the scrollbar on top.
+ */
+export const ScrollWrapper = styled.div`
+  transform: rotateX(180deg);
+  -ms-transform: rotateX(180deg); /* IE 9 */
+  -webkit-transform: rotateX(180deg);
+  overflow-y: auto;
+  margin-top: 1rem;
+`
+
+/** Plain horizontal scroll container for wide tables. */
+export const TableScroll = styled.div`
+  overflow-x: auto;
+  margin-top: 1rem;
+`

--- a/frontend/components/ClubEditPage/QRCodeCard.tsx
+++ b/frontend/components/ClubEditPage/QRCodeCard.tsx
@@ -18,26 +18,35 @@ const QRCode = styled.img`
 export enum QRCodeType {
   CLUB = 'clubs',
   TICKET = 'tickets',
+  SUBSCRIPTION = 'subscription',
 }
 
 const QRCodeCard: React.FC<
   PropsWithChildren<{
     id: string
     type: QRCodeType
+    /**
+     * API path serving the PNG, without the leading /api. Defaults to the
+     * conventional /{type}/{id}/qr route; pass this when the endpoint does not
+     * follow that shape (subscription forms are nested under their club).
+     */
+    apiPath?: string
+    title?: string
   }>
-> = ({ id, type, children }) => {
+> = ({ id, type, apiPath, title, children }) => {
+  const qrPath = apiPath ?? `/${type}/${id}/qr`
   return (
-    <BaseCard title="QR Code">
+    <BaseCard title={title ?? 'QR Code'}>
       {type === QRCodeType.CLUB && (
         <Text>
           When scanned, gives mobile-friendly access to your{' '}
           {OBJECT_NAME_SINGULAR} page and bookmark/subscribe actions.
         </Text>
       )}
-      <QRCode src={getApiUrl(`/${type}/${id}/qr`)} alt="qr code" />
+      <QRCode src={getApiUrl(qrPath)} alt="qr code" />
       <div className="buttons">
         <a
-          href={getApiUrl(`/${type}/${id}/qr`)}
+          href={getApiUrl(qrPath)}
           download={`${id}.png`}
           className="button is-success"
         >

--- a/frontend/components/ClubEditPage/SubscriptionsPage.tsx
+++ b/frontend/components/ClubEditPage/SubscriptionsPage.tsx
@@ -1,0 +1,897 @@
+import { Field, Form, Formik, FormikHelpers } from 'formik'
+import React, { ReactElement, useEffect, useState } from 'react'
+import { toast } from 'react-toastify'
+
+import {
+  Club,
+  SubscriberListItem,
+  SubscriptionGroup,
+  SubscriptionQuestionType,
+} from '~/types'
+import { doApiRequest, formatResponse, getApiUrl } from '~/utils'
+
+import { Loading, Modal, Text } from '../common'
+import { Icon } from '../common/Icon'
+import Table from '../common/Table'
+import {
+  CheckboxField,
+  CreatableMultipleSelectField,
+  DateTimeField,
+  SelectField,
+  TextField,
+} from '../FormComponents'
+import ModelForm from '../ModelForm'
+import BaseCard from './BaseCard'
+import {
+  FormWrapper,
+  ModalContainer,
+  StyledHeader,
+  TableScroll,
+} from './FormManagementStyles'
+import QRCodeCard, { QRCodeType } from './QRCodeCard'
+
+type Props = {
+  club: Club
+}
+
+const QUESTION_TYPES = [
+  { value: SubscriptionQuestionType.FreeResponse, label: 'Free Response' },
+  { value: SubscriptionQuestionType.MultipleChoice, label: 'Multiple Choice' },
+  { value: SubscriptionQuestionType.ShortAnswer, label: 'Short Answer' },
+  { value: SubscriptionQuestionType.InfoText, label: 'Informational Text' },
+]
+
+const ATTRIBUTION_LABELS: Record<string, string> = {
+  direct: 'Club Page',
+  fair: 'Activities Fair',
+  search: 'Search Results',
+  email: 'Email / Magic Link',
+  external: 'External Link',
+  import: 'Imported',
+  unknown: 'Unknown',
+}
+
+/** Status tags shown beside a form name, shared by the list and detail views. */
+const StatusTags = ({ group }: { group: SubscriptionGroup }) => (
+  <>
+    {group.is_default && <span className="tag is-info ml-2">Default</span>}
+    {group.is_archived ? (
+      <span className="tag is-warning ml-2">Archived</span>
+    ) : group.is_active ? (
+      <span className="tag is-success ml-2">Active</span>
+    ) : (
+      <span className="tag is-light ml-2">Inactive</span>
+    )}
+  </>
+)
+
+type InnerTab = 'overview' | 'questions' | 'subscribers' | 'distribution'
+
+const INNER_TABS: { key: InnerTab; label: string }[] = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'questions', label: 'Questions' },
+  { key: 'subscribers', label: 'Subscribers' },
+  { key: 'distribution', label: 'Distribution' },
+]
+
+/* -------------------------------------------------------------------------- */
+/* Overview                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const OverviewTab = ({
+  club,
+  group,
+  onUpdated,
+}: {
+  club: Club
+  group: SubscriptionGroup
+  onUpdated: () => void
+}): ReactElement<any> => {
+  const [pending, setPending] = useState(false)
+  const baseUrl = `/clubs/${club.code}/subscription-groups/${group.id}`
+
+  const handleSave = async (
+    values: Partial<SubscriptionGroup>,
+    { setStatus }: FormikHelpers<any>,
+  ) => {
+    const resp = await doApiRequest(`${baseUrl}/?format=json`, {
+      method: 'PATCH',
+      body: values,
+    })
+
+    if (resp.ok) {
+      setStatus({})
+      toast.success('Form updated.')
+      onUpdated()
+      return
+    }
+
+    // Field errors render from Formik's `status`, not `errors` — see
+    // useFieldWrapper in FormComponents. Pass the DRF error dict straight
+    // through so messages appear under the field they belong to, and toast
+    // as well so the failure is visible without scrolling.
+    const err = await resp.json().catch(() => null)
+    if (err && typeof err === 'object') {
+      setStatus(err)
+      toast.error(formatResponse(err))
+    } else {
+      toast.error('Failed to update form.')
+    }
+  }
+
+  const postAction = async (action: string, success: string) => {
+    setPending(true)
+    const resp = await doApiRequest(`${baseUrl}/${action}/?format=json`, {
+      method: 'POST',
+    })
+    setPending(false)
+    if (resp.ok) {
+      toast.success(success)
+      onUpdated()
+    } else {
+      const data = await resp.json().catch(() => ({}))
+      toast.error(data.detail ?? 'Action failed.')
+    }
+  }
+
+  return (
+    <>
+      <BaseCard title="At a Glance">
+        <div className="columns">
+          <div className="column has-text-centered">
+            <p className="heading">Subscribers</p>
+            <p className="title">{group.subscriber_count}</p>
+          </div>
+          <div className="column has-text-centered">
+            <p className="heading">Questions</p>
+            <p className="title">{group.question_count}</p>
+          </div>
+        </div>
+      </BaseCard>
+
+      <BaseCard title="Settings">
+        <Formik
+          enableReinitialize
+          initialValues={{
+            name: group.name,
+            description: group.description ?? '',
+            is_active: group.is_active,
+            opens_at: group.opens_at,
+            closes_at: group.closes_at,
+          }}
+          onSubmit={handleSave}
+        >
+          {({ isSubmitting }) => (
+            <Form>
+              <Field name="name" label="Name" as={TextField} required />
+              <Field name="description" label="Description" as={TextField} />
+              <Field
+                name="is_active"
+                label="Active (accepting submissions)"
+                as={CheckboxField}
+              />
+              <Field
+                name="opens_at"
+                label="Opens At"
+                as={DateTimeField}
+                helpText="Leave blank to accept submissions as soon as the form is active."
+              />
+              <Field
+                name="closes_at"
+                label="Closes At"
+                as={DateTimeField}
+                helpText="Leave blank to keep the form open indefinitely."
+              />
+              <button
+                type="submit"
+                className="button is-primary"
+                disabled={isSubmitting}
+              >
+                Save
+              </button>
+            </Form>
+          )}
+        </Formik>
+      </BaseCard>
+
+      <BaseCard title="Default Subscription Form">
+        <Text>
+          When a form is set as the default, the subscribe button on the club
+          page opens it instead of subscribing immediately. Until then, students
+          are subscribed in one click.
+        </Text>
+        {group.is_default ? (
+          <span className="tag is-info">
+            This is the default subscription form.
+          </span>
+        ) : (
+          <button
+            className="button is-primary"
+            disabled={pending || group.is_archived}
+            onClick={() => postAction('set-default', 'Default form updated.')}
+          >
+            <Icon name="check" alt="set default" /> Set as Default
+          </button>
+        )}
+        {group.is_archived && !group.is_default && (
+          <p className="help">An archived form cannot be made the default.</p>
+        )}
+      </BaseCard>
+
+      <BaseCard title="Danger Zone">
+        {group.is_archived ? (
+          <>
+            <Text>
+              This form is archived. It accepts no new submissions, and existing
+              subscriber data is retained.
+            </Text>
+            <button
+              className="button is-warning"
+              disabled={pending}
+              onClick={() => postAction('unarchive', 'Form unarchived.')}
+            >
+              Unarchive Form
+            </button>
+          </>
+        ) : (
+          <>
+            <Text>
+              Archiving hides the form and stops new submissions. Subscribers
+              already collected are kept, and the form can be restored later.
+            </Text>
+            <button
+              className="button is-danger"
+              disabled={pending}
+              onClick={() => {
+                if (
+                  confirm(
+                    'Are you sure you want to archive this subscription form?',
+                  )
+                ) {
+                  postAction('archive', 'Form archived.')
+                }
+              }}
+            >
+              Archive Form
+            </button>
+          </>
+        )}
+      </BaseCard>
+    </>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Questions                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const QuestionsTab = ({
+  club,
+  group,
+  onUpdated,
+}: {
+  club: Club
+  group: SubscriptionGroup
+  onUpdated: () => void
+}): ReactElement<any> => {
+  // Formik cannot drive conditional fields on its own, so mirror the applications
+  // question editor and track the in-progress question type locally.
+  const [questionType, setQuestionType] =
+    useState<SubscriptionQuestionType | null>(null)
+  const [multipleChoices, setMultipleChoices] =
+    useState<{ label: string; value: string }[]>()
+
+  const baseUrl = `/clubs/${club.code}/subscription-groups/${group.id}/questions/`
+
+  return (
+    <BaseCard title="Questions">
+      <Text>
+        Questions are shown in the order below — drag a row to reorder them. A
+        form with no questions subscribes students instantly when they open its
+        magic link.
+      </Text>
+      <ModelForm
+        baseUrl={baseUrl}
+        draggable={true}
+        confirmDeletion={true}
+        noun="Question"
+        empty="No questions yet. Students who open this form are subscribed right away."
+        tableFields={[
+          { name: 'prompt', label: 'Prompt' },
+          {
+            name: 'question_type',
+            label: 'Type',
+            converter: (type) =>
+              QUESTION_TYPES.find((x) => x.value === type)?.label ?? type,
+          },
+          {
+            name: 'required',
+            label: 'Required',
+            converter: (required) => (required ? 'Yes' : 'No'),
+          },
+        ]}
+        fields={
+          <>
+            <Field
+              name="question_type"
+              as={SelectField}
+              choices={QUESTION_TYPES}
+              required={true}
+              helpText="Type of question on the subscription form."
+              valueDeserialize={(a: SubscriptionQuestionType) =>
+                QUESTION_TYPES.find((x) => x.value === a)
+              }
+              serialize={(a: { value: SubscriptionQuestionType }) => a.value}
+            />
+            <Field
+              name="prompt"
+              as={TextField}
+              required={true}
+              helpText="Prompt shown to the student for this question."
+            />
+            {questionType !== SubscriptionQuestionType.InfoText && (
+              <Field
+                name="required"
+                as={CheckboxField}
+                label="Students must answer this question before subscribing"
+              />
+            )}
+            {questionType === SubscriptionQuestionType.FreeResponse && (
+              <Field
+                name="word_limit"
+                as={TextField}
+                type="number"
+                helpText="Word limit for this free response question. Leave at 0 for no limit."
+              />
+            )}
+            {questionType === SubscriptionQuestionType.MultipleChoice && (
+              <Field
+                name="multiple_choice"
+                as={CreatableMultipleSelectField}
+                initialValues={multipleChoices}
+                helpText="Options students can choose from. Press enter after each one."
+              />
+            )}
+          </>
+        }
+        onChange={(value) => {
+          setQuestionType(value.question_type as SubscriptionQuestionType)
+          if (value.multiple_choice != null) {
+            setMultipleChoices(
+              (value.multiple_choice as { value: string }[]).map((item) => ({
+                value: item.value,
+                label: item.value,
+              })),
+            )
+          }
+        }}
+        onUpdate={(questions) => {
+          // Persist the dragged order; the endpoint assigns precedence by index.
+          doApiRequest(`${baseUrl}reorder/?format=json`, {
+            method: 'POST',
+            body: { question_ids: questions.map((question) => question.id) },
+          }).then((resp) => {
+            if (!resp.ok) {
+              toast.error('Failed to save question order.')
+            }
+          })
+          onUpdated()
+        }}
+      />
+    </BaseCard>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Subscribers                                                                 */
+/* -------------------------------------------------------------------------- */
+
+type SubscriberDetail = SubscriberListItem & {
+  responses: {
+    question_id: number
+    prompt: string
+    question_type: number
+    text: string
+    multiple_choice_value: string | null
+  }[]
+}
+
+type ExportFormat = {
+  key: string
+  label: string
+  file: string
+  help: string
+}
+
+/**
+ * Every option here is a download of the same subscriber list — what differs is
+ * the column layout each destination expects. Mailchimp and Google Groups are
+ * both CSV files; they carry the exact headers those tools require on import,
+ * so no column mapping is needed on the other end.
+ */
+const EXPORT_FORMATS: ExportFormat[] = [
+  {
+    key: 'csv',
+    label: 'Spreadsheet (CSV)',
+    file: 'emails.csv',
+    help: 'Name, email, source and date. Opens in Excel, Numbers or Sheets.',
+  },
+  {
+    key: 'tsv',
+    label: 'Spreadsheet (TSV)',
+    file: 'emails.tsv',
+    help: 'Same columns as CSV, tab separated for tools that require it.',
+  },
+  {
+    key: 'txt',
+    label: 'Plain email list',
+    file: 'emails-list.txt',
+    help: 'Just the addresses, one per line — paste straight into a listserv.',
+  },
+  {
+    key: 'mailchimp',
+    label: 'Mailchimp',
+    file: 'emails-mailchimp.csv',
+    help: 'CSV with Email Address / First Name / Last Name headers.',
+  },
+  {
+    key: 'google-groups',
+    label: 'Google Groups',
+    file: 'emails-google-groups.csv',
+    help: 'CSV shaped for the Google Groups bulk member import.',
+  },
+]
+
+const SubscribersTab = ({
+  club,
+  group,
+}: {
+  club: Club
+  group: SubscriptionGroup
+}): ReactElement<any> => {
+  const [subscribers, setSubscribers] = useState<SubscriberListItem[] | null>(
+    null,
+  )
+  const [detail, setDetail] = useState<SubscriberDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [exportFormat, setExportFormat] = useState<ExportFormat>(
+    EXPORT_FORMATS[0],
+  )
+
+  const baseUrl = `/clubs/${club.code}/subscription-groups/${group.id}`
+
+  useEffect(() => {
+    setSubscribers(null)
+    doApiRequest(`${baseUrl}/subscribers/?format=json`)
+      .then((resp) => resp.json())
+      .then((data) => {
+        setSubscribers(Array.isArray(data) ? data : (data.results ?? []))
+      })
+      .catch(() => {
+        toast.error('Failed to load subscribers.')
+        setSubscribers([])
+      })
+  }, [group.id])
+
+  const openDetail = (submissionId: number) => {
+    setDetailLoading(true)
+    setDetail(null)
+    doApiRequest(`${baseUrl}/subscribers/${submissionId}/?format=json`)
+      .then((resp) => resp.json())
+      .then((data) => {
+        setDetail(data)
+        setDetailLoading(false)
+      })
+      .catch(() => {
+        toast.error('Failed to load subscriber.')
+        setDetailLoading(false)
+      })
+  }
+
+  if (subscribers === null) {
+    return <Loading />
+  }
+
+  // Table keys rows by `id`, while the API keys submissions by `submission_id`.
+  const tableData = subscribers.map((subscriber) => ({
+    ...subscriber,
+    id: subscriber.submission_id,
+    source: ATTRIBUTION_LABELS[subscriber.attribution_source] ?? 'Unknown',
+    subscribed_on: new Date(subscriber.subscribed_at).toLocaleDateString(),
+  }))
+
+  return (
+    <BaseCard title="Subscribers">
+      <div className="mb-5">
+        <p className="has-text-weight-semibold mb-1">Email list</p>
+        <p className="is-size-7 has-text-grey mb-2">
+          The same subscribers every time — pick the layout your mailing tool
+          expects.
+        </p>
+        <div className="field has-addons">
+          <div className="control">
+            <div className="select is-small">
+              <select
+                value={exportFormat.key}
+                onChange={(e) =>
+                  setExportFormat(
+                    EXPORT_FORMATS.find((f) => f.key === e.target.value) ??
+                      EXPORT_FORMATS[0],
+                  )
+                }
+              >
+                {EXPORT_FORMATS.map((format) => (
+                  <option key={format.key} value={format.key}>
+                    {format.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="control">
+            <a
+              className="button is-link is-small"
+              href={getApiUrl(
+                `/clubs/${club.code}/subscription-groups/${group.id}/export/emails/?fmt=${exportFormat.key}`,
+              )}
+            >
+              <Icon name="download" alt="export" /> Download
+            </a>
+          </div>
+        </div>
+        <p className="is-size-7 has-text-grey">
+          {exportFormat.help} Downloads as <code>{exportFormat.file}</code>.
+        </p>
+
+        <p className="has-text-weight-semibold mt-4 mb-1">Full responses</p>
+        <p className="is-size-7 has-text-grey mb-2">
+          Everything above plus one column per question, for reading what
+          students actually wrote.
+        </p>
+        <div className="buttons">
+          <a
+            className="button is-success is-small"
+            href={getApiUrl(
+              `/clubs/${club.code}/subscription-groups/${group.id}/export/responses/?format=xlsx`,
+            )}
+          >
+            <Icon name="download" alt="export" /> Excel
+          </a>
+          <a
+            className="button is-light is-small"
+            href={getApiUrl(
+              `/clubs/${club.code}/subscription-groups/${group.id}/export/responses/?fmt=csv`,
+            )}
+          >
+            <Icon name="download" alt="export" /> CSV
+          </a>
+        </div>
+      </div>
+
+      {subscribers.length === 0 ? (
+        <Text>No subscribers yet.</Text>
+      ) : (
+        <TableScroll>
+          <Table
+            data={tableData}
+            columns={[
+              { name: 'name', label: 'Name' },
+              { name: 'email', label: 'Email' },
+              { name: 'graduation_year', label: 'Grad Year' },
+              { name: 'source', label: 'Source' },
+              { name: 'subscribed_on', label: 'Subscribed' },
+            ]}
+            searchableColumns={['name', 'email']}
+            filterOptions={[
+              {
+                label: 'source',
+                options: Object.entries(ATTRIBUTION_LABELS).map(
+                  ([key, label]) => ({ key: label, label }),
+                ),
+                filterFunction: (selection, object) =>
+                  object.source === selection,
+              },
+            ]}
+            focusable={true}
+            onClick={(row) => openDetail(row.original.submission_id)}
+          />
+        </TableScroll>
+      )}
+
+      {(detail || detailLoading) && (
+        <Modal
+          show={true}
+          closeModal={() => {
+            setDetail(null)
+            setDetailLoading(false)
+          }}
+          width="600px"
+          marginBottom={false}
+        >
+          <ModalContainer>
+            {detailLoading || !detail ? (
+              <Loading />
+            ) : (
+              <>
+                <p className="title is-5 mb-1">{detail.name}</p>
+                <p className="has-text-grey mb-1">{detail.email}</p>
+                <p className="has-text-grey is-size-7 mb-4">
+                  Subscribed via{' '}
+                  {ATTRIBUTION_LABELS[detail.attribution_source] ?? 'Unknown'}{' '}
+                  on {new Date(detail.subscribed_at).toLocaleDateString()}
+                </p>
+                {detail.responses.length === 0 ? (
+                  <Text>No question responses recorded.</Text>
+                ) : (
+                  detail.responses.map((response) => (
+                    <div key={response.question_id} className="mb-3">
+                      <p className="has-text-weight-semibold">
+                        {response.prompt}
+                      </p>
+                      <p>
+                        {response.multiple_choice_value || response.text || '—'}
+                      </p>
+                    </div>
+                  ))
+                )}
+              </>
+            )}
+          </ModalContainer>
+        </Modal>
+      )}
+    </BaseCard>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Distribution                                                                */
+/* -------------------------------------------------------------------------- */
+
+const DistributionTab = ({
+  club,
+  group,
+}: {
+  club: Club
+  group: SubscriptionGroup
+}): ReactElement<any> => {
+  const [magicLink, setMagicLink] = useState<string | null>(null)
+  const [autoSubscribe, setAutoSubscribe] = useState<boolean>(false)
+
+  useEffect(() => {
+    setMagicLink(null)
+    doApiRequest(
+      `/clubs/${club.code}/subscription-groups/${group.id}/magic-link/?format=json`,
+    )
+      .then((resp) => (resp.ok ? resp.json() : null))
+      .then((data) => {
+        if (data) {
+          setMagicLink(data.url)
+          setAutoSubscribe(data.auto_subscribe_eligible)
+        } else {
+          toast.error('Failed to generate magic link.')
+        }
+      })
+  }, [group.id])
+
+  return (
+    <>
+      <BaseCard title="Magic Link">
+        <Text>
+          {autoSubscribe
+            ? 'This form has no questions, so anyone opening this link is subscribed as soon as they sign in.'
+            : 'Anyone opening this link is taken straight to this subscription form.'}
+        </Text>
+        {magicLink == null ? (
+          <Loading />
+        ) : (
+          <div className="field has-addons">
+            <div className="control is-expanded">
+              <input className="input" readOnly value={magicLink} />
+            </div>
+            <div className="control">
+              <button
+                className="button is-primary"
+                onClick={() => {
+                  navigator.clipboard.writeText(magicLink)
+                  toast.success('Link copied to clipboard.')
+                }}
+              >
+                <Icon name="clipboard" alt="copy" /> Copy
+              </button>
+            </div>
+          </div>
+        )}
+      </BaseCard>
+
+      <QRCodeCard
+        id={`${club.code}-subscription-${group.id}`}
+        type={QRCodeType.SUBSCRIPTION}
+        apiPath={`/clubs/${club.code}/subscription-groups/${group.id}/qr-code`}
+      >
+        <Text className="mt-3">
+          Print this code on a flyer or show it at an activities fair. Scanning
+          it opens the magic link above.
+        </Text>
+      </QRCodeCard>
+    </>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Page                                                                        */
+/* -------------------------------------------------------------------------- */
+
+const SubscriptionsPage = ({ club }: Props): ReactElement<any> => {
+  const [groups, setGroups] = useState<SubscriptionGroup[] | null>(null)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [innerTab, setInnerTab] = useState<InnerTab>('overview')
+  const [showCreateModal, setShowCreateModal] = useState(false)
+
+  const loadGroups = () => {
+    doApiRequest(`/clubs/${club.code}/subscription-groups/?format=json`)
+      .then((resp) => resp.json())
+      .then((data) => {
+        setGroups(Array.isArray(data) ? data : (data.results ?? []))
+      })
+      .catch(() => {
+        toast.error('Failed to load subscription forms.')
+        setGroups([])
+      })
+  }
+
+  useEffect(loadGroups, [])
+
+  const handleCreate = async (values: {
+    name: string
+    description: string
+    is_active: boolean
+  }) => {
+    const resp = await doApiRequest(
+      `/clubs/${club.code}/subscription-groups/?format=json`,
+      { method: 'POST', body: values },
+    )
+    if (resp.ok) {
+      toast.success('Form created.')
+      setShowCreateModal(false)
+      loadGroups()
+    } else {
+      toast.error('Failed to create form.')
+    }
+  }
+
+  if (groups === null) {
+    return <Loading />
+  }
+
+  // Read the selection out of the freshly loaded list so the detail view keeps
+  // showing current counts and flags after any mutation.
+  const selected = groups.find((group) => group.id === selectedId) ?? null
+
+  if (selected) {
+    return (
+      <div>
+        <button
+          className="button is-light is-small mb-3"
+          onClick={() => setSelectedId(null)}
+        >
+          <Icon name="chevron-left" alt="back" /> All Forms
+        </button>
+        <StyledHeader>
+          <span className="info">
+            {selected.name}
+            <StatusTags group={selected} />
+          </span>
+        </StyledHeader>
+
+        <div className="tabs">
+          <ul>
+            {INNER_TABS.map((tab) => (
+              <li
+                key={tab.key}
+                className={innerTab === tab.key ? 'is-active' : ''}
+              >
+                <a onClick={() => setInnerTab(tab.key)}>{tab.label}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {innerTab === 'overview' && (
+          <OverviewTab club={club} group={selected} onUpdated={loadGroups} />
+        )}
+        {innerTab === 'questions' && (
+          <QuestionsTab club={club} group={selected} onUpdated={loadGroups} />
+        )}
+        {innerTab === 'subscribers' && (
+          <SubscribersTab club={club} group={selected} />
+        )}
+        {innerTab === 'distribution' && (
+          <DistributionTab club={club} group={selected} />
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <StyledHeader>
+        <span className="info">Subscription Forms</span>
+        <div className="tools">
+          <button
+            className="button is-primary is-small"
+            onClick={() => setShowCreateModal(true)}
+          >
+            <Icon name="plus" alt="create" /> New Form
+          </button>
+        </div>
+      </StyledHeader>
+
+      {groups.length === 0 ? (
+        <Text>
+          No subscription forms yet. Create one to collect more than an email
+          address when students subscribe.
+        </Text>
+      ) : (
+        groups.map((group) => (
+          <FormWrapper
+            key={group.id}
+            onClick={() => {
+              setSelectedId(group.id)
+              setInnerTab('overview')
+            }}
+          >
+            <span className="has-text-weight-semibold">{group.name}</span>
+            <StatusTags group={group} />
+            <span className="is-pulled-right has-text-grey is-size-7">
+              {group.question_count} questions · {group.subscriber_count}{' '}
+              subscribers
+              <Icon name="chevron-right" alt="open" style={{ marginLeft: 8 }} />
+            </span>
+          </FormWrapper>
+        ))
+      )}
+
+      {showCreateModal && (
+        <Modal
+          show={showCreateModal}
+          closeModal={() => setShowCreateModal(false)}
+          width="500px"
+          marginBottom={false}
+        >
+          <ModalContainer>
+            <p className="title is-5 mb-3">New Subscription Form</p>
+            <Formik
+              initialValues={{ name: '', description: '', is_active: true }}
+              onSubmit={handleCreate}
+            >
+              {({ isSubmitting }) => (
+                <Form>
+                  <Field name="name" label="Name" as={TextField} required />
+                  <Field
+                    name="description"
+                    label="Description"
+                    as={TextField}
+                  />
+                  <Field
+                    name="is_active"
+                    label="Active immediately"
+                    as={CheckboxField}
+                  />
+                  <button
+                    type="submit"
+                    className="button is-primary mt-2"
+                    disabled={isSubmitting}
+                  >
+                    Create
+                  </button>
+                </Form>
+              )}
+            </Formik>
+          </ModalContainer>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+export default SubscriptionsPage

--- a/frontend/components/ClubPage/Actions.tsx
+++ b/frontend/components/ClubPage/Actions.tsx
@@ -326,7 +326,7 @@ const Actions = ({
             {club.enables_subscription && (
               <>
                 <ActionDiv>|</ActionDiv>
-                <SubscribeIcon padding="0" club={club} />
+                <SubscribeIcon padding="0" club={club} source="direct" />
               </>
             )}
           </ActionWrapper>

--- a/frontend/components/common/SubscribeIcon.tsx
+++ b/frontend/components/common/SubscribeIcon.tsx
@@ -1,9 +1,10 @@
+import { useRouter } from 'next/router'
 import { ReactElement, useContext, useState } from 'react'
 import styled from 'styled-components'
 
 import { BLACK, MEDIUM_GRAY } from '../../constants/colors'
-import { Club } from '../../types'
-import { apiSetSubscribeStatus } from '../../utils'
+import { Club, SubscriptionEntryResponse } from '../../types'
+import { apiSetSubscribeStatus, doApiRequest } from '../../utils'
 import { AuthCheckContext } from '../contexts'
 
 const SubscribeIconTag = styled.span<{
@@ -43,6 +44,12 @@ type SubscribeIconProps = {
   absolute?: boolean
   padding?: string
   onSubscribe?: (status: boolean) => void
+  /**
+   * Where this icon is being rendered, recorded against the subscription so
+   * clubs can see how students found them. Must be one of the backend's
+   * ATTRIBUTION_SOURCE_CHOICES; anything else is stored as "unknown".
+   */
+  source?: 'direct' | 'search' | 'fair' | 'external'
 }
 
 export const SubscribeIcon = ({
@@ -50,12 +57,29 @@ export const SubscribeIcon = ({
   absolute = false,
   padding,
   onSubscribe = () => null,
+  source = 'direct',
 }: SubscribeIconProps): ReactElement<any> => {
   const [subscribe, setSubscribe] = useState<boolean>(club.is_subscribe)
   const authCheck = useContext(AuthCheckContext)
+  const router = useRouter()
 
   const updateSubscribe = () => {
-    authCheck(() => {
+    authCheck(async () => {
+      if (!subscribe) {
+        const resp = await doApiRequest(
+          `/clubs/${club.code}/subscription-entry/?source=${source}&format=json`,
+        )
+        if (resp.ok) {
+          const data: SubscriptionEntryResponse = await resp.json()
+          if (data.mode === 'form' && data.subscription_group_id) {
+            router.push(
+              `/club/${club.code}/subscribe/${data.subscription_group_id}` +
+                `?source=${data.attribution_source ?? source}`,
+            )
+            return
+          }
+        }
+      }
       apiSetSubscribeStatus(club.code, !subscribe).then(() => {
         setSubscribe(!subscribe)
         onSubscribe(!subscribe)

--- a/frontend/pages/club/[club]/subscribe/[groupId].tsx
+++ b/frontend/pages/club/[club]/subscribe/[groupId].tsx
@@ -1,0 +1,257 @@
+import { Field, Form, Formik } from 'formik'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { ReactElement, useEffect, useState } from 'react'
+import renderPage from 'renderPage'
+import { SubscriptionGroup, SubscriptionQuestionType, UserInfo } from 'types'
+import { doApiRequest } from 'utils'
+
+import { Container, Loading, Text, Title } from '~/components/common'
+import AuthPrompt from '~/components/common/AuthPrompt'
+
+type SubscribeFormPageProps = {
+  userInfo?: UserInfo
+  authenticated: boolean | null
+}
+
+function SubscribeFormPage({
+  userInfo,
+  authenticated,
+}: SubscribeFormPageProps): ReactElement<any> {
+  const router = useRouter()
+  const {
+    club: clubCode,
+    groupId,
+    source,
+  } = router.query as {
+    club: string
+    groupId: string
+    source?: string
+  }
+
+  const [group, setGroup] = useState<SubscriptionGroup | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!groupId) return
+    doApiRequest(`/subscription-groups/${groupId}/public/?format=json`)
+      .then(async (r) => {
+        const text = await r.text()
+        let data: any
+        try {
+          data = JSON.parse(text)
+        } catch {
+          setError(`Failed to load form (non-JSON response, HTTP ${r.status}).`)
+          setLoading(false)
+          return
+        }
+        if (!r.ok) {
+          setError(data?.detail ?? `Failed to load form (HTTP ${r.status}).`)
+          setLoading(false)
+          return
+        }
+        setGroup(data)
+        setLoading(false)
+      })
+      .catch((err) => {
+        setError(`Network error: ${err?.message ?? String(err)}`)
+        setLoading(false)
+      })
+  }, [groupId])
+
+  if (loading || authenticated === null) {
+    return (
+      <Container>
+        <Loading />
+      </Container>
+    )
+  }
+
+  // Submitting requires a signed-in user, so prompt before showing the form
+  // rather than letting a fair QR scan dead-end on a failed submit.
+  if (!userInfo) {
+    return (
+      <AuthPrompt title="One last step..." hasLogin={true}>
+        Please log in with your PennKey to fill out this subscription form.
+      </AuthPrompt>
+    )
+  }
+
+  if (error || !group) {
+    return (
+      <Container>
+        <Text>{error ?? 'Subscription form not found.'}</Text>
+      </Container>
+    )
+  }
+
+  if (!group.is_active || (group as any).is_archived) {
+    return (
+      <Container>
+        <Title>{group.name}</Title>
+        <div className="notification is-warning">
+          This form is not currently accepting submissions.
+        </div>
+        <Link href={`/club/${clubCode}`} className="button">
+          Back to Club Page
+        </Link>
+      </Container>
+    )
+  }
+
+  if (submitted) {
+    return (
+      <Container>
+        <Title>Subscribed!</Title>
+        <div className="notification is-success">
+          You have successfully subscribed to <strong>{group.name}</strong>.
+        </div>
+        <Link href={`/club/${clubCode}`} className="button is-primary">
+          Back to Club Page
+        </Link>
+      </Container>
+    )
+  }
+
+  const questions = group.questions ?? []
+
+  // Build initial form values
+  const initialValues: Record<string, string> = {}
+  questions.forEach((q) => {
+    initialValues[`q_${q.id}`] = ''
+  })
+
+  const handleSubmit = async (
+    values: Record<string, string>,
+    { setSubmitting, setFieldError }: any,
+  ) => {
+    const answers = questions
+      .filter((q) => q.question_type !== SubscriptionQuestionType.InfoText)
+      .map((q) => {
+        const val = values[`q_${q.id}`]
+        const isMC = q.question_type === SubscriptionQuestionType.MultipleChoice
+        return {
+          question: q.id,
+          text: isMC ? '' : val,
+          multiple_choice: isMC ? (val ? parseInt(val, 10) : null) : null,
+        }
+      })
+
+    const resp = await doApiRequest(
+      `/subscription-groups/${groupId}/submit/?format=json`,
+      {
+        method: 'POST',
+        body: {
+          subscription_group: parseInt(groupId, 10),
+          answers,
+          attribution_source: source ?? 'direct',
+        },
+      },
+    )
+
+    if (resp.ok) {
+      setSubmitted(true)
+    } else {
+      const data = await resp.json()
+      if (data.missing_questions) {
+        data.missing_questions.forEach((qid: number) => {
+          setFieldError(`q_${qid}`, 'This question is required.')
+        })
+      } else {
+        setFieldError('_form', data.detail ?? 'Submission failed.')
+      }
+    }
+    setSubmitting(false)
+  }
+
+  return (
+    <Container>
+      <Title>{group.name}</Title>
+      {group.description && <Text>{group.description}</Text>}
+
+      <Formik initialValues={initialValues} onSubmit={handleSubmit}>
+        {({ errors, isSubmitting }) => (
+          <Form>
+            {(errors as any)._form && (
+              <div className="notification is-danger">
+                {(errors as any)._form}
+              </div>
+            )}
+            {questions.map((q) => {
+              const isInfoText =
+                q.question_type === SubscriptionQuestionType.InfoText
+              const isMC =
+                q.question_type === SubscriptionQuestionType.MultipleChoice
+              const isLong =
+                q.question_type === SubscriptionQuestionType.FreeResponse
+
+              if (isInfoText) {
+                return (
+                  <div
+                    key={q.id}
+                    className="notification is-info is-light mb-3"
+                  >
+                    {q.prompt}
+                  </div>
+                )
+              }
+
+              return (
+                <div key={q.id} className="field mb-4">
+                  <label className="label">
+                    {q.prompt}
+                    {q.required && (
+                      <span className="has-text-danger ml-1">*</span>
+                    )}
+                  </label>
+                  <div className="control">
+                    {isMC ? (
+                      <div className="select">
+                        <Field as="select" name={`q_${q.id}`}>
+                          <option value="">Select an option...</option>
+                          {q.multiple_choice.map((opt) => (
+                            <option key={opt.id} value={opt.id}>
+                              {opt.value}
+                            </option>
+                          ))}
+                        </Field>
+                      </div>
+                    ) : isLong ? (
+                      <Field
+                        as="textarea"
+                        name={`q_${q.id}`}
+                        className="textarea"
+                        rows={4}
+                      />
+                    ) : (
+                      <Field name={`q_${q.id}`} className="input" type="text" />
+                    )}
+                  </div>
+                  {(errors as any)[`q_${q.id}`] && (
+                    <p className="help is-danger">
+                      {(errors as any)[`q_${q.id}`]}
+                    </p>
+                  )}
+                </div>
+              )
+            })}
+
+            <div className="field">
+              <button
+                type="submit"
+                className="button is-primary"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Submitting...' : 'Subscribe'}
+              </button>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </Container>
+  )
+}
+
+export default renderPage(SubscribeFormPage)

--- a/frontend/pages/subscribe/link/[token].tsx
+++ b/frontend/pages/subscribe/link/[token].tsx
@@ -1,0 +1,127 @@
+import { NextPageContext } from 'next'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { ReactElement, useContext, useEffect, useState } from 'react'
+import renderPage from 'renderPage'
+import { doApiRequest } from 'utils'
+
+import { Container, Loading, Text, Title } from '~/components/common'
+import { AuthCheckContext } from '~/components/contexts'
+
+type ResolvedLink = {
+  subscription_group_id: number
+  club_code: string
+  group_name: string
+  is_active: boolean
+  is_archived: boolean
+  auto_subscribe_eligible: boolean
+  attribution_source: string
+}
+
+function MagicLinkPage(): ReactElement<any> {
+  const router = useRouter()
+  const { token } = router.query as { token: string }
+  const authCheck = useContext(AuthCheckContext)
+
+  const [resolved, setResolved] = useState<ResolvedLink | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+    doApiRequest(`/subscription-links/${token}/?format=json`)
+      .then(async (resp) => {
+        if (!resp.ok) {
+          const data = await resp.json()
+          setError(data.detail ?? 'Invalid or expired link.')
+          return
+        }
+        const data: ResolvedLink = await resp.json()
+        setResolved(data)
+      })
+      .catch(() => setError('Failed to resolve link.'))
+  }, [token])
+
+  useEffect(() => {
+    if (!resolved) return
+
+    if (resolved.is_archived || !resolved.is_active) {
+      // Nothing to do — will render an informational message below
+      return
+    }
+
+    if (resolved.auto_subscribe_eligible) {
+      // No questions to answer — send them through auth then subscribe directly
+      authCheck(() => {
+        doApiRequest(
+          `/subscription-groups/${resolved.subscription_group_id}/submit/?format=json`,
+          {
+            method: 'POST',
+            body: {
+              subscription_group: resolved.subscription_group_id,
+              answers: [],
+              attribution_source: resolved.attribution_source,
+            },
+          },
+        ).then((resp) => {
+          if (resp.ok) {
+            router.replace(`/club/${resolved.club_code}`)
+          } else {
+            // Fall back to the form page, which prompts for login if needed.
+            router.replace(
+              `/club/${resolved.club_code}/subscribe/` +
+                `${resolved.subscription_group_id}?source=${resolved.attribution_source}`,
+            )
+          }
+        })
+      })
+    } else {
+      // Has questions — redirect to the form page with attribution
+      router.replace(
+        `/club/${resolved.club_code}/subscribe/${resolved.subscription_group_id}?source=${resolved.attribution_source}`,
+      )
+    }
+  }, [resolved])
+
+  if (error) {
+    return (
+      <Container>
+        <Title>Invalid Link</Title>
+        <div className="notification is-danger">{error}</div>
+      </Container>
+    )
+  }
+
+  if (!resolved) {
+    return (
+      <Container>
+        <Loading />
+      </Container>
+    )
+  }
+
+  if (resolved.is_archived || !resolved.is_active) {
+    return (
+      <Container>
+        <Title>{resolved.group_name}</Title>
+        <div className="notification is-warning">
+          This subscription form is no longer active.
+        </div>
+        <Link href={`/club/${resolved.club_code}`} className="button">
+          View Club Page
+        </Link>
+      </Container>
+    )
+  }
+
+  // Still loading / redirecting
+  return (
+    <Container>
+      <Text>Redirecting you to the subscription form…</Text>
+      <Loading />
+    </Container>
+  )
+}
+
+MagicLinkPage.getInitialProps = async (_ctx: NextPageContext) => ({})
+
+export default renderPage(MagicLinkPage)

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -604,3 +604,59 @@ export type RankingWeights = {
   updated_at: string
   updated_by: string
 }
+
+export enum SubscriptionQuestionType {
+  FreeResponse = 1,
+  MultipleChoice = 2,
+  ShortAnswer = 3,
+  InfoText = 4,
+}
+
+export interface SubscriptionMultipleChoice {
+  id: number
+  value: string
+}
+
+export interface SubscriptionQuestion {
+  id: number
+  subscription_group: number
+  question_type: SubscriptionQuestionType
+  prompt: string
+  required: boolean
+  precedence: number
+  word_limit: number | null
+  multiple_choice: SubscriptionMultipleChoice[]
+}
+
+export interface SubscriptionGroup {
+  id: number
+  name: string
+  description: string
+  is_active: boolean
+  is_archived: boolean
+  is_default: boolean
+  opens_at: string | null
+  closes_at: string | null
+  question_count: number
+  submission_count: number
+  subscriber_count: number
+  questions?: SubscriptionQuestion[]
+  created_at: string
+  updated_at: string
+}
+
+export interface SubscriberListItem {
+  submission_id: number
+  user_id: number
+  name: string
+  email: string
+  graduation_year: number | null
+  attribution_source: string
+  subscribed_at: string
+}
+
+export interface SubscriptionEntryResponse {
+  mode: 'instant' | 'form'
+  subscription_group_id?: number
+  attribution_source?: string
+}


### PR DESCRIPTION
Closes #867.

Replaces the one-click subscribe button with configurable **subscription forms**. A `SubscriptionGroup` is an ordered set of questions a student answers; submitting subscribes them to the club, and the club gets source attribution plus listserv-ready exports.

As #867 puts it, subscriptions today are "a button that students press … after which their email is incremented onto a list", with no source attribution and no way to collect anything else. This makes them useful enough that clubs might actually rely on them.

## What's in it

**Models** — `SubscriptionGroup`, `SubscriptionQuestion`, `SubscriptionMultipleChoice`, `SubscriptionSubmission`, `SubscriptionQuestionResponse`, plus `Club.default_subscription_group` and `Subscribe.subscription_group`.

**Officer UI** — a Subscriptions tab on the club edit page with four panes: Overview (settings, set-default, archive), Questions, Subscribers, Distribution.

**Student-facing** — a public form page and a magic-link landing page. When a form asks nothing beyond auto-collected profile info, opening its link subscribes the user outright instead of showing an empty form.

**Distribution** — signed magic links and QR codes, for flyers and activities fair booths.

**Exports** — six shapes: CSV, TSV, plain email list, Mailchimp, Google Groups, and XLSX. Mailchimp and Google Groups are CSV files carrying the exact headers those tools expect, so there's no column-mapping step on import.

**Attribution** — every subscription records where the student came from (club page, search results, activities fair, magic link).

**Soft delete** — archiving hides a form and stops new submissions while retaining subscriber data, per the issue's requirement that deletion be visual only when submissions exist.

## Design decisions worth reviewing

**Defaults are opt-in.** A club keeps one-click subscribe until an officer explicitly sets a default form. The issue's wording — *"if one is set, hitting the subscription button would redirect to the form instead of instantly subscribing"* — reads as opt-in, and the alternative would silently change subscribe behaviour for every club on the platform.

**`?fmt=` selects the export shape, not `?format=`.** DRF reserves `format` for renderer content negotiation, so `?format=csv` would fail negotiation before reaching the view. `?format=xlsx` is left to DRF's `XLSXRenderer`, matching how `clubs-subscription` already serves spreadsheets.

**Magic links use `DEFAULT_DOMAIN` in production.** A printed QR code has to stay valid. Under `DEBUG` the link instead follows the calling frontend's origin so it's usable on localhost — but only if that origin is already in `CSRF_TRUSTED_ORIGINS`, so a caller can't aim links at an arbitrary host.

**`workflows.py` is shared, not speculative.** `BaseFormWorkflow` holds the submit-and-respond sequence. `ClubApplication` is the other `FormDefinitionBehaviorMixin` implementor and an `ApplicationFormWorkflow` subclass is the natural follow-up. #867 floated a shared abstract *model* for both; that would mean migrating `ClubApplication`'s table against a 5,800-line suite for no user-facing gain, so this shares the behaviour instead.

## Reuse

The officer UI is built on what already exists rather than new components: `ModelForm` (drag-reorder, confirm-delete), `common/Table`, `BaseCard`, `QRCodeCard`, `CreatableMultipleSelectField`, and `XLSXFormatterMixin` on the backend.

`StyledHeader`, `FormWrapper`, `ModalContainer` and `ScrollWrapper` were duplicated verbatim between `ApplicationsPage` and the new page; they now live in one `FormManagementStyles.ts` that both import. `QRCodeCard` gained optional `apiPath` / `title` props so it can serve an endpoint outside the `/{type}/{id}/qr` convention — existing club and ticket usages are unchanged.

## Testing

**454 tests pass** (full suite, run as CI runs it). 97 are new — 60 integration, 37 unit.

Integration covers officer permissions on every endpoint, the entry/instant-vs-form decision, submission (auth, required questions, closed windows, idempotency, attribution), question and multiple-choice CRUD, reordering, all six export formats (content type, filename, header row, exact data row), and magic-link round trips including tampered tokens.

Unit tests cover `is_currently_open` across the window boundaries, `auto_subscribe_eligible`, the workflow contract, and `ClubApplication` as the mixin's other implementor.

The frontend has no component-test framework (`"test"` is `tsc --noemit`), so verification there is typecheck, ESLint, and a production build — all clean.

## Migrations

Rebased onto current `master`, so the three migrations are numbered `0144`–`0146` and chain off `0143_split_club_reject_permission`. The branch is exactly one commit ahead of `master` with nothing behind.

`0146_cleanup_auto_subscription_groups` is data-only and reversible. It removes `SubscriptionGroup` rows named `"Subscribe"` that have **zero questions and zero submissions** — artifacts of an earlier iteration that auto-created a default form on every club save. Any form with real content is untouched, and `Club.default_subscription_group` is cleared before deletion.

## Note for reviewers

`populate.py` includes one line unrelated to this feature — `Club.objects.update(visible_to_public=True)` at the end of the seed command, so the anonymous club list matches `test_club_list_filter`. It predates this work and is carried along rather than dropped; happy to split it out.

## Not included

- Mailchimp OAuth sync and mailing-list sending — both marked TBD in #867 pending an SES budget discussion. The Mailchimp *export* is here; the API integration is not.
- Anonymous (logged-out) submissions. Submitting requires login; the magic-link page routes logged-out users through the standard `AuthPrompt`. True anonymous subscribe would need a nullable `Subscribe.person`, email verification, and rate limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BxU89wnYsLpU14zTHcusY
